### PR TITLE
fix: Fixed tooltip and axes titles when using the scatterplot Time feature

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -32,6 +32,7 @@ import { getColorMap, getInRangeLUT, thresholdMatchFinder, validateThresholds } 
 import { numberToStringDecimal } from "./colorizer/utils/math_utils";
 import { useConstructor, useDebounce, useRecentCollections } from "./colorizer/utils/react_utils";
 import * as urlUtils from "./colorizer/utils/url_utils";
+import { SCATTERPLOT_TIME_FEATURE } from "./components/Tabs/scatter_plot_data_utils";
 import { DEFAULT_PLAYBACK_FPS } from "./constants";
 import { FlexRowAlignCenter } from "./styles/utils";
 import { LocationState } from "./types";
@@ -590,12 +591,16 @@ function Viewer(): ReactElement {
         const newScatterPlotConfig = initialUrlParams.scatterPlotConfig;
         // For backwards-compatibility, cast xAxis and yAxis to feature keys.
         if (newScatterPlotConfig.xAxis) {
-          newScatterPlotConfig.xAxis = dataset?.findFeatureByKeyOrName(newScatterPlotConfig.xAxis);
+          const xAxis = newScatterPlotConfig.xAxis;
+          newScatterPlotConfig.xAxis =
+            xAxis === SCATTERPLOT_TIME_FEATURE.key ? xAxis : dataset?.findFeatureByKeyOrName(xAxis);
         }
         if (newScatterPlotConfig.yAxis) {
-          newScatterPlotConfig.yAxis = dataset?.findFeatureByKeyOrName(newScatterPlotConfig.yAxis);
+          const yAxis = newScatterPlotConfig.yAxis;
+          newScatterPlotConfig.yAxis =
+            yAxis === SCATTERPLOT_TIME_FEATURE.key ? yAxis : dataset?.findFeatureByKeyOrName(yAxis);
         }
-        updateScatterPlotConfig(initialUrlParams.scatterPlotConfig);
+        updateScatterPlotConfig(newScatterPlotConfig);
       }
     };
 

--- a/src/components/Tabs/ScatterPlotTab.tsx
+++ b/src/components/Tabs/ScatterPlotTab.tsx
@@ -15,11 +15,13 @@ import {
   DataArray,
   drawCrosshair,
   getBucketIndex,
+  getFeatureOrTimeNameWithUnits,
   getHoverTemplate,
   isHistogramEvent,
   makeEmptyTraceData,
   makeLineTrace,
   scaleColorOpacityByMarkerCount,
+  SCATTERPLOT_TIME_FEATURE,
   splitTraceData,
   subsampleColorRamp,
   TraceData,
@@ -30,8 +32,6 @@ import SelectionDropdown from "../Dropdowns/SelectionDropdown";
 import IconButton from "../IconButton";
 import LoadingSpinner from "../LoadingSpinner";
 
-/** Extra feature that's added to the dropdowns representing the frame number. */
-const TIME_FEATURE = { key: "scatterplot_time", label: "Time" };
 // TODO: Translate into seconds/minutes/hours for datasets where frame duration is known?
 
 const PLOTLY_CONFIG: Partial<Plotly.Config> = {
@@ -195,7 +195,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
     if (featureKey === null || dataset === null) {
       return undefined;
     }
-    if (featureKey === TIME_FEATURE.key) {
+    if (featureKey === SCATTERPLOT_TIME_FEATURE.key) {
       return dataset.times || undefined;
     }
     return dataset.getFeatureData(featureKey)?.data;
@@ -362,7 +362,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
     let max = dataset?.getFeatureData(featureKey)?.max || 0;
 
     // Special case for time feature, which isn't in the dataset
-    if (featureKey === TIME_FEATURE.key) {
+    if (featureKey === SCATTERPLOT_TIME_FEATURE.key) {
       min = 0;
       max = dataset?.numberOfFrames || 0;
     }
@@ -625,7 +625,8 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
       markerBaseColor = new Color("#dddddd");
     }
 
-    const isUsingTime = xAxisFeatureKey === TIME_FEATURE.key || yAxisFeatureKey === TIME_FEATURE.key;
+    const isUsingTime =
+      xAxisFeatureKey === SCATTERPLOT_TIME_FEATURE.key || yAxisFeatureKey === SCATTERPLOT_TIME_FEATURE.key;
 
     // Configure traces
     const traces = colorizeScatterplotPoints(xData, yData, objectIds, trackIds, {}, markerBaseColor);
@@ -706,11 +707,11 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
       yHistogram
     );
 
-    scatterPlotXAxis.title = dataset.getFeatureNameWithUnits(xAxisFeatureKey || "");
+    scatterPlotXAxis.title = getFeatureOrTimeNameWithUnits(xAxisFeatureKey, dataset);
     // Due to limited space in the Y-axis, hide categorical feature names.
     scatterPlotYAxis.title = dataset.isFeatureCategorical(yAxisFeatureKey)
       ? ""
-      : dataset.getFeatureNameWithUnits(yAxisFeatureKey || "");
+      : getFeatureOrTimeNameWithUnits(yAxisFeatureKey, dataset);
 
     // Add extra margin for categorical feature labels on the Y axis.
     const leftMarginPx = Math.max(60, estimateTextWidthPxForCategories(yAxisFeatureKey));
@@ -787,7 +788,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
     const menuItems: MenuItemType[] = featureKeys.map((key: string) => {
       return { key, label: dataset?.getFeatureNameWithUnits(key) };
     });
-    menuItems.push(TIME_FEATURE);
+    menuItems.push(SCATTERPLOT_TIME_FEATURE);
 
     return (
       <FlexRowAlignCenter $gap={6} style={{ flexWrap: "wrap" }}>

--- a/src/components/Tabs/scatter_plot_data_utils.ts
+++ b/src/components/Tabs/scatter_plot_data_utils.ts
@@ -4,6 +4,9 @@ import { Color, HexColorString } from "three";
 import { ColorRamp, Dataset } from "../../colorizer";
 import { remap } from "../../colorizer/utils/math_utils";
 
+/** Extra feature added to the dropdowns representing the frame number. */
+export const SCATTERPLOT_TIME_FEATURE = { key: "scatterplot_time", label: "Time" };
+
 export type DataArray = Uint32Array | Float32Array | number[];
 
 export type TraceData = {
@@ -118,14 +121,36 @@ export function scaleColorOpacityByMarkerCount(numMarkers: number, baseColor: He
   return (baseColor + opacityString) as HexColorString;
 }
 
+/** Retrieve feature name, if it exists. Accounts for the artificially-added time feature. */
+export const getFeatureOrTimeName = (featureKey: string | null, dataset: Dataset | null): string => {
+  if (featureKey === null || dataset === null) {
+    return "";
+  }
+  if (featureKey === SCATTERPLOT_TIME_FEATURE.key) {
+    return SCATTERPLOT_TIME_FEATURE.label;
+  }
+  return dataset.getFeatureName(featureKey) || "";
+};
+
+/** Retrieve feature name with units, if it exists. Accounts for the artificially-added time feature. */
+export const getFeatureOrTimeNameWithUnits = (featureKey: string | null, dataset: Dataset | null): string => {
+  if (featureKey === null || dataset === null) {
+    return "";
+  }
+  if (featureKey === SCATTERPLOT_TIME_FEATURE.key) {
+    return SCATTERPLOT_TIME_FEATURE.label;
+  }
+  return dataset.getFeatureNameWithUnits(featureKey) || "";
+};
+
 /**
  * Returns a Plotly hovertemplate string for a scatter plot trace.
  * The trace must include the `id` (object ID) and `customdata` (track ID) fields.
  */
 export function getHoverTemplate(dataset: Dataset, xAxisFeatureKey: string, yAxisFeatureKey: string): string {
   return (
-    `${dataset.getFeatureName(xAxisFeatureKey)}: %{x} ${dataset.getFeatureUnits(xAxisFeatureKey)}` +
-    `<br>${dataset.getFeatureName(yAxisFeatureKey)}: %{y} ${dataset.getFeatureUnits(yAxisFeatureKey)}` +
+    `${getFeatureOrTimeName(xAxisFeatureKey, dataset)}: %{x} ${dataset.getFeatureUnits(xAxisFeatureKey)}` +
+    `<br>${getFeatureOrTimeName(yAxisFeatureKey, dataset)}: %{y} ${dataset.getFeatureUnits(yAxisFeatureKey)}` +
     `<br>Track ID: %{customdata}<br>Object ID: %{id}<extra></extra>`
   );
 }

--- a/src/components/Tabs/scatter_plot_data_utils.ts
+++ b/src/components/Tabs/scatter_plot_data_utils.ts
@@ -121,7 +121,7 @@ export function scaleColorOpacityByMarkerCount(numMarkers: number, baseColor: He
   return (baseColor + opacityString) as HexColorString;
 }
 
-/** Retrieve feature name, if it exists. Accounts for the artificially-added time feature. */
+/** Retrieve feature name, if it exists. Accounts for the added time feature. */
 export const getFeatureOrTimeName = (featureKey: string | null, dataset: Dataset | null): string => {
   if (featureKey === null || dataset === null) {
     return "";
@@ -132,7 +132,7 @@ export const getFeatureOrTimeName = (featureKey: string | null, dataset: Dataset
   return dataset.getFeatureName(featureKey) || "";
 };
 
-/** Retrieve feature name with units, if it exists. Accounts for the artificially-added time feature. */
+/** Retrieve feature name with units, if it exists. Accounts for the added time feature. */
 export const getFeatureOrTimeNameWithUnits = (featureKey: string | null, dataset: Dataset | null): string => {
   if (featureKey === null || dataset === null) {
     return "";


### PR DESCRIPTION
Problem
=======
Closes #357, "built-in scatterplot time feature shows as `undefined`".

*Estimated review size: Small, 5 minutes*

Solution
========
- Adds a check for the scatterplot time feature when retrieving dataset feature names.
- Fix a bug where the time feature would not be retrieved from the URL.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open the PR preview link (while on VPN): https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-367/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Fcollection.json&dataset=Mama+Bear&tab=scatter_plot&scatter-x=volume&scatter-y=scatterplot_time
2. The scatterplot tab should already be open. The time feature will be selected, and should appear correctly in the axes titles and in the hover tooltip.

Screenshots (optional):
-----------------------
Before:
![image](https://github.com/allen-cell-animated/timelapse-colorizer/assets/30200665/6fd55798-e2c6-41a3-928c-853918ebb775)

After:
![image](https://github.com/allen-cell-animated/timelapse-colorizer/assets/30200665/5077b5ee-1e54-49cf-97c3-6e6adc332f45)

