### PR TITLE
feature: Add and style cookie banner

### DIFF
--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -374,6 +374,7 @@ export default function AppStyle(props: PropsWithChildren<AppStyleProps>): React
               zIndexPopup: 2000,
             },
             Divider: {
+              colorSplit: theme.color.layout.dividers,
               marginLG: 0,
             },
             Modal: {

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -244,6 +244,10 @@ const CssContainer = styled.div`
     color: ${theme.color.button.outline};
   }
 
+  .ant-btn-text:hover > span {
+    text-decoration: underline;
+  }
+
   font-family: var(--default-font);
   font-style: normal;
   font-weight: 400;

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -244,10 +244,6 @@ const CssContainer = styled.div`
     color: ${theme.color.button.outline};
   }
 
-  .ant-btn-text:hover > span {
-    text-decoration: underline;
-  }
-
   font-family: var(--default-font);
   font-style: normal;
   font-weight: 400;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,8 @@ import { decodeGitHubPagesUrl, isEncodedPathUrl, tryRemoveHashRouting } from "./
 import AppStyle from "./components/AppStyle";
 import Viewer from "./Viewer";
 
+import "./styles/cookie-banner.css";
+
 // Decode URL path if it was encoded for GitHub pages or uses hash routing.
 const locationUrl = new URL(window.location.toString());
 if (locationUrl.hash !== "" || isEncodedPathUrl(locationUrl)) {

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -1,7 +1,7 @@
 import { faUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Button, Tooltip } from "antd";
-import React, { lazy, ReactElement, Suspense } from "react";
+import { Button, Divider, Tooltip } from "antd";
+import React, { lazy, ReactElement, Suspense, useContext } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
@@ -12,6 +12,7 @@ import { DatasetEntry, LocationState, ProjectEntry } from "../types";
 import { PageRoutes } from "./index";
 
 import Collection from "../colorizer/Collection";
+import { AppThemeContext } from "../components/AppStyle";
 import HelpDropdown from "../components/Dropdowns/HelpDropdown";
 import Header from "../components/Header";
 import LoadDatasetButton from "../components/LoadDatasetButton";
@@ -195,6 +196,7 @@ const InReviewFlag = styled(FlexRowAlignCenter)`
 
 export default function LandingPage(): ReactElement {
   const navigate = useNavigate();
+  const theme = useContext(AppThemeContext);
 
   // Behavior
 
@@ -336,9 +338,12 @@ export default function LandingPage(): ReactElement {
         <ProjectList>{landingPageContent.map(renderProject)}</ProjectList>
       </ContentContainer>
 
-      <ContentContainer style={{ marginBottom: "20px" }}>
-        <FlexColumnAlignCenter>
-          <Button className="ot-sdk-show-settings">Cookie Settings</Button>
+      <ContentContainer style={{ padding: "0 30px 40px 30px" }}>
+        <Divider />
+        <FlexColumnAlignCenter style={{ paddingTop: "40px" }}>
+          <Button type="text" style={{ color: theme.color.text.secondary }} className="ot-sdk-show-settings">
+            Cookie settings
+          </Button>
         </FlexColumnAlignCenter>
       </ContentContainer>
     </>

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -1,7 +1,7 @@
 import { faUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Button, Divider, Tooltip } from "antd";
-import React, { lazy, ReactElement, Suspense, useContext } from "react";
+import React, { lazy, ReactElement, Suspense } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
@@ -12,7 +12,6 @@ import { DatasetEntry, LocationState, ProjectEntry } from "../types";
 import { PageRoutes } from "./index";
 
 import Collection from "../colorizer/Collection";
-import { AppThemeContext } from "../components/AppStyle";
 import HelpDropdown from "../components/Dropdowns/HelpDropdown";
 import Header from "../components/Header";
 import LoadDatasetButton from "../components/LoadDatasetButton";
@@ -194,9 +193,15 @@ const InReviewFlag = styled(FlexRowAlignCenter)`
   }
 `;
 
+const CookieSettingsButton = styled(Button)`
+  color: var(--color-text-secondary);
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
 export default function LandingPage(): ReactElement {
   const navigate = useNavigate();
-  const theme = useContext(AppThemeContext);
 
   // Behavior
 
@@ -341,9 +346,9 @@ export default function LandingPage(): ReactElement {
       <ContentContainer style={{ padding: "0 30px 40px 30px" }}>
         <Divider />
         <FlexColumnAlignCenter style={{ paddingTop: "40px" }}>
-          <Button type="text" style={{ color: theme.color.text.secondary }} className="ot-sdk-show-settings">
+          <CookieSettingsButton type="text" className="ot-sdk-show-settings">
             Cookie settings
-          </Button>
+          </CookieSettingsButton>
         </FlexColumnAlignCenter>
       </ContentContainer>
     </>

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -335,6 +335,12 @@ export default function LandingPage(): ReactElement {
       <ContentContainer style={{ paddingBottom: "400px" }}>
         <ProjectList>{landingPageContent.map(renderProject)}</ProjectList>
       </ContentContainer>
+
+      <ContentContainer style={{ marginBottom: "20px" }}>
+        <FlexColumnAlignCenter>
+          <Button className="ot-sdk-show-settings">Cookie Settings</Button>
+        </FlexColumnAlignCenter>
+      </ContentContainer>
     </>
   );
 }

--- a/src/styles/cookie-banner.css
+++ b/src/styles/cookie-banner.css
@@ -3,6 +3,14 @@
 
   #onetrust-banner-sdk {
     height: fit-content !important;
+    box-shadow: 0 2px 6px 2px rgba(0, 0, 0, 0.3) !important;
+    border-radius: 5px;
+    /* Fixes visual bug where shadows would be misaligned */
+    background-color: #e7e2f7;
+
+    .ot-sdk-container {
+      box-shadow: none;
+    }
   }
 
   .ot-sdk-container {
@@ -15,6 +23,7 @@
   h4,
   p,
   #onetrust-policy-text {
+    /** Darken font color for contrast accessibility */
     color: #323233 !important;
   }
 

--- a/src/styles/cookie-banner.css
+++ b/src/styles/cookie-banner.css
@@ -1,0 +1,10 @@
+#onetrust-consent-sdk {
+  font-family: Lato, LatoExtended, sans-serif;
+
+  .ot-sdk-container {
+  }
+
+  #onetrust-policy-text {
+    color: #323233;
+  }
+}

--- a/src/styles/cookie-banner.css
+++ b/src/styles/cookie-banner.css
@@ -1,10 +1,34 @@
 #onetrust-consent-sdk {
   font-family: Lato, LatoExtended, sans-serif;
 
-  .ot-sdk-container {
+  #onetrust-banner-sdk {
+    height: fit-content !important;
   }
 
+  .ot-sdk-container {
+    height: 100% !important;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  p,
   #onetrust-policy-text {
-    color: #323233;
+    color: #323233 !important;
+  }
+
+  #ot-pc-title {
+    margin-top: 20px;
+  }
+
+  #onetrust-accept-btn-handler,
+  .save-preference-btn-handler {
+    border-radius: 6px;
+  }
+
+  #onetrust-pc-btn-handler {
+    font-weight: 400 !important;
+    padding: 12px 10px !important;
   }
 }


### PR DESCRIPTION
Problem
=======
Closes #338, adding the HTML snippets + styling overrides for the cookie consent button and banner.

*Estimated review size: small, 5 minutes*

Solution
========
- Adds CSS styling rules to the root `main.tsx`.
- Overrides the default font style and colors to improve contrast.
- Adds an HTML snippet for the cookie settings button to the project root.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-418/
2. Open the main build. You should see the incorrect font in the cookie popup. https://timelapse.allencell.org

Screenshots (optional):
-----------------------
![image](https://github.com/user-attachments/assets/a9f8aa37-55f5-4ccb-849f-5cdf3c2fa1d4)

