### PR TITLE
fix: Change role and role session name

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -62,8 +62,8 @@ jobs:
           - name: Configure AWS credentials with OIDC
             uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
             with:
-                role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github_nucmorph_colorizer
-                role-session-name: nucmorph_colorizer-${{ env.SHORT_SHA }}
+                role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github_timelapse_colorizer
+                role-session-name: timelapse_colorizer-${{ env.SHORT_SHA }}
                 aws-region: ${{ env.AWS_REGION }}
 
           # Setup variables based on the staging or production environment


### PR DESCRIPTION
Problem
=======
As `nucmorph-colorizer` repo was renamed to `timelapse-colorizer` role and policy related to it were also renamed to avoid and it led to failure in github actions workflow.

Solution
========
Rename role's name 


## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Suggestions for testing:
staging: https://github.com/allen-cell-animated/timelapse-colorizer/actions/runs/9420869265
production: https://github.com/allen-cell-animated/timelapse-colorizer/actions/runs/9420943891

Thanks for contributing!
