### PR TITLE
fix: Link hover colors and disabled inputs

### DIFF
--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -321,6 +321,7 @@ export default function AppStyle(props: PropsWithChildren<AppStyleProps>): React
             colorLinkHover: theme.color.text.linkHover,
             colorBorder: theme.color.layout.borders,
             colorBorderSecondary: theme.color.layout.dividers,
+            colorBgContainerDisabled: theme.color.button.backgroundDisabled,
             controlHeight: theme.controls.height,
             colorTextQuaternary: theme.color.text.disabled,
             controlHeightSM: theme.controls.heightSmall,

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -27,6 +27,7 @@ const palette = {
   success: "#2fc022",
   error: "#f92d20",
   link: "#0094FF",
+  linkDark: "#007FD6",
   warning: "#faad14",
   successLight: "#b7eb8f",
   errorLight: "#ffa39e",
@@ -53,6 +54,7 @@ const theme = {
       success: palette.success,
       theme: palette.theme,
       link: palette.link,
+      linkHover: palette.linkDark,
     },
     layout: {
       background: palette.gray0,
@@ -147,7 +149,8 @@ const CssContainer = styled.div`
   --color-text-button: ${theme.color.text.button};
   --color-text-error: ${theme.color.text.error};
   --color-text-success: ${theme.color.text.success};
-  --color-text-theme: ${theme.color.text.theme};
+  --color-text-theme: ${theme.color.theme};
+  --color-text-theme-dark: ${theme.color.themeDark};
   --color-text-link: ${theme.color.text.link};
 
   /* Layout */
@@ -314,8 +317,8 @@ export default function AppStyle(props: PropsWithChildren<AppStyleProps>): React
         theme={{
           token: {
             colorPrimary: theme.color.theme,
-            colorLink: theme.color.theme,
-            colorLinkHover: theme.color.themeDark,
+            colorLink: theme.color.text.link,
+            colorLinkHover: theme.color.text.linkHover,
             colorBorder: theme.color.layout.borders,
             colorBorderSecondary: theme.color.layout.dividers,
             controlHeight: theme.controls.height,

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -322,6 +322,7 @@ export default function AppStyle(props: PropsWithChildren<AppStyleProps>): React
             colorBorder: theme.color.layout.borders,
             colorBorderSecondary: theme.color.layout.dividers,
             controlHeight: theme.controls.height,
+            colorTextQuaternary: theme.color.text.disabled,
             controlHeightSM: theme.controls.heightSmall,
             fontFamily: theme.font.family,
             borderRadiusLG: 6,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -47,6 +47,13 @@ const VerticalDivider = styled.div`
   }
 `;
 
+const HeaderLink = styled(Link)`
+  color: var(--color-text-theme);
+  &:hover {
+    color: var(--color-text-theme-dark);
+  }
+`;
+
 /**
  * The logo and title of the app, to be used with the Header component.
  * Both the logo and app title are links that can be used for navigation.
@@ -61,9 +68,9 @@ function HeaderLogo(): ReactElement {
         </div>
       </AicsLogoLink>
       <VerticalDivider />
-      <Link to="/" aria-label="Go to home page">
+      <HeaderLink to="/" aria-label="Go to home page">
         <h1 style={{ margin: "0" }}>Timelapse Feature Explorer</h1>
-      </Link>
+      </HeaderLink>
     </FlexRowAlignCenter>
   );
 }

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -235,12 +235,7 @@ export default function LandingPage(): ReactElement {
     const publicationElement = project.publicationLink ? (
       <p>
         Related publication:{" "}
-        <a
-          href={project.publicationLink.toString()}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ color: "var(--color-text-link)" }}
-        >
+        <a href={project.publicationLink.toString()} target="_blank" rel="noopener noreferrer">
           {project.publicationName}
           {/* Icon offset slightly to align with text */}
           <FontAwesomeIcon icon={faUpRightFromSquare} size="sm" style={{ marginBottom: "-1px", marginLeft: "3px" }} />


### PR DESCRIPTION
Problem
=======
Closes #380 and closes #354, adjusting colors on disabled inputs and adding a color when links are hovered.

*Estimated review size: tiny, 4 minutes*

Solution
========
- Adjusts Ant theme configuration to use custom disabled background color and text color.
- Adjusts Ant theme configuration to show a hover color for text links; changes default color from purple to blue.

## Type of change
* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
Preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-386/
1. Open the preview link. Hover over the links in the landing page and the header.
2. Open the default dataset and switch to the Viewer settings tab. Disabled dropdowns will be shown.

Before:
![image](https://github.com/allen-cell-animated/timelapse-colorizer/assets/30200665/3fe4da8a-268b-4c09-889d-dc88a7551ce6)

After:
![image](https://github.com/allen-cell-animated/timelapse-colorizer/assets/30200665/4dd2bd1c-8ce4-457a-81a5-61a09c86144f)