### PR TITLE
feat: Update error page to match website-3d-cell-viewer

### DIFF
--- a/src/routes/ErrorPage.tsx
+++ b/src/routes/ErrorPage.tsx
@@ -29,7 +29,7 @@ export default function ErrorPage(): ReactElement {
   return (
     <div>
       <Header />
-      <FlexColumnAlignCenter style={{ width: "100%", padding: "40px" }}>
+      <FlexColumnAlignCenter style={{ width: "100%", padding: "40px 0" }}>
         <h1>Sorry, something went wrong.</h1>
         <FlexColumnAlignCenter>
           <p>We encountered the following error:</p>

--- a/src/routes/ErrorPage.tsx
+++ b/src/routes/ErrorPage.tsx
@@ -30,9 +30,28 @@ export default function ErrorPage(): ReactElement {
     <div>
       <Header />
       <FlexColumnAlignCenter style={{ width: "100%", padding: "40px" }}>
-        <h1>{errorMessage}</h1>
-        <p>Sorry, something went wrong.</p>
+        <h1>Sorry, something went wrong.</h1>
+        <FlexColumnAlignCenter>
+          <p>We encountered the following error:</p>
+          <FlexColumnAlignCenter style={{ margin: "20px 0" }} $gap={10}>
+            <h3>{errorMessage}</h3>
+            <p>
+              <i>Check the browser console for more details.</i>
+            </p>
+          </FlexColumnAlignCenter>
+          <p>
+            If the issue persists after a refresh,{" "}
+            <Link
+              to="https://github.com/allen-cell-animated/timelapse-colorizer/issues/new?template=bug_report.md"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              please click here to report it.
+            </Link>
+          </p>
+        </FlexColumnAlignCenter>
         <br />
+        {/* TODO: Bad practice to wrap a button inside a link, since it's confusing for tab navigation. */}
         <Link to="/">
           <Button type="primary">Return to homepage</Button>
         </Link>


### PR DESCRIPTION
Problem
=======
Closes #327, giving a better error page experience.

*Estimated review size: tiny, 3 minutes*

Solution
========
- Adds a link to GitHub issues on the error page
- Adds more helpful context and next steps to error page
- Fixes error page padding issues

## Type of change

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-384/bad/

Screenshots (optional):
-----------------------
Before:
![image](https://github.com/allen-cell-animated/timelapse-colorizer/assets/30200665/ec23e17c-71a4-4a29-b5c9-6d315117f0b1)

After:
![image](https://github.com/allen-cell-animated/timelapse-colorizer/assets/30200665/5d943aad-f3e8-4934-a465-aa087f7b44d8)
