### PR TITLE
feat: Show filter count in tab title

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -1051,7 +1051,7 @@ function Viewer(): ReactElement {
                     ),
                   },
                   {
-                    label: "Filters",
+                    label: `Filters ${featureThresholds.length > 0 ? `(${featureThresholds.length})` : ""}`,
                     key: TabType.FILTERS,
                     children: (
                       <div className={styles.tabContent}>


### PR DESCRIPTION
Problem
=======
Design from Lyndsay! Adds the number of filters currently selected to the title of the Filters tab.

Prepares for the NucMorph release which will have filters included on initial load. This makes it more obvious when data is being modified in the viewport.

*Estimated review size: tiny, 2 minutes*

Solution
========
- Filters tab now includes a count of filters in parentheses.

## Type of change
* New feature (non-breaking change which adds functionality)

## Testing
1. Open the preview link and switch to the filters tab: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-369/viewer?dataset=https%3A%2F%2Fraw.githubusercontent.com%2Fallen-cell-animated%2Fcolorizer-data%2Fmain%2Fdocumentation%2Fexample_dataset%2Fmanifest.json&feature=continuous_feature
2. Add one or more filters. The count of filters should update in the tab view.

![image](https://github.com/allen-cell-animated/timelapse-colorizer/assets/30200665/6df65c5b-fd6b-4801-bc4c-45fcfc19eb21)
