### PR TITLE
feature: Loading spinner for datasets

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -96,6 +96,7 @@ function Viewer(): ReactElement {
   );
 
   const [isInitialDatasetLoaded, setIsInitialDatasetLoaded] = useState(false);
+  const [isDatasetLoading, setIsDatasetLoading] = useState(false);
   const [datasetOpen, setDatasetOpen] = useState(false);
 
   const colorRampData = KNOWN_COLOR_RAMPS;
@@ -451,6 +452,7 @@ function Viewer(): ReactElement {
       if (isLoadingInitialDataset.current || isInitialDatasetLoaded) {
         return;
       }
+      setIsDatasetLoading(true);
       isLoadingInitialDataset.current = true;
       let newCollection: Collection;
       let datasetKey: string;
@@ -522,6 +524,7 @@ function Viewer(): ReactElement {
           placement: "bottomLeft",
           duration: 4,
         });
+        setIsDatasetLoading(false);
         return;
       }
 
@@ -532,6 +535,7 @@ function Viewer(): ReactElement {
       if (!isInitialDatasetLoaded) {
         await replaceDataset(datasetResult.dataset, datasetKey);
         setIsInitialDatasetLoaded(true);
+        setIsDatasetLoading(false);
       }
       return;
     };
@@ -611,6 +615,7 @@ function Viewer(): ReactElement {
   const handleDatasetChange = useCallback(
     async (newDatasetKey: string): Promise<void> => {
       if (newDatasetKey !== datasetKey && collection) {
+        setIsDatasetLoading(true);
         const result = await collection.tryLoadDataset(newDatasetKey);
         if (result.loaded) {
           await replaceDataset(result.dataset, newDatasetKey);
@@ -624,6 +629,7 @@ function Viewer(): ReactElement {
             duration: 4,
           });
         }
+        setIsDatasetLoading(false);
       }
     },
     [replaceDataset, collection, datasetKey]
@@ -910,6 +916,7 @@ function Viewer(): ReactElement {
                 disabled={!showHoveredId}
               >
                 <CanvasWrapper
+                  loading={isDatasetLoading}
                   canv={canv}
                   collection={collection || null}
                   dataset={dataset}

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -490,6 +490,7 @@ function Viewer(): ReactElement {
               action: <Link to="/">Return to homepage</Link>,
             });
             console.error("No collection URL or dataset URL provided.");
+            setIsDatasetLoading(false);
             return;
           }
           // Try loading the collection, with the default collection as a fallback.
@@ -508,6 +509,7 @@ function Viewer(): ReactElement {
               ],
               action: <Link to="/">Return to homepage</Link>,
             });
+            setIsDatasetLoading(false);
             return;
           }
         }
@@ -535,8 +537,8 @@ function Viewer(): ReactElement {
       if (!isInitialDatasetLoaded) {
         await replaceDataset(datasetResult.dataset, datasetKey);
         setIsInitialDatasetLoaded(true);
-        setIsDatasetLoading(false);
       }
+      setIsDatasetLoading(false);
       return;
     };
     loadInitialDataset();

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -15,6 +15,7 @@ import Collection from "../colorizer/Collection";
 import { AppThemeContext } from "./AppStyle";
 import { AlertBannerProps } from "./Banner";
 import IconButton from "./IconButton";
+import LoadingSpinner from "./LoadingSpinner";
 
 const ASPECT_RATIO = 14.6 / 10;
 /* Minimum distance in either X or Y that mouse should move
@@ -79,6 +80,7 @@ type CanvasWrapperProps = {
   /** Pan and zoom will be reset on collection change. */
   collection: Collection | null;
   config: ViewerConfig;
+  loading: boolean;
 
   selectedBackdropKey: string | null;
 
@@ -551,14 +553,16 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       }}
       ref={containerRef}
     >
-      <div ref={canvasRef}></div>
+      <LoadingSpinner loading={props.loading} loadingText="This may take a few seconds.">
+        <div ref={canvasRef}></div>
+      </LoadingSpinner>
       <MissingFileIconContainer style={{ visibility: showMissingFileIcon ? "visible" : "hidden" }}>
         <NoImageSVG aria-labelledby="no-image" style={{ width: "50px" }} />
         <p id="no-image">
           <b>Missing image data</b>
         </p>
       </MissingFileIconContainer>
-      <CanvasControlsContainer $gap={4}>
+      <CanvasControlsContainer $gap={4} style={{ zIndex: 101 }}>
         <Tooltip title={"Reset view"} placement="right" trigger={["hover", "focus"]}>
           <IconButton
             onClick={() => {

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -553,7 +553,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       }}
       ref={containerRef}
     >
-      <LoadingSpinner loading={props.loading} loadingText="This may take a few seconds.">
+      <LoadingSpinner loading={props.loading}>
         <div ref={canvasRef}></div>
       </LoadingSpinner>
       <MissingFileIconContainer style={{ visibility: showMissingFileIcon ? "visible" : "hidden" }}>

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -3,9 +3,12 @@ import { Spin } from "antd";
 import React, { PropsWithChildren, ReactElement } from "react";
 import styled, { css } from "styled-components";
 
+import { FlexColumnAlignCenter } from "../styles/utils";
+
 type LoadingSpinnerProps = {
   loading: boolean;
   iconSize?: number;
+  loadingText?: string;
   style?: React.CSSProperties;
 };
 
@@ -18,6 +21,12 @@ const LoadingSpinnerContainer = styled.div`
   position: relative;
   width: 100%;
   height: 100%;
+
+  h4 {
+    font-style: normal;
+    font-weight: 400;
+    /* color: var(--color-text-theme-dark); */
+  }
 `;
 
 const LoadingSpinnerOverlay = styled.div<{ $loading: boolean }>`
@@ -51,7 +60,10 @@ export default function LoadingSpinner(inputProps: PropsWithChildren<LoadingSpin
   return (
     <LoadingSpinnerContainer style={props.style}>
       <LoadingSpinnerOverlay $loading={props.loading}>
-        <Spin indicator={<LoadingOutlined style={{ fontSize: props.iconSize }} spin />}></Spin>
+        <FlexColumnAlignCenter $gap={10}>
+          <Spin indicator={<LoadingOutlined style={{ fontSize: props.iconSize }} spin />}></Spin>
+          {props.loadingText && <h4>{props.loadingText}</h4>}
+        </FlexColumnAlignCenter>
       </LoadingSpinnerOverlay>
       {props.children}
     </LoadingSpinnerContainer>

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -3,17 +3,14 @@ import { Spin } from "antd";
 import React, { PropsWithChildren, ReactElement } from "react";
 import styled, { css } from "styled-components";
 
-import { FlexColumnAlignCenter } from "../styles/utils";
-
 type LoadingSpinnerProps = {
   loading: boolean;
   iconSize?: number;
-  loadingText?: string;
   style?: React.CSSProperties;
 };
 
 const defaultProps: Partial<LoadingSpinnerProps> = {
-  iconSize: 48,
+  iconSize: 72,
   style: {},
 };
 
@@ -21,12 +18,6 @@ const LoadingSpinnerContainer = styled.div`
   position: relative;
   width: 100%;
   height: 100%;
-
-  h4 {
-    font-style: normal;
-    font-weight: 400;
-    /* color: var(--color-text-theme-dark); */
-  }
 `;
 
 const LoadingSpinnerOverlay = styled.div<{ $loading: boolean }>`
@@ -37,7 +28,7 @@ const LoadingSpinnerOverlay = styled.div<{ $loading: boolean }>`
   height: 100%;
   z-index: 100;
   pointer-events: none;
-  background-color: #00000040;
+  background-color: #ffffff90;
   transition: opacity 0.2s ease-in-out 0.2s;
 
   ${(props) => {
@@ -52,6 +43,23 @@ const LoadingSpinnerOverlay = styled.div<{ $loading: boolean }>`
   align-items: center;
 `;
 
+const LoadSpinnerIconContainer = styled.div<{ $fontSize: number }>`
+  position: relative;
+
+  ${(props) => {
+    return css`
+      & > * {
+        position: absolute;
+        font-size: ${props.$fontSize}px;
+        color: var(--color-text-hint);
+        top: calc(50% - ${props.$fontSize / 2}px);
+        left: calc(50% - ${props.$fontSize / 2}px);
+      }
+    `;
+  }}
+`;
+
+// TODO: This component is redundant with the built-in Ant Design Spin component. Remove it?
 /**
  * Applies a loading spinner overlay on the provided children, which can be toggled on and off via props.
  */
@@ -60,10 +68,15 @@ export default function LoadingSpinner(inputProps: PropsWithChildren<LoadingSpin
   return (
     <LoadingSpinnerContainer style={props.style}>
       <LoadingSpinnerOverlay $loading={props.loading}>
-        <FlexColumnAlignCenter $gap={10}>
-          <Spin indicator={<LoadingOutlined style={{ fontSize: props.iconSize }} spin />}></Spin>
-          {props.loadingText && <h4>{props.loadingText}</h4>}
-        </FlexColumnAlignCenter>
+        <Spin
+          indicator={
+            <LoadSpinnerIconContainer $fontSize={props.iconSize}>
+              {/* Make larger loading icon by merging two of them together */}
+              <LoadingOutlined />
+              <LoadingOutlined rotate={90} />
+            </LoadSpinnerIconContainer>
+          }
+        ></Spin>
       </LoadingSpinnerOverlay>
       {props.children}
     </LoadingSpinnerContainer>

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -59,7 +59,6 @@ const LoadSpinnerIconContainer = styled.div<{ $fontSize: number }>`
   }}
 `;
 
-// TODO: This component is redundant with the built-in Ant Design Spin component. Remove it?
 /**
  * Applies a loading spinner overlay on the provided children, which can be toggled on and off via props.
  */
@@ -71,9 +70,11 @@ export default function LoadingSpinner(inputProps: PropsWithChildren<LoadingSpin
         <Spin
           indicator={
             <LoadSpinnerIconContainer $fontSize={props.iconSize}>
-              {/* Make larger loading icon by merging two of them together */}
+              {/* Make larger loading icon by multiple of them together */}
+              {/* TODO: Make custom loading spinner SVG? */}
               <LoadingOutlined />
               <LoadingOutlined rotate={90} />
+              <LoadingOutlined rotate={135} />
             </LoadSpinnerIconContainer>
           }
         ></Spin>

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -158,12 +158,10 @@ const DatasetCard = styled.li`
   margin-top: 10px;
 
   & > h3 {
-    text-align: left;
     display: grid;
     margin: 0;
   }
   & > p {
-    text-align: left;
     display: grid;
   }
   & > a {

--- a/src/routes/LandingPageContent.tsx
+++ b/src/routes/LandingPageContent.tsx
@@ -35,6 +35,36 @@ export const landingPageContent: ProjectEntry[] = [
     // publicationName: "<NucMorph manuscript> (Publisher name, mm/dd/yyyy)",
     datasets: [
       {
+        name: "Baseline colonies dataset",
+        description:
+          "Minimally filtered tracked nuclei with quantitative single-timepoint features (subset of exploratory analysis dataset)",
+        loadParams: {
+          collection:
+            "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/timelapse_feature_explorer_datasets/baseline_colonies_dataset/collection.json",
+          time: 15,
+        },
+      },
+      {
+        name: "Full-interphase dataset",
+        description:
+          "Nuclei tracked throughout interphase (subset of baseline colonies analysis dataset, with added growth trajectory features)",
+        loadParams: {
+          collection:
+            "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/timelapse_feature_explorer_datasets/full-interphase_dataset/collection.json",
+          time: 15,
+        },
+      },
+      {
+        name: "Lineage-annotated dataset",
+        description:
+          "Nuclei tracked across multiple generations (subset of full-interphase analysis dataset, with added lineage annotation)",
+        loadParams: {
+          collection:
+            "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/timelapse_feature_explorer_datasets/lineage-annotated_dataset/collection.json",
+          time: 15,
+        },
+      },
+      {
         name: "Exploratory dataset",
         description: "All successful tracked nuclei, with all available features and filters",
         loadParams: {
@@ -67,36 +97,6 @@ export const landingPageContent: ProjectEntry[] = [
               enabledCategories: [true, true],
             },
           ],
-        },
-      },
-      {
-        name: "Baseline colonies dataset",
-        description:
-          "Minimally filtered tracked nuclei with quantitative single-timepoint features (subset of exploratory analysis dataset)",
-        loadParams: {
-          collection:
-            "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/timelapse_feature_explorer_datasets/baseline_colonies_dataset/collection.json",
-          time: 15,
-        },
-      },
-      {
-        name: "Full-interphase dataset",
-        description:
-          "Nuclei tracked throughout interphase (subset of baseline colonies analysis dataset, with added growth trajectory features)",
-        loadParams: {
-          collection:
-            "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/timelapse_feature_explorer_datasets/full-interphase_dataset/collection.json",
-          time: 15,
-        },
-      },
-      {
-        name: "Lineage-annotated dataset",
-        description:
-          "Nuclei tracked across multiple generations (subset of full-interphase analysis dataset, with added lineage annotation)",
-        loadParams: {
-          collection:
-            "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/timelapse_feature_explorer_datasets/lineage-annotated_dataset/collection.json",
-          time: 15,
         },
       },
     ],


### PR DESCRIPTION
Problem
=======
The nucmorph datasets are loading noticeably slowly (10-15 seconds), so this is a stopgap measure until async feature loading (see #395) can be merged.

*Estimated review size: small, 5-10 minutes*

Solution
========
- Adds a loading spinner to the main view when datasets are being loaded or switched between.
- Fixes some styling on the loading spinner based on feedback from UX.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the PR preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-396/
2. Click on the "Exploratory" dataset, which is the largest and slowest to load. You should see the loading spinner appear.
3. The loading spinner will disappear once the dataset loads.
4. Try switching to a different dataset.

Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/timelapse-colorizer/assets/30200665/6935322f-97db-439d-91dc-8ee4e32c0bc9)

![image](https://github.com/allen-cell-animated/timelapse-colorizer/assets/30200665/98616529-d259-43b6-b528-ab3653fa8fb5)

