### PR TITLE
feat: Update landing page for NucMorph publication + styling

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -777,7 +777,7 @@ function Viewer(): ReactElement {
       <div ref={notificationContainer}>{notificationContextHolder}</div>
       <SmallScreenWarning />
 
-      <Header alertElement={bannerElement}>
+      <Header alertElement={bannerElement} headerOpensInNewTab={true}>
         <h3>{collection?.metadata.name ?? null}</h3>
         <FlexRowAlignCenter $gap={12} $wrap="wrap">
           <FlexRowAlignCenter $gap={2} $wrap="wrap">

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -58,6 +58,7 @@ const theme = {
     },
     layout: {
       background: palette.gray0,
+      backgroundAlt: palette.gray7,
       tabBackground: palette.gray5,
       dividers: palette.gray15,
       borders: palette.gray20,
@@ -108,8 +109,8 @@ const theme = {
     family: "Lato, LatoExtended, sans-serif",
     resource: "https://fonts.googleapis.com/css2?family=Lato&display=swap",
     size: {
-      header: 20,
-      section: 18,
+      header: 26,
+      section: 20,
       label: 16,
       content: 14,
       labelSmall: 12,
@@ -154,6 +155,7 @@ const CssContainer = styled.div`
   --color-text-link: ${theme.color.text.link};
 
   /* Layout */
+  --color-background-alt: ${theme.color.layout.backgroundAlt};
   --color-background: ${theme.color.layout.background};
   --color-dividers: ${theme.color.layout.dividers};
   --color-borders: ${theme.color.layout.borders};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -69,7 +69,7 @@ function HeaderLogo(): ReactElement {
       </AicsLogoLink>
       <VerticalDivider />
       <HeaderLink to="/" aria-label="Go to home page">
-        <h1 style={{ margin: "0" }}>Timelapse Feature Explorer</h1>
+        <h1 style={{ margin: "0", fontSize: "20px" }}>Timelapse Feature Explorer</h1>
       </HeaderLink>
     </FlexRowAlignCenter>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -58,7 +58,7 @@ const HeaderLink = styled(Link)`
  * The logo and title of the app, to be used with the Header component.
  * Both the logo and app title are links that can be used for navigation.
  */
-function HeaderLogo(): ReactElement {
+function HeaderLogo(props: { headerOpensInNewTab?: boolean }): ReactElement {
   return (
     <FlexRowAlignCenter>
       <AicsLogoLink href="https://www.allencell.org/" rel="noopener noreferrer" target="_blank">
@@ -68,7 +68,12 @@ function HeaderLogo(): ReactElement {
         </div>
       </AicsLogoLink>
       <VerticalDivider />
-      <HeaderLink to="/" aria-label="Go to home page">
+      <HeaderLink
+        to="/"
+        aria-label="Go to home page"
+        target={props.headerOpensInNewTab ? "_blank" : undefined}
+        rel={props.headerOpensInNewTab ? "noopener noreferrer" : undefined}
+      >
         <h1 style={{ margin: "0", fontSize: "20px" }}>Timelapse Feature Explorer</h1>
       </HeaderLink>
     </FlexRowAlignCenter>
@@ -103,13 +108,14 @@ const HeaderContainer = styled(FlexRowAlignCenter)`
 type HeaderProps = {
   /** Optional element for alerts; will be rendered under the main header bar and use sticky positioning. */
   alertElement?: ReactElement;
+  headerOpensInNewTab?: boolean;
 };
 
 export default function Header(props: PropsWithChildren<HeaderProps>): ReactElement {
   return (
     <StickyContainer>
       <HeaderContainer>
-        <HeaderLogo />
+        <HeaderLogo headerOpensInNewTab={props.headerOpensInNewTab} />
         {props.children}
       </HeaderContainer>
       {props.alertElement}

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -97,15 +97,6 @@ const FeatureHighlightsItem = styled(FlexColumn)`
   }
 `;
 
-const Divider = styled.hr`
-  display: block;
-  width: 100%;
-  height: 1px;
-  background-color: var(--color-borders);
-  border-style: none;
-  margin: 0 0;
-`;
-
 const ProjectList = styled.ul`
   display: flex;
   flex-direction: column;

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -152,7 +152,7 @@ const DatasetList = styled.ol`
   display: grid;
   // Use grid + subgrid to align the title, description, and button for each horizontal
   // row of cards. repeat is used to tile the layout if the cards wrap to a new line.
-  grid-template-rows: repeat(3, auto);
+  grid-template-rows: repeat(2, auto);
   grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
   justify-content: space-around;
   text-align: start;
@@ -162,23 +162,22 @@ const DatasetList = styled.ol`
 const DatasetCard = styled.li`
   display: grid;
   grid-template-rows: subgrid;
-  grid-row: span 3;
+  grid-row: span 2;
   min-width: 180px;
   align-items: flex-start;
   margin-top: 10px;
 
-  & > h3 {
+  & > h3,
+  & > div {
     text-align: left;
     display: grid;
     margin: 0;
   }
   & > p {
     text-align: left;
-    display: grid;
   }
   & > a {
     margin: 2px auto 0 0;
-    display: grid;
   }
 `;
 
@@ -222,12 +221,14 @@ export default function LandingPage(): ReactElement {
     return (
       <DatasetCard key={index}>
         <h3>{dataset.name}</h3>
-        <p>{dataset.description}</p>
-        <Link to={viewerLink}>
-          <Button type="primary">
-            Load<VisuallyHidden> dataset {dataset.name}</VisuallyHidden>
-          </Button>
-        </Link>
+        <FlexColumn $gap={10}>
+          <p>{dataset.description}</p>
+          <Link to={viewerLink}>
+            <Button type="primary">
+              Load<VisuallyHidden> dataset {dataset.name}</VisuallyHidden>
+            </Button>
+          </Link>
+        </FlexColumn>
       </DatasetCard>
     );
   };

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -73,7 +73,6 @@ const ContentContainer = styled(FlexColumn)`
   max-width: 1060px;
   width: calc(90vw - 40px);
   margin: auto;
-  padding: 0 20px;
 `;
 
 const FeatureHighlightsContainer = styled.li`
@@ -329,7 +328,7 @@ export default function LandingPage(): ReactElement {
         <h2 style={{ margin: 0 }}>Load dataset(s) below or your own data to get started</h2>
       </FlexColumnAlignCenter>
 
-      <ContentContainer>
+      <ContentContainer style={{ paddingBottom: "400px" }}>
         <ProjectList>{landingPageContent.map(renderProject)}</ProjectList>
       </ContentContainer>
     </>

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -84,7 +84,7 @@ const FeatureHighlightsContainer = styled.li`
   padding: 0;
   justify-content: space-evenly;
   gap: 10px;
-  margin: 20px 0;
+  margin: 30px 0 0 0;
 `;
 
 const FeatureHighlightsItem = styled(FlexColumn)`
@@ -103,12 +103,13 @@ const Divider = styled.hr`
   height: 1px;
   background-color: var(--color-borders);
   border-style: none;
+  margin: 0 0;
 `;
 
 const ProjectList = styled.ul`
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 30px;
   padding: 0;
   margin-top: 0;
 
@@ -119,7 +120,7 @@ const ProjectList = styled.ul`
     width: 100%;
     height: 1px;
     background-color: var(--color-borders);
-    margin-bottom: 10px;
+    margin-bottom: 15px;
   }
 `;
 
@@ -127,10 +128,21 @@ const ProjectCard = styled.li`
   display: flex;
   width: 100%;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
 
   & h3 {
     font-weight: 600;
+  }
+
+  & p,
+  & h3,
+  & span {
+    margin: 0;
+  }
+
+  & a {
+    // Add 2px margin to maintain the same visual gap that text has
+    margin: 2px 0 0 0;
   }
 `;
 
@@ -143,6 +155,7 @@ const DatasetList = styled.ol`
   grid-template-rows: repeat(3, auto);
   grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
   justify-content: space-around;
+  text-align: start;
   gap: 10px 20px;
 `;
 
@@ -151,19 +164,20 @@ const DatasetCard = styled.li`
   grid-template-rows: subgrid;
   grid-row: span 3;
   min-width: 180px;
-  padding: 5px;
+  align-items: flex-start;
+  margin-top: 10px;
 
-  & > h4 {
-    text-align: center;
+  & > h3 {
+    text-align: left;
     display: grid;
     margin: 0;
   }
   & > p {
-    text-align: center;
+    text-align: left;
     display: grid;
   }
   & > a {
-    margin: auto;
+    margin: 2px auto 0 0;
     display: grid;
   }
 `;
@@ -207,7 +221,7 @@ export default function LandingPage(): ReactElement {
 
     return (
       <DatasetCard key={index}>
-        <h4>{dataset.name}</h4>
+        <h3>{dataset.name}</h3>
         <p>{dataset.description}</p>
         <Link to={viewerLink}>
           <Button type="primary">
@@ -297,8 +311,7 @@ export default function LandingPage(): ReactElement {
         </BannerTextContainer>
       </Banner>
 
-      <br />
-      <ContentContainer $gap={10}>
+      <ContentContainer $gap={30}>
         <FeatureHighlightsContainer>
           <FeatureHighlightsItem>
             <h3>Dynamic color mapping</h3>
@@ -322,10 +335,10 @@ export default function LandingPage(): ReactElement {
             </p>
           </FeatureHighlightsItem>
         </FeatureHighlightsContainer>
+
         <Divider />
-        <FlexColumnAlignCenter>
-          <h2>Load dataset(s) below or your own data to get started</h2>
-        </FlexColumnAlignCenter>
+        <h2 style={{ margin: 0 }}>Load dataset(s) below or your own data to get started</h2>
+
         <ProjectList>{landingPageContent.map(renderProject)}</ProjectList>
       </ContentContainer>
     </>

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -82,7 +82,7 @@ const FeatureHighlightsContainer = styled.li`
   grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
   padding: 0;
   justify-content: space-evenly;
-  gap: 10px;
+  gap: 20px;
   margin: 30px 0 0 0;
 `;
 

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -152,7 +152,7 @@ const DatasetList = styled.ol`
   display: grid;
   // Use grid + subgrid to align the title, description, and button for each horizontal
   // row of cards. repeat is used to tile the layout if the cards wrap to a new line.
-  grid-template-rows: repeat(2, auto);
+  grid-template-rows: repeat(3, auto);
   grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
   justify-content: space-around;
   text-align: start;
@@ -162,22 +162,23 @@ const DatasetList = styled.ol`
 const DatasetCard = styled.li`
   display: grid;
   grid-template-rows: subgrid;
-  grid-row: span 2;
+  grid-row: span 3;
   min-width: 180px;
   align-items: flex-start;
   margin-top: 10px;
 
-  & > h3,
-  & > div {
+  & > h3 {
     text-align: left;
     display: grid;
     margin: 0;
   }
   & > p {
     text-align: left;
+    display: grid;
   }
   & > a {
     margin: 2px auto 0 0;
+    display: grid;
   }
 `;
 
@@ -221,14 +222,12 @@ export default function LandingPage(): ReactElement {
     return (
       <DatasetCard key={index}>
         <h3>{dataset.name}</h3>
-        <FlexColumn $gap={10}>
-          <p>{dataset.description}</p>
-          <Link to={viewerLink}>
-            <Button type="primary">
-              Load<VisuallyHidden> dataset {dataset.name}</VisuallyHidden>
-            </Button>
-          </Link>
-        </FlexColumn>
+        <p>{dataset.description}</p>
+        <Link to={viewerLink}>
+          <Button type="primary">
+            Load<VisuallyHidden> dataset {dataset.name}</VisuallyHidden>
+          </Button>
+        </Link>
       </DatasetCard>
     );
   };

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -27,7 +27,7 @@ const Banner = styled(FlexColumnAlignCenter)`
   margin: 0;
 `;
 
-const BannerTextContainer = styled(FlexColumn)`
+const BannerTextContainer = styled(FlexColumnAlignCenter)`
   --padding-x: 30px;
   padding: var(--padding-x);
   max-width: calc(1060px - 2 * var(--padding-x));
@@ -331,10 +331,15 @@ export default function LandingPage(): ReactElement {
             </p>
           </FeatureHighlightsItem>
         </FeatureHighlightsContainer>
+      </ContentContainer>
 
-        <Divider />
+      <FlexColumnAlignCenter
+        style={{ backgroundColor: "var(--color-background-alt)", padding: "30px", margin: "30px 0" }}
+      >
         <h2 style={{ margin: 0 }}>Load dataset(s) below or your own data to get started</h2>
+      </FlexColumnAlignCenter>
 
+      <ContentContainer>
         <ProjectList>{landingPageContent.map(renderProject)}</ProjectList>
       </ContentContainer>
     </>

--- a/src/routes/LandingPageContent.tsx
+++ b/src/routes/LandingPageContent.tsx
@@ -1,3 +1,5 @@
+import { faUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
 import { Color } from "three";
 
@@ -7,8 +9,24 @@ import { ProjectEntry } from "../types";
 export const landingPageContent: ProjectEntry[] = [
   {
     name: "Segmented hiPSC FOV-nuclei timelapse and analysis datasets",
-    description:
-      "Maximum projections of tracked 3D segmentations of nuclei in growing hiPS cell colonies, with quantitative features of nuclear shape, size and more. The exploratory dataset includes all tracked nuclei, with the baseline colony, full-interphase and lineage-annotated datasets as subsets of this dataset, analyzed in the study of nuclear growth <Biorxiv ref>. For documentation on the features available in these datasets, visit <link to quilt readme on features>.",
+    description: (
+      <p>
+        Maximum projections of tracked 3D segmentations of nuclei in growing hiPS cell colonies, with quantitative
+        features of nuclear shape, size and more. The exploratory dataset includes all tracked nuclei, with the baseline
+        colony, full-interphase and lineage-annotated datasets as subsets of this dataset, analyzed in the study of
+        nuclear growth{" "}
+        <a href="https://www.biorxiv.org/" rel="noopener noreferrer" target="_blank">
+          {"<Biorxiv ref>"}
+          <FontAwesomeIcon icon={faUpRightFromSquare} size="sm" style={{ marginBottom: "-1px", marginLeft: "3px" }} />
+        </a>
+        . For documentation on the features available in these datasets, visit{" "}
+        <a href="https://www.quiltdata.com/" rel="noopener noreferrer" target="_blank">
+          {"<a to quilt readme on features>"}
+          <FontAwesomeIcon icon={faUpRightFromSquare} size="sm" style={{ marginBottom: "-1px", marginLeft: "3px" }} />
+        </a>
+        .
+      </p>
+    ),
     publicationLink: new URL("https://www.google.com"),
     publicationName: "<NucMorph manuscript> (Publisher name, mm/dd/yyyy)",
     datasets: [

--- a/src/routes/LandingPageContent.tsx
+++ b/src/routes/LandingPageContent.tsx
@@ -1,14 +1,13 @@
 import { faUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
-import { Color } from "three";
 
-import { DrawMode, ThresholdType } from "../colorizer/types";
+import { ThresholdType } from "../colorizer/types";
 import { ProjectEntry } from "../types";
 
 export const landingPageContent: ProjectEntry[] = [
   {
-    name: "Segmented hiPSC FOV-nuclei timelapse and analysis datasets",
+    name: "Tracked hiPSC FOV-nuclei timelapse datasets",
     inReview: true,
     description: (
       <p>
@@ -34,114 +33,67 @@ export const landingPageContent: ProjectEntry[] = [
       {
         name: "Exploratory dataset",
         description: "All successful tracked nuclei, with all available features and filters",
-        loadParams: {},
+        loadParams: {
+          collection:
+            "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/timelapse_feature_explorer_datasets/exploratory_dataset/collection.json",
+          time: 15,
+          thresholds: [
+            {
+              featureKey: "growth_outlier_filter",
+              type: ThresholdType.CATEGORICAL,
+              unit: "",
+              enabledCategories: [true, true],
+            },
+            {
+              featureKey: "baseline_colonies_dataset_filter",
+              type: ThresholdType.CATEGORICAL,
+              unit: "",
+              enabledCategories: [true, true],
+            },
+            {
+              featureKey: "fullinterphase_dataset_filter",
+              type: ThresholdType.CATEGORICAL,
+              unit: "",
+              enabledCategories: [true, true],
+            },
+            {
+              featureKey: "lineageannotated_dataset_filter",
+              type: ThresholdType.CATEGORICAL,
+              unit: "",
+              enabledCategories: [true, true],
+            },
+          ],
+        },
       },
       {
         name: "Baseline colony dataset",
-        description: "Nuclei tracked throughout colony growth (subset of exploratory analysis dataset)",
-        loadParams: {},
+        description:
+          "Minimally filtered tracked nuclei with quantitative single-timepoint features (subset of exploratory analysis dataset)",
+        loadParams: {
+          collection:
+            "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/timelapse_feature_explorer_datasets/baseline_colonies_dataset/collection.json",
+          time: 15,
+        },
       },
       {
         name: "Full-interphase dataset",
         description:
           "Nuclei tracked throughout interphase (subset of baseline colony analysis dataset, with added growth trajectory features)",
-        loadParams: {},
+        loadParams: {
+          collection:
+            "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/timelapse_feature_explorer_datasets/full-interphase_dataset/collection.json",
+          time: 15,
+        },
       },
       {
         name: "Lineage-annotated dataset",
         description:
           "Nuclei tracked across multiple generations (subset of full-interphase analysis dataset, with added lineage annotation)",
-        loadParams: {},
-      },
-    ],
-  },
-  {
-    name: "NucMorph dataset name which usually is a rather long name so may wrap to two lines",
-    description:
-      "Introductory explanatory text about the dataset(s) and anything a user should know before opening in app. This should ideally only be a couple of sentences.",
-    publicationLink: new URL("https://www.google.com"),
-    publicationName:
-      "This is the name of the associated publication that the user can click to open in a new tab (Publisher name, mm/dd/yyyy)",
-    loadParams: {
-      collection: "https://dev-aics-dtp-001.int.allencell.org/dan-data/colorizer/data/collection.json",
-      dataset: "Mama Bear",
-      feature: "volume",
-    },
-    inReview: true,
-  },
-  {
-    name: "This is a project name in the case of multiple datasets belonging to a single project/publication",
-    description:
-      "Introductory explanatory text about the dataset(s) and anything a user should know before opening in app. This should ideally only be a couple of sentences.",
-    datasets: [
-      {
-        name: "This is a dataset with a semi-long name",
-        description: "This is a short description about this particular dataset. 2 lines at most.",
         loadParams: {
-          collection: "https://dev-aics-dtp-001.int.allencell.org/dan-data/colorizer/data/collection.json",
-          dataset: "Mama Bear",
-          feature: "height",
-          range: [0.54, 9.452],
-          colorRampKey: "esri-mentone_beach",
-          time: 154,
+          collection:
+            "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/timelapse_feature_explorer_datasets/lineage-annotated_dataset/collection.json",
+          time: 15,
         },
-      },
-      {
-        name: "This is a dataset with a semi-long name",
-        description: "This is a long description about this particular dataset. 2 lines at most.",
-        loadParams: {
-          collection: "https://dev-aics-dtp-001.int.allencell.org/dan-data/colorizer/data/collection.json",
-          dataset: "Goldilocks",
-          feature: "height",
-          range: [1.084, 8.156],
-          colorRampKey: "esri-blue_red_8",
-          time: 446,
-        },
-      },
-      {
-        name: "This is a dataset with a semi-long name",
-        description: "This is a short description about this particular dataset. 2 lines at most.",
-        loadParams: {
-          collection: "https://dev-aics-dtp-001.int.allencell.org/dan-data/colorizer/data/collection.json",
-          dataset: "Baby Bear",
-          feature: "height",
-          range: [0.54, 8.895],
-          colorRampKey: "esri-green_brown_1",
-          time: 397,
-          thresholds: [
-            {
-              featureKey: "volume",
-              type: ThresholdType.NUMERIC,
-              unit: "µm³",
-              min: 649.121,
-              max: 2457.944,
-            },
-          ],
-          config: {
-            outOfRangeDrawSettings: {
-              mode: DrawMode.USE_COLOR,
-              color: new Color("#858585"),
-            },
-          },
-        },
-      },
-    ],
-  },
-  {
-    name: "This is a project name in the case of multiple datasets belonging to a single project/publication",
-    description:
-      "Introductory explanatory text about the dataset(s) and anything a user should know before opening in app. This should ideally only be a couple of sentences.",
-    datasets: [
-      {
-        name: "This is a dataset with a semi-long name",
-        description: "This is a short description about this particular dataset. 2 lines at most.",
-        loadParams: {},
-      },
-      {
-        name: "This is a dataset with a semi-long name",
-        description:
-          "This is a long description about this particular dataset. 2 lines at most, but it has extra lines, so the entire section should wrap.",
-        loadParams: {},
       },
     ],
   },

--- a/src/routes/LandingPageContent.tsx
+++ b/src/routes/LandingPageContent.tsx
@@ -1,9 +1,57 @@
+import React from "react";
 import { Color } from "three";
 
 import { DrawMode, ThresholdType } from "../colorizer/types";
 import { ProjectEntry } from "../types";
 
 export const landingPageContent: ProjectEntry[] = [
+  {
+    name: "Segmented hiPSC FOV-nuclei timelapse and analysis datasets",
+    description:
+      "Maximum projections of tracked 3D segmentations of nuclei in growing hiPS cell colonies, with quantitative features of nuclear shape, size and more. The exploratory dataset includes all tracked nuclei, with the baseline colony, full-interphase and lineage-annotated datasets as subsets of this dataset, analyzed in the study of nuclear growth <Biorxiv ref>. For documentation on the features available in these datasets, visit <link to quilt readme on features>.",
+    publicationLink: new URL("https://www.google.com"),
+    publicationName: "<NucMorph manuscript> (Publisher name, mm/dd/yyyy)",
+    datasets: [
+      {
+        name: "Exploratory dataset",
+        description: "All successful tracked nuclei, with all available features and filters",
+        loadParams: {},
+      },
+      {
+        name: "Baseline colony dataset",
+        description: (
+          <p>
+            Nuclei tracked throughout colony growth
+            <br />
+            (subset of exploratory analysis dataset)
+          </p>
+        ),
+        loadParams: {},
+      },
+      {
+        name: "Full-interphase dataset",
+        description: (
+          <p>
+            Nuclei tracked throughout interphase
+            <br />
+            (subset of baseline colony analysis dataset, with added growth trajectory features)
+          </p>
+        ),
+        loadParams: {},
+      },
+      {
+        name: "Lineage-annotated dataset",
+        description: (
+          <p>
+            Nuclei tracked across multiple generations
+            <br />
+            (subset of full-interphase analysis dataset, with added lineage annotation)
+          </p>
+        ),
+        loadParams: {},
+      },
+    ],
+  },
   {
     name: "NucMorph dataset name which usually is a rather long name so may wrap to two lines",
     description:
@@ -90,42 +138,6 @@ export const landingPageContent: ProjectEntry[] = [
         name: "This is a dataset with a semi-long name",
         description:
           "This is a long description about this particular dataset. 2 lines at most, but it has extra lines, so the entire section should wrap.",
-        loadParams: {},
-      },
-    ],
-  },
-  {
-    name: "This is a project name in the case of multiple datasets belonging to a single project/publication",
-    description:
-      "Introductory explanatory text about the dataset(s) and anything a user should know before opening in app. This should ideally only be a couple of sentences.",
-    publicationLink: new URL("https://www.google.com"),
-    publicationName:
-      "This is the name of the associated publication that the user can click to open in a new tab (Publisher name, mm/dd/yyyy)",
-    datasets: [
-      {
-        name: "This is a dataset with a semi-long name",
-        description: "This is a short description about this particular dataset. 2 lines at most.",
-        loadParams: {},
-      },
-      {
-        name: "This is a dataset with a semi-long name",
-        description:
-          "This is a long description about this particular dataset. 2 lines at most, but it has extra lines, so the entire section should wrap.",
-        loadParams: {},
-      },
-      {
-        name: "This is a dataset with a longer name than the other elements, which should cause it to wrap",
-        description: "This is a short description about this particular dataset. 2 lines at most.",
-        loadParams: {},
-      },
-      {
-        name: "This is a dataset with a longer name than the other elements, which should cause it to wrap",
-        description: "This is a short description about this particular dataset. 2 lines at most.",
-        loadParams: {},
-      },
-      {
-        name: "This is a dataset with a longer name than the other elements, which should cause it to wrap",
-        description: "This is a short description about this particular dataset. 2 lines at most.",
         loadParams: {},
       },
     ],

--- a/src/routes/LandingPageContent.tsx
+++ b/src/routes/LandingPageContent.tsx
@@ -20,8 +20,12 @@ export const landingPageContent: ProjectEntry[] = [
           <FontAwesomeIcon icon={faUpRightFromSquare} size="sm" style={{ marginBottom: "-1px", marginLeft: "3px" }} />
         </a>
         . For documentation on the features available in these datasets, visit{" "}
-        <a href="https://www.quiltdata.com/" rel="noopener noreferrer" target="_blank">
-          {"<a to quilt readme on features>"}
+        <a
+          href="https://open.quiltdata.com/b/allencell/tree/aics/nuc-morph-dataset/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          {"our datasets hosted on Quilt"}
           <FontAwesomeIcon icon={faUpRightFromSquare} size="sm" style={{ marginBottom: "-1px", marginLeft: "3px" }} />
         </a>
         .

--- a/src/routes/LandingPageContent.tsx
+++ b/src/routes/LandingPageContent.tsx
@@ -38,35 +38,19 @@ export const landingPageContent: ProjectEntry[] = [
       },
       {
         name: "Baseline colony dataset",
-        description: (
-          <p>
-            Nuclei tracked throughout colony growth
-            <br />
-            (subset of exploratory analysis dataset)
-          </p>
-        ),
+        description: "Nuclei tracked throughout colony growth (subset of exploratory analysis dataset)",
         loadParams: {},
       },
       {
         name: "Full-interphase dataset",
-        description: (
-          <p>
-            Nuclei tracked throughout interphase
-            <br />
-            (subset of baseline colony analysis dataset, with added growth trajectory features)
-          </p>
-        ),
+        description:
+          "Nuclei tracked throughout interphase (subset of baseline colony analysis dataset, with added growth trajectory features)",
         loadParams: {},
       },
       {
         name: "Lineage-annotated dataset",
-        description: (
-          <p>
-            Nuclei tracked across multiple generations
-            <br />
-            (subset of full-interphase analysis dataset, with added lineage annotation)
-          </p>
-        ),
+        description:
+          "Nuclei tracked across multiple generations (subset of full-interphase analysis dataset, with added lineage annotation)",
         loadParams: {},
       },
     ],

--- a/src/routes/LandingPageContent.tsx
+++ b/src/routes/LandingPageContent.tsx
@@ -13,7 +13,7 @@ export const landingPageContent: ProjectEntry[] = [
       <p>
         Maximum projections of tracked 3D segmentations of nuclei in growing hiPS cell colonies, with quantitative
         features of nuclear shape, size and more. The exploratory dataset includes all tracked nuclei, with the baseline
-        colony, full-interphase and lineage-annotated datasets as subsets of this dataset, analyzed in the study of
+        colonies, full-interphase, and lineage-annotated datasets as subsets of this dataset, analyzed in the study of
         nuclear growth{" "}
         <a href="https://www.biorxiv.org/" rel="noopener noreferrer" target="_blank">
           {"<Biorxiv ref>"}
@@ -70,7 +70,7 @@ export const landingPageContent: ProjectEntry[] = [
         },
       },
       {
-        name: "Baseline colony dataset",
+        name: "Baseline colonies dataset",
         description:
           "Minimally filtered tracked nuclei with quantitative single-timepoint features (subset of exploratory analysis dataset)",
         loadParams: {
@@ -82,7 +82,7 @@ export const landingPageContent: ProjectEntry[] = [
       {
         name: "Full-interphase dataset",
         description:
-          "Nuclei tracked throughout interphase (subset of baseline colony analysis dataset, with added growth trajectory features)",
+          "Nuclei tracked throughout interphase (subset of baseline colonies analysis dataset, with added growth trajectory features)",
         loadParams: {
           collection:
             "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/timelapse_feature_explorer_datasets/full-interphase_dataset/collection.json",

--- a/src/routes/LandingPageContent.tsx
+++ b/src/routes/LandingPageContent.tsx
@@ -9,6 +9,7 @@ import { ProjectEntry } from "../types";
 export const landingPageContent: ProjectEntry[] = [
   {
     name: "Segmented hiPSC FOV-nuclei timelapse and analysis datasets",
+    inReview: true,
     description: (
       <p>
         Maximum projections of tracked 3D segmentations of nuclei in growing hiPS cell colonies, with quantitative
@@ -27,8 +28,8 @@ export const landingPageContent: ProjectEntry[] = [
         .
       </p>
     ),
-    publicationLink: new URL("https://www.google.com"),
-    publicationName: "<NucMorph manuscript> (Publisher name, mm/dd/yyyy)",
+    // publicationLink: new URL("https://www.google.com"),
+    // publicationName: "<NucMorph manuscript> (Publisher name, mm/dd/yyyy)",
     datasets: [
       {
         name: "Exploratory dataset",

--- a/src/routes/LandingPageContent.tsx
+++ b/src/routes/LandingPageContent.tsx
@@ -21,7 +21,7 @@ export const landingPageContent: ProjectEntry[] = [
         </a>
         . For documentation on the features available in these datasets, visit{" "}
         <a
-          href="https://open.quiltdata.com/b/allencell/tree/aics/nuc-morph-dataset/"
+          href="https://open.quiltdata.com/b/allencell/tree/aics/nuc-morph-dataset/timelapse_feature_explorer_datasets/"
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -1,16 +1,18 @@
+import { ReactNode } from "react";
+
 import { UrlParams } from "../colorizer/utils/url_utils";
 
 import Collection from "../colorizer/Collection";
 
 export type DatasetEntry = {
   name: string;
-  description: string;
+  description: ReactNode;
   loadParams: Partial<UrlParams>;
 };
 
 export type ProjectEntry = {
   name: string;
-  description: string;
+  description: ReactNode;
   publicationLink?: URL;
   publicationName?: string;
   loadParams?: Partial<UrlParams>;


### PR DESCRIPTION
Problem
=======
Closes #381 ("Home or "splash" page refinement updates needed") and closes #208 ("Update landing page with new dataset URLs + descriptions").

*Estimated review size: 20 minutes (probably faster if you skip through the landing page content)*

Solution
========
- Updates links and text descriptions for the new Nucmorph manuscript datasets.
- Adjusts margins on landing page elements for consistency
- Header on viewer now opens link in new tab

## Type of change
* New feature (non-breaking change which adds functionality)

## Testing
1. Open the preview: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-385/

Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/timelapse-colorizer/assets/30200665/07c72603-b714-4d0b-821d-1ac9a1e01301)
