### PR TITLE
fix: Fixed bug where integer Parquet feature data could not be parsed

### DIFF
--- a/src/colorizer/loaders/UrlArrayLoader.ts
+++ b/src/colorizer/loaders/UrlArrayLoader.ts
@@ -86,13 +86,15 @@ export default class UrlArrayLoader implements IArrayLoader {
       await parquetRead({
         file: arrayBuffer,
         compressors,
+        columns: ["data"],
         onComplete: (loadedData: number[][]) => {
-          for (const row of loadedData) {
-            dataMin = dataMin === undefined ? row[0] : Math.min(dataMin, row[0]);
-            dataMax = dataMax === undefined ? row[0] : Math.max(dataMax, row[0]);
-            data.push(row[0]);
+          data = Array(loadedData.length);
+          for (let i = 0; i < loadedData.length; i++) {
+            const value = Number(loadedData[i][0]);
+            dataMin = dataMin === undefined ? value : Math.min(dataMin, value);
+            dataMax = dataMax === undefined ? value : Math.max(dataMax, value);
+            data[i] = value;
           }
-          data = loadedData.map((row) => Number(row[0]));
         },
       });
       return new UrlArraySource(data, min ?? dataMin, max ?? dataMax);


### PR DESCRIPTION
Problem
=======
Fixes a bug where certain features could not be loaded from the Exploratory NucMorph dataset because of a missing cast to `Number`. 

Error Message:
```
TypeError: Cannot convert a BigInt value to a number
    at Math.min (<anonymous>)
```

*Estimated review size: tiny, 3 minutes*

Solution
========

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open the main build. You should see a warning message about failed feature loads: https://timelapse.allencell.org/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Ftest%2Fparquet%2Fcollection.json&dataset=Medium+Parquet
1. Open the preview link. The warning message should not appear: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-415/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Ftest%2Fparquet%2Fcollection.json&dataset=Medium+Parquet
