### PR TITLE
fix: Obscured dropdown items, abrupt dropdown close

### DIFF
--- a/src/components/Dropdowns/AccessibleDropdown.tsx
+++ b/src/components/Dropdowns/AccessibleDropdown.tsx
@@ -183,15 +183,17 @@ export default function AccessibleDropdown(inputProps: AccessibleDropdownProps):
         false
       );
     };
-    const handleFocusLoss = (event: FocusEvent): void => {
-      if (!doesContainTarget(event.target)) {
+    const handleDocumentClick = (event: MouseEvent): void => {
+      // Close dropdown if the dropdown loses focus (click outside of the dropdown).
+      // Uses click listener instead of focus listener to handle clicks on non-focusable elements.
+      if (forceOpenState === OpenState.FORCE_OPEN && !doesContainTarget(event.target)) {
         setForceOpenState(OpenState.DEFAULT);
       }
     };
 
-    componentContainerRef.current?.addEventListener("focusout", handleFocusLoss);
+    document.addEventListener("click", handleDocumentClick);
     return () => {
-      componentContainerRef.current?.removeEventListener("focusout", handleFocusLoss);
+      document.removeEventListener("click", handleDocumentClick);
     };
   }, [forceOpenState]);
 

--- a/src/components/Dropdowns/AccessibleDropdown.tsx
+++ b/src/components/Dropdowns/AccessibleDropdown.tsx
@@ -184,7 +184,7 @@ export default function AccessibleDropdown(inputProps: AccessibleDropdownProps):
       );
     };
     const handleFocusLoss = (event: FocusEvent): void => {
-      if (!doesContainTarget(event.relatedTarget)) {
+      if (!doesContainTarget(event.target)) {
         setForceOpenState(OpenState.DEFAULT);
       }
     };

--- a/src/components/Tabs/FeatureThresholdsTab.tsx
+++ b/src/components/Tabs/FeatureThresholdsTab.tsx
@@ -352,6 +352,8 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
           suffixIcon={isFocused ? <SearchOutlined /> : <DropdownSVG style={{ pointerEvents: "none", width: "12px" }} />}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
+          // Fixes a bug where the last item would be cut off
+          virtual={false}
         />
       </SelectContainer>
       <FiltersContainer>


### PR DESCRIPTION
Problem
=======
Closes #355, "last item in features list is partially hidden". Also fixes an extra bug in the dropdowns I found where they would close unexpectedly.

*Estimated review time: tiny, 3 minutes*

Solution
========
- Fixes a bug where the last item in the features list dropdown would be partially hidden.
- Fixes a bug where clicking on the scrollbar in certain dropdowns causes the dropdown to close.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
1. Open the preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-360/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Fnucmorph-apr2024%2Fcollection.json&dataset=Mama+Bear&feature=colony_time&t=263&filters=full_interphase_track_flag%3A%3Afff&scatter-x=volume&scatter-y=volume_at_b
2. Go to the scatter plot tab and click on the dropdown. Manipulating the scrollbar should not cause it to close.
3. Go to the filters tab and click the "Add features" dropdown. Scroll all the way down to the bottom of the list. The last item should no longer be cut off.

For comparison, this is the main (broken) build: https://allen-cell-animated.github.io/timelapse-colorizer/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Fnucmorph-apr2024%2Fcollection.json&dataset=Mama+Bear&feature=colony_time&t=263&filters=full_interphase_track_flag%3A%3Afff&scatter-x=volume&scatter-y=volume_at_b