### PR TITLE
fix: Fixed bug where units would not appear on the UI.

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -117,8 +117,8 @@ function Viewer(): ReactElement {
       // threshold values.
       const featureData = dataset?.getFeatureData(featureKey);
       if (featureData) {
-        const oldThreshold = featureThresholds.find(thresholdMatchFinder(featureKey, featureData.units));
-        const newThreshold = newThresholds.find(thresholdMatchFinder(featureKey, featureData.units));
+        const oldThreshold = featureThresholds.find(thresholdMatchFinder(featureKey, featureData.unit));
+        const newThreshold = newThresholds.find(thresholdMatchFinder(featureKey, featureData.unit));
 
         if (newThreshold && oldThreshold && isThresholdNumeric(newThreshold) && isThresholdNumeric(oldThreshold)) {
           if (newThreshold.min !== oldThreshold.min || newThreshold.max !== oldThreshold.max) {
@@ -338,7 +338,7 @@ function Viewer(): ReactElement {
       const featureData = featureDataset.getFeatureData(featureKey);
       if (!config.keepRangeBetweenDatasets && featureData) {
         // Use min/max from threshold if there is a matching one, otherwise use feature min/max
-        const threshold = featureThresholds.find(thresholdMatchFinder(featureKey, featureData.units));
+        const threshold = featureThresholds.find(thresholdMatchFinder(featureKey, featureData.unit));
         if (threshold && isThresholdNumeric(threshold)) {
           setColorRampMin(threshold.min);
           setColorRampMax(threshold.max);
@@ -655,7 +655,7 @@ function Viewer(): ReactElement {
       // (safe for falsy values like 0 or NaN, which are valid feature values)
       let featureValue = featureData?.data[id] ?? -1;
       featureValue = isFinite(featureValue) ? featureValue : NaN;
-      const unitsLabel = featureData?.units ? ` ${featureData?.units}` : "";
+      const unitsLabel = featureData?.unit ? ` ${featureData?.unit}` : "";
       // Check if int, otherwise return float
       return numberToStringDecimal(featureValue, 3) + unitsLabel;
     },
@@ -754,7 +754,7 @@ function Viewer(): ReactElement {
     if (!featureData || featureThresholds.length === 0) {
       return undefined;
     }
-    const threshold = featureThresholds.find(thresholdMatchFinder(featureKey, featureData.units));
+    const threshold = featureThresholds.find(thresholdMatchFinder(featureKey, featureData.unit));
     if (!threshold || !isThresholdNumeric(threshold)) {
       return undefined;
     }

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -26,7 +26,7 @@ export type FeatureData = {
   tex: Texture;
   min: number;
   max: number;
-  units: string;
+  unit: string;
   type: FeatureType;
   categories: string[] | null;
 };
@@ -156,7 +156,7 @@ export default class Dataset {
         data: source.getBuffer(FeatureDataType.F32),
         min: source.getMin(),
         max: source.getMax(),
-        units: metadata?.units || "",
+        unit: metadata?.unit || "",
         type: featureType,
         categories: featureCategories || null,
       },
@@ -205,7 +205,7 @@ export default class Dataset {
    * Gets the feature's units if it exists; otherwise returns an empty string.
    */
   public getFeatureUnits(key: string): string {
-    return this.getFeatureData(key)?.units || "";
+    return this.getFeatureData(key)?.unit || "";
   }
 
   public getFeatureNameWithUnits(key: string): string {

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -103,7 +103,7 @@ export enum ThresholdType {
 
 type BaseFeatureThreshold = {
   featureKey: string;
-  units: string;
+  unit: string;
   type: ThresholdType;
 };
 

--- a/src/colorizer/utils/data_utils.ts
+++ b/src/colorizer/utils/data_utils.ts
@@ -55,7 +55,7 @@ export function validateThresholds(dataset: Dataset, thresholds: FeatureThreshol
     }
 
     const featureData = dataset.getFeatureData(featureKey);
-    const isInDataset = featureData && featureData.units === threshold.units;
+    const isInDataset = featureData && featureData.unit === threshold.units;
 
     if (isInDataset) {
       // Threshold key + unit matches, so update feature key just in case it was a name
@@ -119,7 +119,7 @@ export function getInRangeLUT(dataset: Dataset, thresholds: FeatureThreshold[]):
   // Ignore thresholds with features that don't exist in this dataset or whose units don't match
   const validThresholds = thresholds.filter((threshold) => {
     const featureData = dataset.getFeatureData(threshold.featureKey);
-    return featureData && featureData.units === threshold.units;
+    return featureData && featureData.unit === threshold.units;
   });
 
   for (let id = 0; id < dataset.numObjects; id++) {

--- a/src/colorizer/utils/data_utils.ts
+++ b/src/colorizer/utils/data_utils.ts
@@ -16,8 +16,8 @@ import Dataset, { FeatureType } from "../Dataset";
  * const matchThreshold = featureThresholds.find(thresholdMatchFinder("Temperature", "°C"));
  * ```
  */
-export function thresholdMatchFinder(featureKey: string, units: string): (threshold: FeatureThreshold) => boolean {
-  return (threshold: FeatureThreshold) => threshold.featureKey === featureKey && threshold.units === units;
+export function thresholdMatchFinder(featureKey: string, unit: string): (threshold: FeatureThreshold) => boolean {
+  return (threshold: FeatureThreshold) => threshold.featureKey === featureKey && threshold.unit === unit;
 }
 
 /**
@@ -55,7 +55,7 @@ export function validateThresholds(dataset: Dataset, thresholds: FeatureThreshol
     }
 
     const featureData = dataset.getFeatureData(featureKey);
-    const isInDataset = featureData && featureData.unit === threshold.units;
+    const isInDataset = featureData && featureData.unit === threshold.unit;
 
     if (isInDataset) {
       // Threshold key + unit matches, so update feature key just in case it was a name
@@ -70,7 +70,7 @@ export function validateThresholds(dataset: Dataset, thresholds: FeatureThreshol
       // thresholds. This would cause categorical features loaded from the URL to be incorrectly shown on the UI.
       newThresholds.push({
         featureKey: featureKey,
-        units: threshold.units,
+        unit: threshold.unit,
         type: ThresholdType.CATEGORICAL,
         enabledCategories: Array(MAX_FEATURE_CATEGORIES).fill(true),
       });
@@ -79,7 +79,7 @@ export function validateThresholds(dataset: Dataset, thresholds: FeatureThreshol
       // Convert to numeric threshold instead.
       newThresholds.push({
         featureKey: featureKey,
-        units: threshold.units,
+        unit: threshold.unit,
         type: ThresholdType.NUMERIC,
         min: featureData.min,
         max: featureData.max,
@@ -119,7 +119,7 @@ export function getInRangeLUT(dataset: Dataset, thresholds: FeatureThreshold[]):
   // Ignore thresholds with features that don't exist in this dataset or whose units don't match
   const validThresholds = thresholds.filter((threshold) => {
     const featureData = dataset.getFeatureData(threshold.featureKey);
-    return featureData && featureData.unit === threshold.units;
+    return featureData && featureData.unit === threshold.unit;
   });
 
   for (let id = 0; id < dataset.numObjects; id++) {

--- a/src/colorizer/utils/dataset_utils.ts
+++ b/src/colorizer/utils/dataset_utils.ts
@@ -56,11 +56,12 @@ type ManifestFileV0_0_0 = {
 // array of metadata objects.
 // eslint-disable-next-line @typescript-eslint/naming-convention
 type ManifestFileV1_0_0 = Omit<ManifestFileV0_0_0, "features" | "featureMetadata" | "metadata"> & {
+  /** List of feature metadata, including keys and data paths. */
   features: {
     key?: string;
     name: string;
     data: string;
-    units?: string;
+    unit?: string;
     type?: string;
     categories?: string[];
   }[];
@@ -106,7 +107,8 @@ export const updateManifestVersion = (manifest: AnyManifestFile): ManifestFile =
       features.push({
         name: featureName,
         data: featurePath,
-        units: featureMetadata?.units || undefined,
+        // Note change from "units" to "unit"
+        unit: featureMetadata?.units || undefined,
         type: featureMetadata?.type || undefined,
         categories: featureMetadata?.categories || undefined,
       });

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -115,7 +115,7 @@ function serializeThreshold(threshold: FeatureThreshold): string {
   // featureKey + units are encoded in case it contains special characters (":" or ",").
   // TODO: remove once feature keys are implemented.
   const featureKey = encodeURIComponent(threshold.featureKey);
-  const featureUnit = encodeURIComponent(threshold.units);
+  const featureUnit = encodeURIComponent(threshold.unit);
 
   // TODO: Are there better characters I can be using here? ":" and "," take up
   // more space in the URL. -> once features are converted to use keys, use "-" as a separator here? "|"?
@@ -163,7 +163,7 @@ function deserializeThreshold(thresholdString: string): FeatureThreshold | undef
     }
     threshold = {
       featureKey: decodeURIComponent(featureKey),
-      units: decodeURIComponent(featureUnit),
+      unit: decodeURIComponent(featureUnit),
       type: ThresholdType.CATEGORICAL,
       enabledCategories,
     };
@@ -171,7 +171,7 @@ function deserializeThreshold(thresholdString: string): FeatureThreshold | undef
     // Feature is numeric and a range.
     threshold = {
       featureKey: decodeURIComponent(featureKey),
-      units: decodeURIComponent(featureUnit),
+      unit: decodeURIComponent(featureUnit),
       type: ThresholdType.NUMERIC,
       min: parseFloat(selection[0]),
       max: parseFloat(selection[1]),
@@ -187,7 +187,7 @@ function deserializeThreshold(thresholdString: string): FeatureThreshold | undef
     );
     threshold = {
       featureKey: decodeURIComponent(featureKey),
-      units: decodeURIComponent(featureUnit),
+      unit: decodeURIComponent(featureUnit),
       type: ThresholdType.NUMERIC,
       min: NaN,
       max: NaN,

--- a/src/components/Tabs/FeatureThresholdsTab.tsx
+++ b/src/components/Tabs/FeatureThresholdsTab.tsx
@@ -147,7 +147,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
     // reflect the last known good values.
     for (const threshold of props.featureThresholds) {
       const featureData = props.dataset?.getFeatureData(threshold.featureKey);
-      if (featureData && featureData.units === threshold.units && featureData.type !== FeatureType.CATEGORICAL) {
+      if (featureData && featureData.unit === threshold.units && featureData.type !== FeatureType.CATEGORICAL) {
         featureMinMaxBoundsFallback.current.set(thresholdToKey(threshold), [featureData.min, featureData.max]);
       }
     }
@@ -186,7 +186,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
     const featureData = props.dataset?.getFeatureData(featureKey);
     const newThresholds = [...props.featureThresholds];
     if (featureData) {
-      const index = props.featureThresholds.findIndex(thresholdMatchFinder(featureKey, featureData.units));
+      const index = props.featureThresholds.findIndex(thresholdMatchFinder(featureKey, featureData.unit));
       if (index !== -1) {
         // Delete saved min/max bounds for this feature
         const thresholdToRemove = props.featureThresholds[index];
@@ -246,13 +246,13 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
   // show selections that are actually valid.
   const thresholdsInDataset = props.featureThresholds.filter((t) => {
     const featureData = props.dataset?.getFeatureData(t.featureKey);
-    return featureData && featureData.units === t.units;
+    return featureData && featureData.unit === t.units;
   });
   const selectedFeatures = thresholdsInDataset.map((t) => t.featureKey);
 
   const renderNumericItem = (item: NumericFeatureThreshold, index: number): ReactNode => {
     const featureData = props.dataset?.getFeatureData(item.featureKey);
-    const disabled = featureData === undefined || featureData.units !== item.units;
+    const disabled = featureData === undefined || featureData.unit !== item.units;
     // If the feature is no longer in the dataset, use the saved min/max bounds.
     const savedMinMax = featureMinMaxBoundsFallback.current.get(thresholdToKey(item)) || [Number.NaN, Number.NaN];
     const sliderMin = disabled ? savedMinMax[0] : featureData.min;
@@ -275,7 +275,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
 
   const renderCategoricalItem = (item: CategoricalFeatureThreshold, index: number): ReactNode => {
     const featureData = props.dataset?.getFeatureData(item.featureKey);
-    const disabled = featureData === undefined || featureData.units !== item.units;
+    const disabled = featureData === undefined || featureData.unit !== item.units;
 
     const categories = featureData?.categories || [];
     const enabledCategories = item.enabledCategories;
@@ -308,7 +308,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
     // Thresholds are matched on both feature names and units; a threshold must match
     // both in the current dataset to be enabled and editable.
     const featureData = props.dataset?.getFeatureData(threshold.featureKey);
-    const disabled = featureData === undefined || featureData.units !== threshold.units;
+    const disabled = featureData === undefined || featureData.unit !== threshold.units;
     // TODO: This will show the internal feature key name for any filters on features not in
     // the current dataset. Show a different placeholder instead?
     const name = featureData?.name || threshold.featureKey;

--- a/src/components/Tabs/FeatureThresholdsTab.tsx
+++ b/src/components/Tabs/FeatureThresholdsTab.tsx
@@ -131,7 +131,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
 
   /** Converts a threshold to a unique key that can be used to look up its information later. Matches on feature key and unit. */
   const thresholdToKey = (threshold: FeatureThreshold): string => {
-    return `${encodeURIComponent(threshold.featureKey)}:${threshold.units ? encodeURIComponent(threshold.units) : ""}`;
+    return `${encodeURIComponent(threshold.featureKey)}:${threshold.unit ? encodeURIComponent(threshold.unit) : ""}`;
   };
   // Save the FEATURE min/max bounds (not the selected range of the threshold) for each threshold. We do
   // this in case the user switches to a dataset that no longer has the threshold's feature
@@ -147,7 +147,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
     // reflect the last known good values.
     for (const threshold of props.featureThresholds) {
       const featureData = props.dataset?.getFeatureData(threshold.featureKey);
-      if (featureData && featureData.unit === threshold.units && featureData.type !== FeatureType.CATEGORICAL) {
+      if (featureData && featureData.unit === threshold.unit && featureData.type !== FeatureType.CATEGORICAL) {
         featureMinMaxBoundsFallback.current.set(thresholdToKey(threshold), [featureData.min, featureData.max]);
       }
     }
@@ -164,7 +164,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
       newThresholds.push({
         type: ThresholdType.NUMERIC,
         featureKey: featureKey,
-        units: props.dataset!.getFeatureUnits(featureKey),
+        unit: props.dataset!.getFeatureUnits(featureKey),
         min: featureData.min,
         max: featureData.max,
       });
@@ -173,7 +173,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
       newThresholds.push({
         type: ThresholdType.CATEGORICAL,
         featureKey: featureKey,
-        units: props.dataset!.getFeatureUnits(featureKey),
+        unit: props.dataset!.getFeatureUnits(featureKey),
         enabledCategories: Array(MAX_FEATURE_CATEGORIES).fill(true),
       });
     }
@@ -246,13 +246,13 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
   // show selections that are actually valid.
   const thresholdsInDataset = props.featureThresholds.filter((t) => {
     const featureData = props.dataset?.getFeatureData(t.featureKey);
-    return featureData && featureData.unit === t.units;
+    return featureData && featureData.unit === t.unit;
   });
   const selectedFeatures = thresholdsInDataset.map((t) => t.featureKey);
 
   const renderNumericItem = (item: NumericFeatureThreshold, index: number): ReactNode => {
     const featureData = props.dataset?.getFeatureData(item.featureKey);
-    const disabled = featureData === undefined || featureData.unit !== item.units;
+    const disabled = featureData === undefined || featureData.unit !== item.unit;
     // If the feature is no longer in the dataset, use the saved min/max bounds.
     const savedMinMax = featureMinMaxBoundsFallback.current.get(thresholdToKey(item)) || [Number.NaN, Number.NaN];
     const sliderMin = disabled ? savedMinMax[0] : featureData.min;
@@ -275,7 +275,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
 
   const renderCategoricalItem = (item: CategoricalFeatureThreshold, index: number): ReactNode => {
     const featureData = props.dataset?.getFeatureData(item.featureKey);
-    const disabled = featureData === undefined || featureData.unit !== item.units;
+    const disabled = featureData === undefined || featureData.unit !== item.unit;
 
     const categories = featureData?.categories || [];
     const enabledCategories = item.enabledCategories;
@@ -308,11 +308,11 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
     // Thresholds are matched on both feature names and units; a threshold must match
     // both in the current dataset to be enabled and editable.
     const featureData = props.dataset?.getFeatureData(threshold.featureKey);
-    const disabled = featureData === undefined || featureData.unit !== threshold.units;
+    const disabled = featureData === undefined || featureData.unit !== threshold.unit;
     // TODO: This will show the internal feature key name for any filters on features not in
     // the current dataset. Show a different placeholder instead?
     const name = featureData?.name || threshold.featureKey;
-    const featureLabel = threshold.units ? `${name} (${threshold.units})` : name;
+    const featureLabel = threshold.unit ? `${name} (${threshold.unit})` : name;
 
     return (
       <List.Item style={{ position: "relative" }} key={index}>

--- a/src/routes/LandingPageContent.ts
+++ b/src/routes/LandingPageContent.ts
@@ -61,7 +61,7 @@ export const landingPageContent: ProjectEntry[] = [
             {
               featureKey: "volume",
               type: ThresholdType.NUMERIC,
-              units: "µm³",
+              unit: "µm³",
               min: 649.121,
               max: 2457.944,
             },

--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -159,6 +159,25 @@ describe("Dataset", () => {
         expect(dataset.getFeatureUnits("feature5")).to.equal("");
       });
 
+      it("retrieves feature units and names", async () => {
+        const dataset = await makeMockDataset(manifest);
+
+        // Display labels are only implemented in v1.0.0 and later
+        if (semver.lt(version, "1.0.0")) {
+          expect(dataset.getFeatureNameWithUnits("feature1")).to.equal("feature1 (meters)");
+          expect(dataset.getFeatureNameWithUnits("feature2")).to.equal("feature2 ((m))");
+          expect(dataset.getFeatureNameWithUnits("feature3")).to.equal("feature3 (μm/s)");
+          expect(dataset.getFeatureNameWithUnits("feature4")).to.equal("feature4");
+          expect(dataset.getFeatureNameWithUnits("feature5")).to.equal("feature5");
+        } else {
+          expect(dataset.getFeatureNameWithUnits("feature1")).to.equal("Feature1 (meters)");
+          expect(dataset.getFeatureNameWithUnits("feature2")).to.equal("Feature2 ((m))");
+          expect(dataset.getFeatureNameWithUnits("feature3")).to.equal("Feature3 (μm/s)");
+          expect(dataset.getFeatureNameWithUnits("feature4")).to.equal("Feature4");
+          expect(dataset.getFeatureNameWithUnits("feature5")).to.equal("Feature5");
+        }
+      });
+
       it("retrieves feature types", async () => {
         const dataset = await makeMockDataset(manifest);
 

--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -95,9 +95,9 @@ describe("Dataset", () => {
   const manifestV1_0_0: AnyManifestFile = {
     ...manifestV0_0_0,
     features: [
-      { key: "feature1", name: "Feature1", data: "feature1.json", units: "meters", type: "continuous" },
-      { key: "feature2", name: "Feature2", data: "feature2.json", units: "(m)", type: "discrete" },
-      { name: "Feature3", data: "feature3.json", units: "μm/s", type: "bad-type" },
+      { key: "feature1", name: "Feature1", data: "feature1.json", unit: "meters", type: "continuous" },
+      { key: "feature2", name: "Feature2", data: "feature2.json", unit: "(m)", type: "discrete" },
+      { name: "Feature3", data: "feature3.json", unit: "μm/s", type: "bad-type" },
       { name: "Feature4", data: "feature4.json" },
       {
         key: "feature5",

--- a/tests/data_utils.test.ts
+++ b/tests/data_utils.test.ts
@@ -40,13 +40,13 @@ describe("data_utils", () => {
       const dataset = await makeMockDataset({
         frames: ["frame0.json"],
         features: [
-          { name: "Feature A", key: "feature_a", data: "feature1.json", units: "", type: "discrete" },
-          { name: "MY FEATURE B", key: "feature_b", data: "feature2.json", units: "", type: "discrete" },
+          { name: "Feature A", key: "feature_a", data: "feature1.json", unit: "", type: "discrete" },
+          { name: "MY FEATURE B", key: "feature_b", data: "feature2.json", unit: "", type: "discrete" },
           {
             name: "My Feature C",
             key: "feature_c",
             data: "feature3.json",
-            units: "b",
+            unit: "b",
             type: "continuous",
             categories: ["1", "2", "3"],
           },
@@ -56,21 +56,21 @@ describe("data_utils", () => {
       const existingThresholds: FeatureThreshold[] = [
         {
           featureKey: "Feature A",
-          units: "",
+          unit: "",
           type: ThresholdType.NUMERIC,
           min: 0,
           max: 10,
         },
         {
           featureKey: "MY FEATURE B",
-          units: "",
+          unit: "",
           type: ThresholdType.NUMERIC,
           min: 0,
           max: 10,
         },
         {
           featureKey: "My Feature C",
-          units: "different_unit_and_wont_match",
+          unit: "different_unit_and_wont_match",
           type: ThresholdType.CATEGORICAL,
           enabledCategories: [true, false, false],
         },
@@ -81,14 +81,14 @@ describe("data_utils", () => {
       expect(newThresholds).to.deep.equal([
         {
           featureKey: "feature_a",
-          units: "",
+          unit: "",
           type: ThresholdType.NUMERIC,
           min: 0,
           max: 10,
         },
         {
           featureKey: "feature_b",
-          units: "",
+          unit: "",
           type: ThresholdType.NUMERIC,
           min: 0,
           max: 10,
@@ -96,7 +96,7 @@ describe("data_utils", () => {
         // Ignores features that don't match the units of the dataset's feature
         {
           featureKey: "My Feature C",
-          units: "different_unit_and_wont_match",
+          unit: "different_unit_and_wont_match",
           type: ThresholdType.CATEGORICAL,
           enabledCategories: [true, false, false],
         },

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -125,19 +125,19 @@ describe("Loading + saving from URL query strings", () => {
       track: 25,
       time: 14,
       thresholds: [
-        { featureKey: "f1", units: "m", type: ThresholdType.NUMERIC, min: 0, max: 0 },
-        { featureKey: "f2", units: "um", type: ThresholdType.NUMERIC, min: NaN, max: NaN },
-        { featureKey: "f3", units: "km", type: ThresholdType.NUMERIC, min: 0, max: 1 },
-        { featureKey: "f4", units: "mm", type: ThresholdType.NUMERIC, min: 0.501, max: 1000.485 },
+        { featureKey: "f1", unit: "m", type: ThresholdType.NUMERIC, min: 0, max: 0 },
+        { featureKey: "f2", unit: "um", type: ThresholdType.NUMERIC, min: NaN, max: NaN },
+        { featureKey: "f3", unit: "km", type: ThresholdType.NUMERIC, min: 0, max: 1 },
+        { featureKey: "f4", unit: "mm", type: ThresholdType.NUMERIC, min: 0.501, max: 1000.485 },
         {
           featureKey: "f5",
-          units: "",
+          unit: "",
           type: ThresholdType.CATEGORICAL,
           enabledCategories: [true, true, true, true, true, true, true, true, true, true, true, true],
         },
         {
           featureKey: "f6",
-          units: "",
+          unit: "",
           type: ThresholdType.CATEGORICAL,
           enabledCategories: [true, false, false, false, true, false, false, false, false, false, false, false],
         },
@@ -177,12 +177,12 @@ describe("Loading + saving from URL query strings", () => {
   it("Handles feature threshold names with nonstandard characters", () => {
     const originalParams: Partial<UrlParams> = {
       thresholds: [
-        { featureKey: "feature,,,", units: ",m,", type: ThresholdType.NUMERIC, min: 0, max: 1 },
-        { featureKey: "(feature)", units: "(m)", type: ThresholdType.NUMERIC, min: 0, max: 1 },
-        { featureKey: "feat:ure", units: ":m", type: ThresholdType.NUMERIC, min: 0, max: 1 },
+        { featureKey: "feature,,,", unit: ",m,", type: ThresholdType.NUMERIC, min: 0, max: 1 },
+        { featureKey: "(feature)", unit: "(m)", type: ThresholdType.NUMERIC, min: 0, max: 1 },
+        { featureKey: "feat:ure", unit: ":m", type: ThresholdType.NUMERIC, min: 0, max: 1 },
         {
           featureKey: "0.0%",
-          units: "m&m's",
+          unit: "m&m's",
           type: ThresholdType.CATEGORICAL,
           enabledCategories: padCategories([true, false, false]),
         },
@@ -200,9 +200,9 @@ describe("Loading + saving from URL query strings", () => {
   it("Enforces min/max on range and thresholds", () => {
     const originalParams: Partial<UrlParams> = {
       thresholds: [
-        { featureKey: "feature1", units: "m", type: ThresholdType.NUMERIC, min: 1, max: 0 },
-        { featureKey: "feature2", units: "m", type: ThresholdType.NUMERIC, min: 12, max: -34 },
-        { featureKey: "feature3", units: "m", type: ThresholdType.NUMERIC, min: 0.5, max: 0.25 },
+        { featureKey: "feature1", unit: "m", type: ThresholdType.NUMERIC, min: 1, max: 0 },
+        { featureKey: "feature2", unit: "m", type: ThresholdType.NUMERIC, min: 12, max: -34 },
+        { featureKey: "feature3", unit: "m", type: ThresholdType.NUMERIC, min: 0.5, max: 0.25 },
       ],
       range: [1, 0],
     };
@@ -214,16 +214,16 @@ describe("Loading + saving from URL query strings", () => {
     const parsedParams = loadFromUrlSearchParams(new URLSearchParams(queryString));
 
     expect(parsedParams.thresholds).deep.equals([
-      { featureKey: "feature1", units: "m", type: ThresholdType.NUMERIC, min: 0, max: 1 },
-      { featureKey: "feature2", units: "m", type: ThresholdType.NUMERIC, min: -34, max: 12 },
-      { featureKey: "feature3", units: "m", type: ThresholdType.NUMERIC, min: 0.25, max: 0.5 },
+      { featureKey: "feature1", unit: "m", type: ThresholdType.NUMERIC, min: 0, max: 1 },
+      { featureKey: "feature2", unit: "m", type: ThresholdType.NUMERIC, min: -34, max: 12 },
+      { featureKey: "feature3", unit: "m", type: ThresholdType.NUMERIC, min: 0.25, max: 0.5 },
     ]);
     expect(parsedParams.range).deep.equals([0, 1]);
   });
 
   it("Handles empty feature thresholds", () => {
     const originalParams: Partial<UrlParams> = {
-      thresholds: [{ featureKey: "feature1", units: "", type: ThresholdType.NUMERIC, min: 0, max: 1 }],
+      thresholds: [{ featureKey: "feature1", unit: "", type: ThresholdType.NUMERIC, min: 0, max: 1 }],
     };
     const queryString = paramsToUrlQueryString(originalParams);
     const expectedQueryString = "?filters=feature1%3A%3A0%3A1";
@@ -238,7 +238,7 @@ describe("Loading + saving from URL query strings", () => {
       time: 0,
       track: 0,
       range: [0, 0],
-      thresholds: [{ featureKey: "feature", units: "", type: ThresholdType.NUMERIC, min: 0, max: 0 }],
+      thresholds: [{ featureKey: "feature", unit: "", type: ThresholdType.NUMERIC, min: 0, max: 0 }],
     };
     const queryString = paramsToUrlQueryString(originalParams);
     const expectedQueryString = "?track=0&t=0&filters=feature%3A%3A0%3A0&range=0%2C0";
@@ -250,7 +250,7 @@ describe("Loading + saving from URL query strings", () => {
 
   it("Handles less than the maximum expected categories", () => {
     const originalParams: Partial<UrlParams> = {
-      thresholds: [{ featureKey: "feature", units: "", type: ThresholdType.CATEGORICAL, enabledCategories: [true] }],
+      thresholds: [{ featureKey: "feature", unit: "", type: ThresholdType.CATEGORICAL, enabledCategories: [true] }],
     };
     const queryString = paramsToUrlQueryString(originalParams);
     const expectedQueryString = "?filters=feature%3A%3A1";
@@ -260,7 +260,7 @@ describe("Loading + saving from URL query strings", () => {
     expect(parsedParams.thresholds).deep.equals([
       {
         featureKey: "feature",
-        units: "",
+        unit: "",
         type: ThresholdType.CATEGORICAL,
         enabledCategories: padCategories([true]),
       },
@@ -271,9 +271,7 @@ describe("Loading + saving from URL query strings", () => {
     const thresholds = padCategories([true, true]);
     thresholds.push(true); // Add an extra threshold. This should be ignored
     const originalParams: Partial<UrlParams> = {
-      thresholds: [
-        { featureKey: "feature", units: "", type: ThresholdType.CATEGORICAL, enabledCategories: thresholds },
-      ],
+      thresholds: [{ featureKey: "feature", unit: "", type: ThresholdType.CATEGORICAL, enabledCategories: thresholds }],
     };
     const queryString = paramsToUrlQueryString(originalParams);
     const expectedQueryString = "?filters=feature%3A%3A1003";
@@ -283,7 +281,7 @@ describe("Loading + saving from URL query strings", () => {
     expect(parsedParams.thresholds).deep.equals([
       {
         featureKey: "feature",
-        units: "",
+        unit: "",
         type: ThresholdType.CATEGORICAL,
         enabledCategories: padCategories([true, true]),
       },


### PR DESCRIPTION
Problem
=======
Closes #382, a bug where the feature units from newer datasets did not appear on the UI. This was caused by a mismatch in the key it was retrieving ("units" instead of "unit", which is the expected format based on our documentation: https://github.com/allen-cell-animated/colorizer-data/blob/main/documentation/DATA_FORMAT.md#dataset).

*Estimated review size: small, 5-10 minutes*

Solution
========
- Feature units will now be loaded with the key `unit`.
- Changed thresholds to also refer to `unit` instead of `units` for consistency.
- Older versions of the manifest will now have features remapped from `units` to `unit`.
- Updated unit tests.

## Type of change
* Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
1. Load these two older datasets, which use the deprecated dataset format (internally use "units"). Mouse over the features dropdown to make sure that the names of the features look identical.
  - FIXED BUILD: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-383/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Fcollection.json
  - BROKEN BUILD: https://allen-cell-animated.github.io/timelapse-colorizer/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Fcollection.json
2. Load this newer dataset (internally uses "unit"). Units should appear in the feature dropdown in the new build but not in the old build.
  - FIXED BUILD: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-383/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fassay-dev%2Fcomputational%2Fdata%2FEMT_deliverable_processing%2FTranscription_factor_cell_lines%2FVersion_1%2Fcolorizer_output%2FEOMES%2Fcollections_all.json
  - BROKEN BUILD: https://allen-cell-animated.github.io/timelapse-colorizer/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fassay-dev%2Fcomputational%2Fdata%2FEMT_deliverable_processing%2FTranscription_factor_cell_lines%2FVersion_1%2Fcolorizer_output%2FEOMES%2Fcollections_all.json

Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/timelapse-colorizer/assets/30200665/d759389c-da22-436c-9d3c-358aa88063a5)

![image](https://github.com/allen-cell-animated/timelapse-colorizer/assets/30200665/77613d4a-63e3-4891-a93f-371c47f5bb36)
