### PR TITLE
fix: Header and dropdown spacing, tooltip Z-height

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -799,7 +799,7 @@ function Viewer(): ReactElement {
       {/** Main Content: Contains canvas and plot, ramp controls, time controls, etc. */}
       <div className={styles.mainContent}>
         {/** Top Control Bar */}
-        <FlexRowAlignCenter $gap={12} style={{ margin: "16px 0", flexWrap: "wrap" }}>
+        <FlexRowAlignCenter $gap={20} style={{ margin: "16px 0", flexWrap: "wrap" }}>
           <SelectionDropdown
             disabled={disableUi}
             label="Dataset"

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -355,13 +355,16 @@ export default function AppStyle(props: PropsWithChildren<AppStyleProps>): React
               colorBorder: theme.color.layout.borders,
               colorBorderSecondary: theme.color.layout.borders,
             },
+            Tooltip: {
+              zIndexPopup: 2000,
+            },
             Divider: {
               marginLG: 0,
             },
             Modal: {
               // Set z-index to 2000 here because Ant sets popups to 1050 by default, and modals to 1000.
-              zIndexBase: 2000,
-              zIndexPopupBase: 2000,
+              zIndexBase: 2100,
+              zIndexPopupBase: 2100,
               titleFontSize: theme.font.size.section,
               margin: 20,
             },

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -362,7 +362,7 @@ export default function AppStyle(props: PropsWithChildren<AppStyleProps>): React
               marginLG: 0,
             },
             Modal: {
-              // Set z-index to 2000 here because Ant sets popups to 1050 by default, and modals to 1000.
+              // Set z-index to 2100 here because Ant sets popups to 1050 by default, and modals to 1000.
               zIndexBase: 2100,
               zIndexPopupBase: 2100,
               titleFontSize: theme.font.size.section,

--- a/src/components/Dropdowns/ColorRampDropdown.tsx
+++ b/src/components/Dropdowns/ColorRampDropdown.tsx
@@ -221,7 +221,7 @@ const ColorRampSelector: React.FC<ColorRampSelectorProps> = (propsInput): ReactE
           // Force the tooltip to be hidden (open=false) when disabled
           open={props.disabled ? false : undefined}
           title={currentSelectionName}
-          placement="right"
+          placement="top"
           trigger={["focus", "hover"]}
         >
           <Button

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,8 +9,8 @@ const AICS_LOGO_RESIZE_THRESHOLD_PX = 540;
 
 const AicsLogoLink = styled.a`
   position: relative;
-  width: 180px;
-  height: 46px;
+  width: 140px;
+  height: 36px;
 
   div > svg:last-child {
     display: none;
@@ -62,7 +62,7 @@ function HeaderLogo(): ReactElement {
       </AicsLogoLink>
       <VerticalDivider />
       <Link to="/" aria-label="Go to home page">
-        <h1>Timelapse Feature Explorer</h1>
+        <h1 style={{ margin: "0" }}>Timelapse Feature Explorer</h1>
       </Link>
     </FlexRowAlignCenter>
   );


### PR DESCRIPTION
Problem
=======
Closes #359 and closes #358 , issues raised by Lyndsay! Also closes #352, "reverse ramp button is covered by tooltip".

*Estimated review size: Tiny, 1-5 minutes*

Solution
========
- Increases spacing between dropdowns on the top toolbar.
- Decreases height of header by shrinking logo and removing margins from text.
- Changes Z-height of tooltips to prevent them from being covered by the header.
- Adjusts color map tooltip direction so it doesn't cover over the reverse color map button.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/timelapse-colorizer/assets/30200665/a088023e-d3b9-4086-b37c-b2369d20f2d6)

Preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-365/

