### PR TITLE
fix: URL no longer updates while dataset is still unloaded

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -248,10 +248,12 @@ function Viewer(): ReactElement {
     scatterPlotConfig,
   ]);
 
-  // Update url whenever the viewer settings change
-  // (but not while playing/recording for performance reasons)
+  // Update url whenever the viewer settings change, with a few exceptions:
+  // - The URL should not change while playing/recording for performance reasons.
+  // - The URL should not change if the dataset hasn't loaded yet, or if it failed to load.
+  //   that way, users can refresh the page to try again.
   useEffect(() => {
-    if (!timeControls.isPlaying() && !isRecording) {
+    if (!timeControls.isPlaying() && !isRecording && isInitialDatasetLoaded) {
       setSearchParams(getUrlParams(), { replace: true });
     }
   }, [timeControls.isPlaying(), isRecording, getUrlParams]);
@@ -359,14 +361,10 @@ function Viewer(): ReactElement {
    * @returns a Promise<void> that resolves when the loading is complete.
    */
   const replaceDataset = useCallback(
-    async (newDataset: Dataset | null, newDatasetKey: string): Promise<void> => {
+    async (newDataset: Dataset, newDatasetKey: string): Promise<void> => {
       console.trace("Replacing dataset with " + newDatasetKey + ".");
       // TODO: Change the way flags are handled to prevent flickering during dataset replacement
       setDatasetOpen(false);
-      if (newDataset === null) {
-        // TODO: Determine with UX what expected behavior should be for bad datasets
-        return;
-      }
 
       // Dispose of the old dataset
       if (dataset !== null) {
@@ -524,11 +522,9 @@ function Viewer(): ReactElement {
         });
         return;
       }
-
       // Add the collection to the recent collections list
       addRecentCollection({ url: newCollection.getUrl() });
 
-      // TODO: The new dataset may be null if loading failed. See TODO in replaceDataset about expected behavior.
       if (!isInitialDatasetLoaded) {
         await replaceDataset(datasetResult.dataset, datasetKey);
         setIsInitialDatasetLoaded(true);


### PR DESCRIPTION
Problem
=======
Closes #387, "URL changes when dataset fails to load and breaks refresh".

Solution
========
- Prevents URL from updating while dataset is unloaded or fails to load.
- Also removes old TODOs.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open the preview link:
2. 

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
3. other important file

Thanks for contributing!
