### PR TITLE
feature: Use multithreading when loading feature data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Timelapse Feature Explorer 🔬🎨
 
-#### A web-based, time-series visualizer for tracked segmented data.
+#### A web-based, time-series visualizer for tracked segmented data
 
 ## Description
 
@@ -50,11 +50,11 @@ npm run dev
 
 This will start a development server you can access from your browser. By default, the server will be hosted at `http://localhost:5173/`.
 
-### Data preprocessing
+### Uploading datasets
 
 Data must be preprocessed to work with Timelapse Feature Explorer. We provide a Python package and example scripts in the [`colorizer-data` GitHub repository](https://github.com/allen-cell-animated/colorizer-data).
 
- [You can read more about the data format specification here.](https://github.com/allen-cell-animated/colorizer-data/blob/main/documentation/DATA_FORMAT.md)
+ You can read more about the [data format specification](https://github.com/allen-cell-animated/colorizer-data/blob/main/documentation/DATA_FORMAT.md) or follow our [data preprocessing tutorial](https://github.com/allen-cell-animated/colorizer-data/blob/main/documentation/getting_started_guide/GETTING_STARTED.ipynb) for more details on how to load your own datasets.
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "react-router-dom": "^6.22.2",
         "styled-components": "^6.0.8",
         "three": "^0.151.3",
-        "usehooks-ts": "^2.9.1"
+        "usehooks-ts": "^2.9.1",
+        "workerpool": "^9.1.3"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.3",
@@ -12685,6 +12686,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/workerpool": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.1.3.tgz",
+      "integrity": "sha512-LhUrk4tbxJRDQmRrrFWA9EnboXI79fe0ZNTy3u8m+dqPN1EkVSIsQYAB8OF/fkyhG8Rtup+c/bzj/+bzbG8fqg=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-router-dom": "^6.22.2",
     "styled-components": "^6.0.8",
     "three": "^0.151.3",
-    "usehooks-ts": "^2.9.1"
+    "usehooks-ts": "^2.9.1",
+    "workerpool": "^9.1.3"
   }
 }

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -40,6 +40,7 @@ import { LocationState } from "./types";
 import Collection from "./colorizer/Collection";
 import { BACKGROUND_ID } from "./colorizer/ColorizeCanvas";
 import { FeatureType } from "./colorizer/Dataset";
+import UrlArrayLoader from "./colorizer/loaders/UrlArrayLoader";
 import TimeControls from "./colorizer/TimeControls";
 import { AppThemeContext } from "./components/AppStyle";
 import { useAlertBanner } from "./components/Banner";
@@ -80,6 +81,8 @@ function Viewer(): ReactElement {
   const [dataset, setDataset] = useState<Dataset | null>(null);
   const [datasetKey, setDatasetKey] = useState("");
   const [, addRecentCollection] = useRecentCollections();
+  // Shared array loader to manage worker pool
+  const arrayLoader = useConstructor(() => new UrlArrayLoader());
 
   const [featureKey, setFeatureKey] = useState("");
   const [selectedTrack, setSelectedTrack] = useState<Track | null>(null);
@@ -526,7 +529,7 @@ function Viewer(): ReactElement {
 
       setCollection(newCollection);
       setDatasetLoadProgress(null);
-      const datasetResult = await newCollection.tryLoadDataset(datasetKey, handleProgressUpdate);
+      const datasetResult = await newCollection.tryLoadDataset(datasetKey, handleProgressUpdate, arrayLoader);
 
       if (!datasetResult.loaded) {
         console.error(datasetResult.errorMessage);
@@ -627,7 +630,7 @@ function Viewer(): ReactElement {
       if (newDatasetKey !== datasetKey && collection) {
         setIsDatasetLoading(true);
         setDatasetLoadProgress(null);
-        const result = await collection.tryLoadDataset(newDatasetKey, handleProgressUpdate);
+        const result = await collection.tryLoadDataset(newDatasetKey, handleProgressUpdate, arrayLoader);
         if (result.loaded) {
           await replaceDataset(result.dataset, newDatasetKey);
         } else {

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -10,7 +10,6 @@ import { DEFAULT_FETCH_TIMEOUT_MS, fetchWithTimeout, formatPath, isJson, isUrl }
 
 import Dataset from "./Dataset";
 import { IArrayLoader } from "./loaders/ILoader";
-import UrlArrayLoader from "./loaders/UrlArrayLoader";
 
 export type CollectionData = Map<string, CollectionEntry>;
 
@@ -31,7 +30,6 @@ export type DatasetLoadResult =
  * information and paths.
  */
 export default class Collection {
-  private arrayLoader: IArrayLoader;
   private entries: CollectionData;
   public metadata: Partial<CollectionFileMetadata>;
   /**
@@ -51,7 +49,6 @@ export default class Collection {
     this.entries = entries;
     this.url = url ? Collection.formatAbsoluteCollectionPath(url) : url;
     this.metadata = metadata;
-    this.arrayLoader = new UrlArrayLoader();
     console.log("Collection metadata: ", this.metadata);
 
     // Check that all entry paths are JSON urls.
@@ -130,7 +127,8 @@ export default class Collection {
    */
   public async tryLoadDataset(
     datasetKey: string,
-    onLoadProgress?: (complete: number, total: number) => void
+    onLoadProgress?: (complete: number, total: number) => void,
+    arrayLoader?: IArrayLoader
   ): Promise<DatasetLoadResult> {
     console.time("loadDataset");
 
@@ -152,7 +150,7 @@ export default class Collection {
 
     // TODO: Override fetch method
     try {
-      const dataset = new Dataset(path, undefined, this.arrayLoader);
+      const dataset = new Dataset(path, undefined, arrayLoader);
       await dataset.open({ onLoadStart, onLoadComplete });
       console.timeEnd("loadDataset");
       return { loaded: true, dataset: dataset };

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -118,6 +118,8 @@ export default class Collection {
   /**
    * Attempts to load and return the dataset specified by the key.
    * @param datasetKey string key of the dataset.
+   * @param onLoadProgress optional callback for loading progress.
+   * @param arrayLoader optional array loader to use for loading the dataset.
    * @returns A promise of a `DatasetLoadResult`.
    * - On a success, returns an object with a Dataset `dataset` and the `loaded` flag set to true.
    * - On a failure, returns an object with a null `dataset` and `loaded` set to false, as well as

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -9,6 +9,8 @@ import {
 import { DEFAULT_FETCH_TIMEOUT_MS, fetchWithTimeout, formatPath, isJson, isUrl } from "./utils/url_utils";
 
 import Dataset from "./Dataset";
+import { IArrayLoader } from "./loaders/ILoader";
+import UrlArrayLoader from "./loaders/UrlArrayLoader";
 
 export type CollectionData = Map<string, CollectionEntry>;
 
@@ -29,6 +31,7 @@ export type DatasetLoadResult =
  * information and paths.
  */
 export default class Collection {
+  private arrayLoader: IArrayLoader;
   private entries: CollectionData;
   public metadata: Partial<CollectionFileMetadata>;
   /**
@@ -48,6 +51,7 @@ export default class Collection {
     this.entries = entries;
     this.url = url ? Collection.formatAbsoluteCollectionPath(url) : url;
     this.metadata = metadata;
+    this.arrayLoader = new UrlArrayLoader();
     console.log("Collection metadata: ", this.metadata);
 
     // Check that all entry paths are JSON urls.
@@ -148,7 +152,7 @@ export default class Collection {
 
     // TODO: Override fetch method
     try {
-      const dataset = new Dataset(path);
+      const dataset = new Dataset(path, undefined, this.arrayLoader);
       await dataset.open({ onLoadStart, onLoadComplete });
       console.timeEnd("loadDataset");
       return { loaded: true, dataset: dataset };

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -130,7 +130,12 @@ export default class Dataset {
     const url = this.resolveUrl(metadata.data);
     const featureType = this.parseFeatureType(metadata.type);
 
-    const source = await this.arrayLoader.load(url, FeatureDataType.F32);
+    const source = await this.arrayLoader.load(
+      url,
+      FeatureDataType.F32,
+      metadata.min ?? undefined,
+      metadata.max ?? undefined
+    );
 
     const featureCategories = metadata?.categories;
     // Validation

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -8,7 +8,7 @@ import { ManifestFile, ManifestFileMetadata, updateManifestVersion } from "./uti
 import * as urlUtils from "./utils/url_utils";
 
 import DataCache from "./DataCache";
-import { IArrayLoader, IFrameLoader } from "./loaders/ILoader";
+import { IArrayLoader, ITextureImageLoader } from "./loaders/ILoader";
 import ImageFrameLoader from "./loaders/ImageFrameLoader";
 import UrlArrayLoader from "./loaders/UrlArrayLoader";
 import Track from "./Track";
@@ -49,12 +49,12 @@ const defaultMetadata: ManifestFileMetadata = {
 const MAX_CACHED_FRAME_BYTES = 1_000_000_000; // 1 GB
 
 export default class Dataset {
-  private frameLoader: IFrameLoader;
+  private frameLoader: ITextureImageLoader;
   private frameFiles: string[];
   private frames: DataCache<number, Texture> | null;
   private frameDimensions: Vector2 | null;
 
-  private backdropLoader: IFrameLoader;
+  private backdropLoader: ITextureImageLoader;
   private backdropData: Map<string, BackdropData>;
   // TODO: Implement caching for overlays-- extend FrameCache to allow multiple frames per index -> string name?
   // private backdrops: Map<string, FrameCache | null>;
@@ -91,7 +91,7 @@ export default class Dataset {
    * @param frameLoader Optional.
    * @param arrayLoader Optional.
    */
-  constructor(manifestUrl: string, frameLoader?: IFrameLoader, arrayLoader?: IArrayLoader) {
+  constructor(manifestUrl: string, frameLoader?: ITextureImageLoader, arrayLoader?: IArrayLoader) {
     this.manifestUrl = manifestUrl;
 
     this.baseUrl = urlUtils.formatPath(manifestUrl.substring(0, manifestUrl.lastIndexOf("/")));

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -130,7 +130,7 @@ export default class Dataset {
     const url = this.resolveUrl(metadata.data);
     const featureType = this.parseFeatureType(metadata.type);
 
-    const source = await this.arrayLoader.load(url);
+    const source = await this.arrayLoader.load(url, FeatureDataType.F32);
 
     const featureCategories = metadata?.categories;
     // Validation
@@ -148,8 +148,8 @@ export default class Dataset {
       {
         name,
         key,
-        tex: source.getTexture(FeatureDataType.F32),
-        data: source.getBuffer(FeatureDataType.F32),
+        tex: source.getTexture(),
+        data: source.getBuffer(),
         min: source.getMin(),
         max: source.getMax(),
         unit: metadata?.unit || "",
@@ -269,8 +269,8 @@ export default class Dataset {
     }
     try {
       const url = this.resolveUrl(fileUrl);
-      const source = await this.arrayLoader.load(url);
-      return source.getBuffer(dataType);
+      const source = await this.arrayLoader.load(url, dataType);
+      return source.getBuffer();
     } catch (e) {
       return null;
     }

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -60,6 +60,7 @@ export default class Dataset {
   // private backdrops: Map<string, FrameCache | null>;
 
   private arrayLoader: IArrayLoader;
+  private cleanupArrayLoaderOnDispose: boolean;
   // Use map to enforce ordering
   /** Ordered map from feature keys to feature data. */
   private features: Map<string, FeatureData>;
@@ -104,6 +105,7 @@ export default class Dataset {
     this.backdropLoader = frameLoader || new ImageFrameLoader(RGBAFormat);
     this.backdropData = new Map();
 
+    this.cleanupArrayLoaderOnDispose = !arrayLoader;
     this.arrayLoader = arrayLoader || new UrlArrayLoader();
     this.features = new Map();
     this.metadata = defaultMetadata;
@@ -479,6 +481,10 @@ export default class Dataset {
   public dispose(): void {
     Object.values(this.features).forEach(({ tex }) => tex.dispose());
     this.frames?.dispose();
+    // Cleanup array loader if it was created in the constructor
+    if (this.cleanupArrayLoaderOnDispose) {
+      this.arrayLoader.dispose();
+    }
   }
 
   /** get frame index of a given cell id */

--- a/src/colorizer/index.ts
+++ b/src/colorizer/index.ts
@@ -6,7 +6,7 @@ import UrlArrayLoader from "./loaders/UrlArrayLoader";
 import Plotting from "./Plotting";
 import Track from "./Track";
 
-export type { ArraySource, IArrayLoader, IFrameLoader } from "./loaders/ILoader";
+export type { ArraySource, IArrayLoader, ITextureImageLoader } from "./loaders/ILoader";
 
 export {
   ColorizeCanvas,

--- a/src/colorizer/loaders/ILoader.ts
+++ b/src/colorizer/loaders/ILoader.ts
@@ -18,5 +18,5 @@ export interface IFrameLoader {
 }
 
 export interface IArrayLoader {
-  load<T extends FeatureDataType>(url: string, type: T): Promise<ArraySource<T>>;
+  load<T extends FeatureDataType>(url: string, type: T, min?: number, max?: number): Promise<ArraySource<T>>;
 }

--- a/src/colorizer/loaders/ILoader.ts
+++ b/src/colorizer/loaders/ILoader.ts
@@ -2,21 +2,21 @@ import { Texture } from "three";
 
 import { FeatureArrayType, FeatureDataType } from "../types";
 
-export interface ArraySource {
+export interface ArraySource<T extends FeatureDataType> {
   /** Create a `TypedArray` of the specified type from this data source */
-  getBuffer<T extends FeatureDataType>(type: T): FeatureArrayType[T];
+  getBuffer(): FeatureArrayType[T];
   /** Create a square texture of the specified type from this data source */
-  getTexture(type: FeatureDataType): Texture;
+  getTexture(): Texture;
   /** Get the minimum value of the contained data */
   getMin(): number;
   /** Get the maximum value of the contained data */
   getMax(): number;
 }
 
-interface ILoader<DataType> {
-  /** Begin loading data */
-  load(url: string): Promise<DataType>;
+export interface IFrameLoader {
+  load(url: string): Promise<Texture>;
 }
 
-export interface IFrameLoader extends ILoader<Texture> {}
-export interface IArrayLoader extends ILoader<ArraySource> {}
+export interface IArrayLoader {
+  load<T extends FeatureDataType>(url: string, type: T): Promise<ArraySource<T>>;
+}

--- a/src/colorizer/loaders/ILoader.ts
+++ b/src/colorizer/loaders/ILoader.ts
@@ -19,4 +19,5 @@ export interface IFrameLoader {
 
 export interface IArrayLoader {
   load<T extends FeatureDataType>(url: string, type: T, min?: number, max?: number): Promise<ArraySource<T>>;
+  dispose(): void;
 }

--- a/src/colorizer/loaders/ILoader.ts
+++ b/src/colorizer/loaders/ILoader.ts
@@ -13,7 +13,7 @@ export interface ArraySource<T extends FeatureDataType> {
   getMax(): number;
 }
 
-export interface IFrameLoader {
+export interface ITextureImageLoader {
   load(url: string): Promise<Texture>;
 }
 

--- a/src/colorizer/loaders/ImageFrameLoader.ts
+++ b/src/colorizer/loaders/ImageFrameLoader.ts
@@ -1,6 +1,6 @@
 import { NearestFilter, PixelFormat, RGBAIntegerFormat, Texture } from "three";
 
-import { IFrameLoader } from "./ILoader";
+import { ITextureImageLoader } from "./ILoader";
 
 /** Promise-ifies image loading */
 async function loadImageElement(url: string): Promise<HTMLImageElement> {
@@ -29,7 +29,7 @@ async function loadImageElement(url: string): Promise<HTMLImageElement> {
   });
 }
 
-export default class ImageFrameLoader implements IFrameLoader {
+export default class ImageFrameLoader implements ITextureImageLoader {
   private pixelFormat: PixelFormat;
 
   constructor(pixelFormat: PixelFormat = RGBAIntegerFormat) {

--- a/src/colorizer/loaders/UrlArrayLoader.ts
+++ b/src/colorizer/loaders/UrlArrayLoader.ts
@@ -2,7 +2,8 @@
 import { DataTexture } from "three";
 import workerpool from "workerpool";
 
-// @ts-ignore Ignore missing file
+// Vite import directive for worker files! See https://v3.vitejs.dev/guide/features.html#import-with-query-suffixes.
+// @ts-ignore Ignore missing file warning
 import WorkerUrl from "./workers/urlLoadWorker?url&worker";
 
 import { FeatureArrayType, FeatureDataType } from "../types";
@@ -47,8 +48,8 @@ export default class UrlArrayLoader implements IArrayLoader {
     // TODO: Maintain a single worker pool for all loaders/all asynchronous operations in the app?
     this.workerPool = workerpool.pool(WorkerUrl, {
       workerOpts: {
-        // Set worker type to fix a Vite issue where the application fails in production:
-        // https://github.com/josdejong/workerpool/tree/master/examples/vite
+        // Set worker type to undefined (classic)  in production to fix a Vite issue where the application.
+        // Copied from https://github.com/josdejong/workerpool/tree/master/examples/vite.
         type: import.meta.env.PROD ? undefined : "module",
       },
     });

--- a/src/colorizer/loaders/UrlArrayLoader.ts
+++ b/src/colorizer/loaders/UrlArrayLoader.ts
@@ -1,3 +1,4 @@
+// @ts-ignore Ignore missing file
 import WorkerUrl from "./workers/urlLoadWorker?url&worker";
 import { DataTexture } from "three";
 import workerpool from "workerpool";

--- a/src/colorizer/loaders/UrlArrayLoader.ts
+++ b/src/colorizer/loaders/UrlArrayLoader.ts
@@ -17,9 +17,6 @@ export class UrlArraySource<T extends FeatureDataType> implements ArraySource<T>
   max: number;
 
   constructor(array: FeatureArrayType[T], type: T, min: number, max: number) {
-    // Must store Infinity values internally because WebGL states that NaN behavior is undefined.
-    // This can cause shaders to not detect NaN, and operations like isnan() fail.
-    // On the UI, however, Infinity should be parsed as NaN for display.
     this.array = array;
     this.type = type;
     this.min = min;
@@ -47,11 +44,11 @@ export default class UrlArrayLoader implements IArrayLoader {
   private workerPool: workerpool.Pool;
 
   constructor() {
-    // TODO: Maintain a single worker pool for all loaders/all asynchronous operations in the app
+    // TODO: Maintain a single worker pool for all loaders/all asynchronous operations in the app?
     this.workerPool = workerpool.pool(WorkerUrl, {
       workerOpts: {
-        // Fixes a Vite issue  where the application fails in production:
-        //  https://github.com/josdejong/workerpool/tree/master/examples/vite
+        // Set worker type to fix a Vite issue where the application fails in production:
+        // https://github.com/josdejong/workerpool/tree/master/examples/vite
         type: import.meta.env.PROD ? undefined : "module",
       },
     });
@@ -60,22 +57,20 @@ export default class UrlArrayLoader implements IArrayLoader {
   /**
    * Loads array data from the specified URL, handling both JSON and Parquet files.
    * @param url The URL to load data from. Must end in ".json" or ".parquet".
+   * @param type `FeatureDataType` for the returned array source (e.g. `F32` or `U8`).
    * @param min Optional minimum value for the data. If defined, overrides the `min` field
    *   in JSON files or the calculated minimum value for Parquet files.
    * @param max Optional maximum value for the data. If defined, overrides the `max` field
    *   in JSON files or the calculated maximum value for Parquet files.
-   * @param type Optional data type for the returned array. Defaults to `FeatureDataType.F32`.
    * @throws Error if the file format is not supported (not JSON or Parquet).
    * @returns a URLArraySource object containing the loaded data.
    */
   async load<T extends FeatureDataType>(url: string, type: T, min?: number, max?: number): Promise<UrlArraySource<T>> {
-    if (url.endsWith(".json") || url.endsWith(".parquet")) {
-      const { data, min: newMin, max: newMax } = await this.workerPool.exec("load", [url, type]);
-      const result = new UrlArraySource<T>(data, type, min ?? newMin, max ?? newMax);
-      return result;
-    } else {
+    if (!url.endsWith(".json") && !url.endsWith(".parquet")) {
       throw new Error(`Unsupported file format for URL array loader: ${url}`);
     }
+    const { data, min: newMin, max: newMax } = await this.workerPool.exec("load", [url, type]);
+    return new UrlArraySource<T>(data, type, min ?? newMin, max ?? newMax);
   }
 
   dispose(): void {

--- a/src/colorizer/loaders/UrlArrayLoader.ts
+++ b/src/colorizer/loaders/UrlArrayLoader.ts
@@ -1,7 +1,9 @@
-// @ts-ignore Ignore missing file
-import WorkerUrl from "./workers/urlLoadWorker?url&worker";
+// sort-imports-ignore
 import { DataTexture } from "three";
 import workerpool from "workerpool";
+
+// @ts-ignore Ignore missing file
+import WorkerUrl from "./workers/urlLoadWorker?url&worker";
 
 import { FeatureArrayType, FeatureDataType } from "../types";
 import { packDataTexture } from "../utils/texture_utils";
@@ -45,8 +47,11 @@ export default class UrlArrayLoader implements IArrayLoader {
   private workerPool: workerpool.Pool;
 
   constructor() {
+    // TODO: Maintain a single worker pool for all loaders/all asynchronous operations in the app
     this.workerPool = workerpool.pool(WorkerUrl, {
       workerOpts: {
+        // Fixes a Vite issue  where the application fails in production:
+        //  https://github.com/josdejong/workerpool/tree/master/examples/vite
         type: import.meta.env.PROD ? undefined : "module",
       },
     });
@@ -71,5 +76,9 @@ export default class UrlArrayLoader implements IArrayLoader {
     } else {
       throw new Error(`Unsupported file format for URL array loader: ${url}`);
     }
+  }
+
+  dispose(): void {
+    this.workerPool.terminate();
   }
 }

--- a/src/colorizer/loaders/UrlArrayLoader.ts
+++ b/src/colorizer/loaders/UrlArrayLoader.ts
@@ -4,38 +4,22 @@ import { DataTexture } from "three";
 import workerpool from "workerpool";
 
 import { FeatureArrayType, FeatureDataType, featureTypeSpecs } from "../types";
-import { nanToNull } from "../utils/data_utils";
 import { packDataTexture } from "../utils/texture_utils";
 
 import { ArraySource, IArrayLoader } from "./ILoader";
 
-type FeatureDataJson = {
-  data: number[] | boolean[];
-  min?: number;
-  max?: number;
-};
-
-const isBoolArray = (arr: number[] | boolean[]): arr is boolean[] => typeof arr[0] === "boolean";
-
 export class UrlArraySource implements ArraySource {
   array: number[];
-  isBool: boolean;
-  min?: number;
-  max?: number;
+  min: number;
+  max: number;
 
-  constructor(array: number[] | boolean[], min?: number | boolean, max?: number | boolean) {
-    if (isBoolArray(array)) {
-      this.array = array.map(Number);
-      this.isBool = true;
-    } else {
-      // Must store Infinity values internally because WebGL states that NaN behavior is undefined.
-      // This can cause shaders to not detect NaN, and operations like isnan() fail.
-      // On the UI, however, Infinity should be parsed as NaN for display.
-      this.array = array.map((val) => (val === null ? Infinity : val));
-      this.isBool = false;
-    }
-    this.min = typeof min === "boolean" ? Number(min) : min;
-    this.max = typeof max === "boolean" ? Number(max) : max;
+  constructor(array: number[] | Float32Array, min: number, max: number) {
+    // Must store Infinity values internally because WebGL states that NaN behavior is undefined.
+    // This can cause shaders to not detect NaN, and operations like isnan() fail.
+    // On the UI, however, Infinity should be parsed as NaN for display.
+    this.array = array.map((val) => (val === null ? Infinity : val));
+    this.min = min;
+    this.max = max;
   }
 
   getBuffer<T extends FeatureDataType>(type: T): FeatureArrayType[T] {
@@ -47,16 +31,10 @@ export class UrlArraySource implements ArraySource {
   }
 
   getMin(): number {
-    if (this.min === undefined) {
-      this.min = this.array.reduce((acc, val) => (val < acc ? val : acc));
-    }
     return this.min;
   }
 
   getMax(): number {
-    if (this.max === undefined) {
-      this.max = this.array.reduce((acc, val) => (val > acc ? val : acc));
-    }
     return this.max;
   }
 }
@@ -80,36 +58,19 @@ export default class UrlArrayLoader implements IArrayLoader {
    *   in JSON files or the calculated minimum value for Parquet files.
    * @param max Optional maximum value for the data. If defined, overrides the `max` field
    *   in JSON files or the calculated maximum value for Parquet files.
+   * @param type Optional data type for the returned array. Defaults to `FeatureDataType.F32`.
    * @throws Error if the file format is not supported (not JSON or Parquet).
    * @returns a URLArraySource object containing the loaded data.
    */
-  async load(url: string, min?: number, max?: number): Promise<UrlArraySource> {
-    if (url.endsWith(".json")) {
-      const response = await fetch(url);
-      const text = await response.text();
-      const { data, min: jsonMin, max: jsonMax }: FeatureDataJson = JSON.parse(nanToNull(text));
-      return new UrlArraySource(data, min ?? jsonMin, max ?? jsonMax);
-    } else if (url.endsWith(".parquet")) {
-      const { data, min: newMin, max: newMax } = await this.workerPool.exec("loadFromParquetUrl", [url, min, max]);
+  async load(
+    url: string,
+    min?: number,
+    max?: number,
+    type: FeatureDataType = FeatureDataType.F32
+  ): Promise<UrlArraySource> {
+    if (url.endsWith(".json") || url.endsWith(".parquet")) {
+      const { data, min: newMin, max: newMax } = await this.workerPool.exec("load", [url, type]);
       return new UrlArraySource(data, min ?? newMin, max ?? newMax);
-      // const result = await fetch(url);
-      // const arrayBuffer = await result.arrayBuffer();
-      // let data: number[] = [];
-      // let dataMin: number | undefined = undefined;
-      // let dataMax: number | undefined = undefined;
-      // await parquetRead({
-      //   file: arrayBuffer,
-      //   compressors,
-      //   onComplete: (loadedData: number[][]) => {
-      //     for (const row of loadedData) {
-      //       dataMin = dataMin === undefined ? row[0] : Math.min(dataMin, row[0]);
-      //       dataMax = dataMax === undefined ? row[0] : Math.max(dataMax, row[0]);
-      //       data.push(row[0]);
-      //     }
-      //     data = loadedData.map((row) => Number(row[0]));
-      //   },
-      // });
-      // return new UrlArraySource(data, min ?? dataMin, max ?? dataMax);
     } else {
       throw new Error(`Unsupported file format for URL array loader: ${url}`);
     }

--- a/src/colorizer/loaders/UrlArrayLoader.ts
+++ b/src/colorizer/loaders/UrlArrayLoader.ts
@@ -3,7 +3,7 @@ import WorkerUrl from "./workers/urlLoadWorker?url&worker";
 import { DataTexture } from "three";
 import workerpool from "workerpool";
 
-import { FeatureArrayType, FeatureDataType, featureTypeSpecs } from "../types";
+import { FeatureArrayType, FeatureDataType } from "../types";
 import { packDataTexture } from "../utils/texture_utils";
 
 import { ArraySource, IArrayLoader } from "./ILoader";
@@ -46,7 +46,6 @@ export default class UrlArrayLoader implements IArrayLoader {
 
   constructor() {
     this.workerPool = workerpool.pool(WorkerUrl, {
-      maxWorkers: 5,
       workerOpts: {
         type: import.meta.env.PROD ? undefined : "module",
       },
@@ -67,7 +66,8 @@ export default class UrlArrayLoader implements IArrayLoader {
   async load<T extends FeatureDataType>(url: string, type: T, min?: number, max?: number): Promise<UrlArraySource<T>> {
     if (url.endsWith(".json") || url.endsWith(".parquet")) {
       const { data, min: newMin, max: newMax } = await this.workerPool.exec("load", [url, type]);
-      return new UrlArraySource<T>(data, type, min ?? newMin, max ?? newMax);
+      const result = new UrlArraySource<T>(data, type, min ?? newMin, max ?? newMax);
+      return result;
     } else {
       throw new Error(`Unsupported file format for URL array loader: ${url}`);
     }

--- a/src/colorizer/loaders/UrlArrayLoader.ts
+++ b/src/colorizer/loaders/UrlArrayLoader.ts
@@ -2,7 +2,7 @@
 import { DataTexture } from "three";
 import workerpool from "workerpool";
 
-// Vite import directive for worker files! See https://v3.vitejs.dev/guide/features.html#import-with-query-suffixes.
+// Vite import directive for worker files! See https://vitejs.dev/guide/features.html#import-with-query-suffixes.
 // @ts-ignore Ignore missing file warning
 import WorkerUrl from "./workers/urlLoadWorker?url&worker";
 
@@ -48,7 +48,8 @@ export default class UrlArrayLoader implements IArrayLoader {
     // TODO: Maintain a single worker pool for all loaders/all asynchronous operations in the app?
     this.workerPool = workerpool.pool(WorkerUrl, {
       workerOpts: {
-        // Set worker type to undefined (classic)  in production to fix a Vite issue where the application.
+        // Set worker type to undefined (classic) in production to fix a Vite issue where the application
+        // crashes when loading a module worker.
         // Copied from https://github.com/josdejong/workerpool/tree/master/examples/vite.
         type: import.meta.env.PROD ? undefined : "module",
       },

--- a/src/colorizer/loaders/workers/urlLoadWorker.ts
+++ b/src/colorizer/loaders/workers/urlLoadWorker.ts
@@ -1,28 +1,28 @@
 import { parquetRead } from "hyparquet";
 import { compressors } from "hyparquet-compressors";
 import workerpool from "workerpool";
+import Transfer from "workerpool/types/transfer";
 
-async function loadFromParquetUrl(
-  url: string
-): Promise<{ data: number[]; min: number | undefined; max: number | undefined }> {
+async function loadFromParquetUrl(url: string): Promise<Transfer> {
   const result = await fetch(url);
   const arrayBuffer = await result.arrayBuffer();
-  let data: number[] = [];
+  let data: Float32Array = new Float32Array(0);
   let dataMin: number | undefined = undefined;
   let dataMax: number | undefined = undefined;
   await parquetRead({
     file: arrayBuffer,
     compressors,
     onComplete: (loadedData: number[][]) => {
-      for (const row of loadedData) {
-        dataMin = dataMin === undefined ? row[0] : Math.min(dataMin, row[0]);
-        dataMax = dataMax === undefined ? row[0] : Math.max(dataMax, row[0]);
-        data.push(row[0]);
+      const data = new Float32Array(loadedData.length);
+      for (let i = 0; i < loadedData.length; i++) {
+        const value = loadedData[i][0];
+        dataMin = dataMin === undefined ? value : Math.min(dataMin, value);
+        dataMax = dataMax === undefined ? value : Math.max(dataMax, value);
+        data[i] = value;
       }
-      data = loadedData.map((row) => Number(row[0]));
     },
   });
-  return { data, min: dataMin, max: dataMax };
+  return new workerpool.Transfer({ min: dataMin, max: dataMax, data }, [data.buffer]);
 }
 
 workerpool.worker({

--- a/src/colorizer/loaders/workers/urlLoadWorker.ts
+++ b/src/colorizer/loaders/workers/urlLoadWorker.ts
@@ -3,28 +3,76 @@ import { compressors } from "hyparquet-compressors";
 import workerpool from "workerpool";
 import Transfer from "workerpool/types/transfer";
 
-async function loadFromParquetUrl(url: string): Promise<Transfer> {
+import { FeatureDataType, featureTypeSpecs } from "../../types";
+import { nanToNull } from "../../utils/data_utils";
+
+const isBoolArray = (arr: number[] | boolean[]): arr is boolean[] => typeof arr[0] === "boolean";
+
+type FeatureDataJson = {
+  data: number[] | boolean[];
+  min?: number;
+  max?: number;
+};
+
+async function loadFromJsonUrl(url: string, type: FeatureDataType): Promise<Transfer> {
+  const result = await fetch(url);
+  const text = await result.text();
+  let { data: rawData, min, max }: FeatureDataJson = JSON.parse(nanToNull(text));
+
+  // Construct typed array from raw data so it can be transferred w/o copying to
+  // main thread
+  if (isBoolArray(rawData)) {
+    rawData = rawData.map(Number);
+  }
+  // Replace null values with Infinity due to WebGL not supporting NaN
+  for (let i = 0; i < rawData.length; i++) {
+    if (rawData[i] === null) {
+      rawData[i] = Infinity;
+    }
+  }
+  const data = new featureTypeSpecs[type].ArrayConstructor(rawData);
+
+  return new workerpool.Transfer({ min, max, data }, [data.buffer]);
+}
+
+async function loadFromParquetUrl(url: string, type: FeatureDataType): Promise<Transfer> {
   const result = await fetch(url);
   const arrayBuffer = await result.arrayBuffer();
-  let data: Float32Array = new Float32Array(0);
+  let data: Float32Array | Uint32Array | Uint8Array = new Float32Array(0);
   let dataMin: number | undefined = undefined;
   let dataMax: number | undefined = undefined;
+
   await parquetRead({
     file: arrayBuffer,
     compressors,
-    onComplete: (loadedData: number[][]) => {
-      const data = new Float32Array(loadedData.length);
-      for (let i = 0; i < loadedData.length; i++) {
-        const value = loadedData[i][0];
+    onComplete: (rawData: number[][]) => {
+      const data = new featureTypeSpecs[type].ArrayConstructor(rawData.flat().map(Number));
+
+      // Get min and max values for the data
+      for (let i = 0; i < data.length; i++) {
+        const value = Number(data);
         dataMin = dataMin === undefined ? value : Math.min(dataMin, value);
         dataMax = dataMax === undefined ? value : Math.max(dataMax, value);
-        data[i] = value;
       }
     },
   });
+
   return new workerpool.Transfer({ min: dataMin, max: dataMax, data }, [data.buffer]);
 }
 
+async function load(url: string, type: FeatureDataType): Promise<Transfer> {
+  if (url.endsWith(".json")) {
+    return loadFromJsonUrl(url, type);
+  } else if (url.endsWith(".parquet")) {
+    return loadFromParquetUrl(url, type);
+  } else {
+    throw new Error(`Unsupported file format: ${url}`);
+  }
+
+  // TODO: Also generate textures for the data on the worker thread too?
+  // Would need access to the underlying array buffer to transfer
+}
+
 workerpool.worker({
-  loadFromParquetUrl: loadFromParquetUrl,
+  load: load,
 });

--- a/src/colorizer/loaders/workers/urlLoadWorker.ts
+++ b/src/colorizer/loaders/workers/urlLoadWorker.ts
@@ -1,0 +1,30 @@
+import { parquetRead } from "hyparquet";
+import { compressors } from "hyparquet-compressors";
+import workerpool from "workerpool";
+
+async function loadFromParquetUrl(
+  url: string
+): Promise<{ data: number[]; min: number | undefined; max: number | undefined }> {
+  const result = await fetch(url);
+  const arrayBuffer = await result.arrayBuffer();
+  let data: number[] = [];
+  let dataMin: number | undefined = undefined;
+  let dataMax: number | undefined = undefined;
+  await parquetRead({
+    file: arrayBuffer,
+    compressors,
+    onComplete: (loadedData: number[][]) => {
+      for (const row of loadedData) {
+        dataMin = dataMin === undefined ? row[0] : Math.min(dataMin, row[0]);
+        dataMax = dataMax === undefined ? row[0] : Math.max(dataMax, row[0]);
+        data.push(row[0]);
+      }
+      data = loadedData.map((row) => Number(row[0]));
+    },
+  });
+  return { data, min: dataMin, max: dataMax };
+}
+
+workerpool.worker({
+  loadFromParquetUrl: loadFromParquetUrl,
+});

--- a/src/colorizer/loaders/workers/urlLoadWorker.ts
+++ b/src/colorizer/loaders/workers/urlLoadWorker.ts
@@ -3,7 +3,7 @@ import { compressors } from "hyparquet-compressors";
 import workerpool from "workerpool";
 import Transfer from "workerpool/types/transfer";
 
-import { FeatureDataType, featureTypeSpecs } from "../../types";
+import { FeatureArrayType, FeatureDataType, featureTypeSpecs } from "../../types";
 import { nanToNull } from "../../utils/data_utils";
 
 const isBoolArray = (arr: number[] | boolean[]): arr is boolean[] => typeof arr[0] === "boolean";
@@ -14,40 +14,58 @@ type FeatureDataJson = {
   max?: number;
 };
 
-async function loadFromJsonUrl(url: string, type: FeatureDataType): Promise<Transfer> {
+type LoadedData<T extends FeatureDataType> = {
+  data: FeatureArrayType[T];
+  min: number;
+  max: number;
+};
+
+async function loadFromJsonUrl(url: string, type: FeatureDataType): Promise<LoadedData<typeof type>> {
   const result = await fetch(url);
   const text = await result.text();
-  // JSON does not support `NaN` so we use `null` as a placeholder for it.
+  // JSON does not support `NaN` so we use `null` as a placeholder for it, then convert back
+  // to `NaN` when parsing the data.
   let { data: rawData, min, max }: FeatureDataJson = JSON.parse(nanToNull(text));
-
-  // Convert `null` placeholder values back to `NaN`.
   for (let i = 0; i < rawData.length; i++) {
     if (rawData[i] === null) {
       rawData[i] = NaN;
     }
   }
+
   if (isBoolArray(rawData)) {
     rawData = rawData.map(Number);
   }
+
+  // If min/max is not provided, calculate it from the data
+  let dataMin = Number.POSITIVE_INFINITY;
+  let dataMax = Number.NEGATIVE_INFINITY;
+  for (let i = 0; i < rawData.length; i++) {
+    dataMin = Math.min(rawData[i], dataMin);
+    dataMax = Math.max(rawData[i], dataMax);
+  }
+
   // Construct typed array from raw data so it can be transferred w/o copying to
   // main thread
   const data = new featureTypeSpecs[type].ArrayConstructor(rawData);
 
-  return new workerpool.Transfer({ min, max, data }, [data.buffer]);
+  return { data, min: min ?? dataMin, max: max ?? dataMax };
 }
 
-async function loadFromParquetUrl(url: string, type: FeatureDataType): Promise<Transfer> {
+async function loadFromParquetUrl(url: string, type: FeatureDataType): Promise<LoadedData<typeof type>> {
   const result = await fetch(url);
   const arrayBuffer = await result.arrayBuffer();
-  let data: Float32Array | Uint32Array | Uint8Array = new Float32Array(0);
-  let dataMin: number | undefined = undefined;
-  let dataMax: number | undefined = undefined;
+  let data: FeatureArrayType[typeof type] = new featureTypeSpecs[type].ArrayConstructor(0);
+  let dataMin: number = Number.POSITIVE_INFINITY;
+  let dataMax: number = Number.NEGATIVE_INFINITY;
 
   await parquetRead({
     file: arrayBuffer,
     compressors,
     onComplete: (rawData: number[][]) => {
-      const data = new featureTypeSpecs[type].ArrayConstructor(rawData.flat().map(Number));
+      const flattenedMap = rawData.flat().map((value) => {
+        return value === null ? NaN : Number(value);
+      });
+      data = new featureTypeSpecs[type].ArrayConstructor(flattenedMap);
       // Get min and max values for the data
       for (let i = 0; i < data.length; i++) {
         const value = Number(data[i]);
@@ -56,22 +74,25 @@ async function loadFromParquetUrl(url: string, type: FeatureDataType): Promise<T
       }
     },
   });
-  return new workerpool.Transfer({ min: dataMin, max: dataMax, data }, [data.buffer]);
+  return { data, min: dataMin, max: dataMax };
 }
 
 async function load(url: string, type: FeatureDataType): Promise<Transfer> {
+  let result: LoadedData<typeof type>;
   if (url.endsWith(".json")) {
-    return loadFromJsonUrl(url, type);
+    result = await loadFromJsonUrl(url, type);
   } else if (url.endsWith(".parquet")) {
-    return loadFromParquetUrl(url, type);
+    result = await loadFromParquetUrl(url, type);
   } else {
     throw new Error(`Unsupported file format: ${url}`);
   }
 
-  // TODO: For float arrays, convert NaN to Infinity.
+  const { min, max, data } = result;
 
   // TODO: Also generate textures for the data on the worker thread too?
   // Would need access to the underlying array buffer to transfer
+
+  return new workerpool.Transfer({ min, max, data }, [data.buffer]);
 }
 
 workerpool.worker({

--- a/src/colorizer/loaders/workers/urlLoadWorker.ts
+++ b/src/colorizer/loaders/workers/urlLoadWorker.ts
@@ -37,16 +37,15 @@ async function loadFromJsonUrl<T extends FeatureDataType>(url: string, type: T):
     rawData = rawData.map(Number);
   }
 
+  // Construct typed array
+  const data = new featureTypeSpecs[type].ArrayConstructor(rawData);
   // If min/max is not provided, calculate it from the data
   let dataMin = Number.POSITIVE_INFINITY;
   let dataMax = Number.NEGATIVE_INFINITY;
-  for (let i = 0; i < rawData.length; i++) {
-    dataMin = Math.min(rawData[i], dataMin);
-    dataMax = Math.max(rawData[i], dataMax);
+  for (let i = 0; i < data.length; i++) {
+    dataMin = Math.min(data[i], dataMin);
+    dataMax = Math.max(data[i], dataMax);
   }
-
-  // Construct typed array from raw data for transferring to main thread
-  const data = new featureTypeSpecs[type].ArrayConstructor(rawData);
   return { data, min: min ?? dataMin, max: max ?? dataMax };
 }
 
@@ -91,6 +90,7 @@ async function load(url: string, type: FeatureDataType): Promise<Transfer> {
   // TODO: Also generate textures for the data on the worker thread too?
   // Would need access to the underlying array buffer to transfer
 
+  // `Transfer` is used to transfer the data buffer to the main thread without copying.
   return new workerpool.Transfer({ min, max, data }, [data.buffer]);
 }
 

--- a/src/colorizer/loaders/workers/urlLoadWorker.ts
+++ b/src/colorizer/loaders/workers/urlLoadWorker.ts
@@ -4,7 +4,7 @@ import workerpool from "workerpool";
 import Transfer from "workerpool/types/transfer";
 
 import { FeatureArrayType, FeatureDataType, featureTypeSpecs } from "../../types";
-import { nanToNull } from "../../utils/data_utils";
+import { nanToNull } from "../../utils/json_utils";
 
 const isBoolArray = (arr: number[] | boolean[]): arr is boolean[] => typeof arr[0] === "boolean";
 
@@ -25,7 +25,10 @@ async function loadFromJsonUrl(url: string, type: FeatureDataType): Promise<Load
   const text = await result.text();
   // JSON does not support `NaN` so we use `null` as a placeholder for it, then convert back
   // to `NaN` when parsing the data.
-  let { data: rawData, min, max }: FeatureDataJson = JSON.parse(nanToNull(text));
+  const parseResult: FeatureDataJson = JSON.parse(nanToNull(text));
+  let { data: rawData } = parseResult;
+  const { min, max } = parseResult;
+
   for (let i = 0; i < rawData.length; i++) {
     if (rawData[i] === null) {
       rawData[i] = NaN;

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -39,7 +39,7 @@ export type FeatureArrayType = {
 type FeatureTypeSpec<T extends FeatureDataType> = {
   /** The constructor for a `TypedArray` of this numeric type */
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  ArrayConstructor: { new (arr: number[]): FeatureArrayType[T] };
+  ArrayConstructor: { new (arr: number[] | number): FeatureArrayType[T] };
   format: PixelFormat;
   dataType: TextureDataType;
   internalFormat: PixelFormatGPU;

--- a/src/colorizer/utils/data_utils.ts
+++ b/src/colorizer/utils/data_utils.ts
@@ -6,12 +6,6 @@ import ColorRamp from "../ColorRamp";
 import Dataset, { FeatureType } from "../Dataset";
 
 /**
- * Replaces all NaN in string text (such as the string representation of a JSON
- * object) with null. Can be used to safely parse JSON objects with NaN values.
- */
-export const nanToNull = (json: string): string => json.replace(/NaN/g, "null");
-
-/**
  * Generates a find function for a FeatureThreshold, matching on feature name and unit.
  * @param featureKey String feature key to match on.
  * @param unit String unit to match on.

--- a/src/colorizer/utils/json_utils.ts
+++ b/src/colorizer/utils/json_utils.ts
@@ -1,0 +1,5 @@
+/**
+ * Replaces all NaN in string text (such as the string representation of a JSON
+ * object) with null. Can be used to safely parse JSON objects with NaN values.
+ */
+export const nanToNull = (json: string): string => json.replace(/NaN/g, "null");

--- a/src/colorizer/utils/texture_utils.ts
+++ b/src/colorizer/utils/texture_utils.ts
@@ -5,7 +5,7 @@ import { FeatureArrayType, FeatureDataType, featureTypeSpecs } from "../types";
 /**
  * Calculate the squarest possible texture that `data` can fit into and return a tuple of `[width, height]`
  */
-function getSquareDimensions<T extends FeatureDataType>(data: FeatureArrayType[T]): [number, number] {
+function getSquareDimensions<T extends FeatureDataType>(data: FeatureArrayType[T] | number[]): [number, number] {
   const width = Math.ceil(Math.sqrt(data.length));
   const height = Math.ceil(data.length / width);
 
@@ -28,15 +28,20 @@ function padToLength<T extends FeatureDataType>(
 }
 
 /** Pack a 1d array of data into the squarest 2d texture possible */
-export function packDataTexture<T extends FeatureDataType>(data: FeatureArrayType[T], type: T): DataTexture {
+export function packDataTexture<T extends FeatureDataType>(data: FeatureArrayType[T] | number[], type: T): DataTexture {
   const [width, height] = getSquareDimensions(data);
   const length = width * height;
+
+  // Convert array of regular numbers to typed arrays
+  if (!ArrayBuffer.isView(data)) {
+    data = new featureTypeSpecs[type].ArrayConstructor(data);
+  }
 
   const spec = featureTypeSpecs[type];
   const buffer = padToLength(data, type, 0, length);
 
-  // Convert all NaNs in the buffer to Infinity to avoid issues with WebGL.
-  // This assumes that the data is float-based.
+  // Convert all NaNs in the buffer to Infinity before texture conversion, as WebGL has undefined
+  // behavior for NaNs. This assumes that the data is float-based.
   for (let i = 0; i < buffer.length; i++) {
     if (Number.isNaN(buffer[i])) {
       buffer[i] = Infinity;

--- a/src/colorizer/utils/texture_utils.ts
+++ b/src/colorizer/utils/texture_utils.ts
@@ -33,7 +33,7 @@ export function packDataTexture<T extends FeatureDataType>(data: FeatureArrayTyp
   const length = width * height;
 
   // If provided a regular array of numbers, convert to TypedArray
-  if (!ArrayBuffer.isView(data)) {
+  if (Array.isArray(data)) {
     data = new featureTypeSpecs[type].ArrayConstructor(data);
   }
 

--- a/src/colorizer/utils/texture_utils.ts
+++ b/src/colorizer/utils/texture_utils.ts
@@ -5,7 +5,9 @@ import { FeatureArrayType, FeatureDataType, featureTypeSpecs } from "../types";
 /**
  * Calculate the squarest possible texture that `data` can fit into and return a tuple of `[width, height]`
  */
-function getSquareDimensions<T extends FeatureDataType>(data: FeatureArrayType[T] | number[]): [number, number] {
+function getSquarestTextureDimensions<T extends FeatureDataType>(
+  data: FeatureArrayType[T] | number[]
+): [number, number] {
   const width = Math.ceil(Math.sqrt(data.length));
   const height = Math.ceil(data.length / width);
 
@@ -29,7 +31,7 @@ function padToLength<T extends FeatureDataType>(
 
 /** Pack a 1d array of data into the squarest 2d texture possible */
 export function packDataTexture<T extends FeatureDataType>(data: FeatureArrayType[T] | number[], type: T): DataTexture {
-  const [width, height] = getSquareDimensions(data);
+  const [width, height] = getSquarestTextureDimensions(data);
   const length = width * height;
 
   // If provided a regular array of numbers, convert to TypedArray

--- a/src/colorizer/utils/texture_utils.ts
+++ b/src/colorizer/utils/texture_utils.ts
@@ -1,29 +1,39 @@
 import { DataTexture } from "three";
 
-import { FeatureDataType, featureTypeSpecs } from "../types";
+import { FeatureArrayType, FeatureDataType, featureTypeSpecs } from "../types";
 
 /**
- * Calculate the squarest possible texture that `data` can fit into, extend it with
- * `emptyVal` to fit perfectly into that space, and return a tuple of `[width, height]`
+ * Calculate the squarest possible texture that `data` can fit into and return a tuple of `[width, height]`
  */
-function fitIntoSquare<T>(data: T[], emptyVal: T): [number, number] {
+function getSquareDimensions<T extends FeatureDataType>(data: FeatureArrayType[T]): [number, number] {
   const width = Math.ceil(Math.sqrt(data.length));
   const height = Math.ceil(data.length / width);
-  const length = width * height;
-
-  while (data.length < length) {
-    data.push(emptyVal);
-  }
 
   return [width, height];
 }
 
+/**
+ * Returns a copy of the typed array `data` padded with `emptyVal` to the specified length.
+ */
+function padToLength<T extends FeatureDataType>(
+  data: FeatureArrayType[T],
+  type: T,
+  emptyVal: number,
+  length: number
+): FeatureArrayType[T] {
+  const buffer = new featureTypeSpecs[type].ArrayConstructor(length);
+  buffer.fill(emptyVal, data.length, length);
+  buffer.set(data, 0);
+  return buffer;
+}
+
 /** Pack a 1d array of data into the squarest 2d texture possible */
-export function packDataTexture(data: number[], type: FeatureDataType): DataTexture {
-  const [width, height] = fitIntoSquare(data, 0);
+export function packDataTexture<T extends FeatureDataType>(data: FeatureArrayType[T], type: T): DataTexture {
+  const [width, height] = getSquareDimensions(data);
+  const length = width * height;
 
   const spec = featureTypeSpecs[type];
-  const buffer = new spec.ArrayConstructor(data);
+  const buffer = padToLength(data, type, 0, length);
 
   const tex = new DataTexture(buffer, width, height, spec.format, spec.dataType);
   tex.internalFormat = spec.internalFormat;

--- a/src/colorizer/utils/texture_utils.ts
+++ b/src/colorizer/utils/texture_utils.ts
@@ -32,7 +32,7 @@ export function packDataTexture<T extends FeatureDataType>(data: FeatureArrayTyp
   const [width, height] = getSquareDimensions(data);
   const length = width * height;
 
-  // Convert array of regular numbers to typed arrays
+  // If provided a regular array of numbers, convert to TypedArray
   if (!ArrayBuffer.isView(data)) {
     data = new featureTypeSpecs[type].ArrayConstructor(data);
   }

--- a/src/colorizer/utils/texture_utils.ts
+++ b/src/colorizer/utils/texture_utils.ts
@@ -18,7 +18,7 @@ function getSquarestTextureDimensions<T extends FeatureDataType>(
  * Returns a copy of the typed array `data` padded with `emptyVal` to the specified length.
  */
 function padToLength<T extends FeatureDataType>(
-  data: FeatureArrayType[T],
+  data: FeatureArrayType[T] | number[],
   type: T,
   emptyVal: number,
   length: number
@@ -33,11 +33,6 @@ function padToLength<T extends FeatureDataType>(
 export function packDataTexture<T extends FeatureDataType>(data: FeatureArrayType[T] | number[], type: T): DataTexture {
   const [width, height] = getSquarestTextureDimensions(data);
   const length = width * height;
-
-  // If provided a regular array of numbers, convert to TypedArray
-  if (Array.isArray(data)) {
-    data = new featureTypeSpecs[type].ArrayConstructor(data);
-  }
 
   const spec = featureTypeSpecs[type];
   const buffer = padToLength(data, type, 0, length);

--- a/src/colorizer/utils/texture_utils.ts
+++ b/src/colorizer/utils/texture_utils.ts
@@ -35,6 +35,14 @@ export function packDataTexture<T extends FeatureDataType>(data: FeatureArrayTyp
   const spec = featureTypeSpecs[type];
   const buffer = padToLength(data, type, 0, length);
 
+  // Convert all NaNs in the buffer to Infinity to avoid issues with WebGL.
+  // This assumes that the data is float-based.
+  for (let i = 0; i < buffer.length; i++) {
+    if (Number.isNaN(buffer[i])) {
+      buffer[i] = Infinity;
+    }
+  }
+
   const tex = new DataTexture(buffer, width, height, spec.format, spec.dataType);
   tex.internalFormat = spec.internalFormat;
   tex.needsUpdate = true;

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -21,8 +21,8 @@ import {
   ThresholdType,
   ViewerConfig,
 } from "../types";
-import { nanToNull } from "./data_utils";
 import { AnyManifestFile } from "./dataset_utils";
+import { nanToNull } from "./json_utils";
 import { numberToStringDecimal } from "./math_utils";
 
 enum UrlParam {

--- a/src/components/Tabs/ScatterPlotTab.tsx
+++ b/src/components/Tabs/ScatterPlotTab.tsx
@@ -496,6 +496,8 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
     // Sort data into buckets
     for (let i = 0; i < xData.length; i++) {
       const objectId = objectIds[i];
+      const isMinMaxNaN = Number.isNaN(colorMaxValue) && Number.isNaN(colorMinValue);
+      const isNaN = Number.isNaN(featureData.data[objectId]);
       const isOutlier = dataset.outliers ? dataset.outliers[objectId] : false;
       const isOutOfRange = inRangeIds[objectId] === 0;
 
@@ -506,7 +508,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
       let bucketIndex;
       if (isOutOfRange) {
         bucketIndex = BUCKET_INDEX_OUTOFRANGE;
-      } else if (isOutlier) {
+      } else if (isOutlier || isNaN || isMinMaxNaN) {
         bucketIndex = BUCKET_INDEX_OUTLIERS;
       } else if (usingOverrideColor) {
         bucketIndex = NUM_RESERVED_BUCKETS;

--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -43,11 +43,17 @@ class MockFrameLoader implements IFrameLoader {
   }
 }
 
-class MockArraySource implements ArraySource {
-  getBuffer<T extends FeatureDataType>(type: T): FeatureArrayType[T] {
-    return new featureTypeSpecs[type].ArrayConstructor([]);
+class MockArraySource<T extends FeatureDataType> implements ArraySource<T> {
+  private type: T;
+
+  constructor(type: T) {
+    this.type = type;
   }
-  getTexture(_type: FeatureDataType): Texture {
+
+  getBuffer<T extends FeatureDataType>(): FeatureArrayType[T] {
+    return new featureTypeSpecs[this.type].ArrayConstructor([]) as unknown as FeatureArrayType[T];
+  }
+  getTexture(): Texture {
     return new Texture();
   }
   getMin(): number {
@@ -59,8 +65,10 @@ class MockArraySource implements ArraySource {
 }
 
 class MockArrayLoader implements IArrayLoader {
-  load(_url: string): Promise<ArraySource> {
-    return Promise.resolve(new MockArraySource());
+  dispose(): void {}
+
+  load<T extends FeatureDataType>(_url: string, type: T): Promise<ArraySource<T>> {
+    return Promise.resolve(new MockArraySource(type));
   }
 }
 

--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -2,7 +2,7 @@ import semver from "semver";
 import { DataTexture, RGBAFormat, Texture, UnsignedByteType, Vector2 } from "three";
 import { describe, expect, it } from "vitest";
 
-import { ArraySource, IArrayLoader, IFrameLoader } from "../src/colorizer";
+import { ArraySource, IArrayLoader, ITextureImageLoader } from "../src/colorizer";
 import { FeatureArrayType, FeatureDataType, featureTypeSpecs } from "../src/colorizer/types";
 import { AnyManifestFile, ManifestFile } from "../src/colorizer/utils/dataset_utils";
 import { MAX_FEATURE_CATEGORIES } from "../src/constants";
@@ -21,7 +21,7 @@ const makeMockFetchMethod = <T>(url: string, manifestJson: T): ((url: string) =>
   };
 };
 
-class MockFrameLoader implements IFrameLoader {
+class MockFrameLoader implements ITextureImageLoader {
   width: number;
   height: number;
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,11 +13,13 @@ process.env = {
 
 export default defineConfig({
   build: {
-    commonjsOptions: {
-      // Ignore built-in modules in Node.js. Fix copied from the workerpool documentation:
-      // https://github.com/josdejong/workerpool/blob/master/examples/vite/vite.config.ts
-      ignore: ["os", "child_process", "worker_threads"],
-    },
+    // This quiets the "module has been externalized for browser compatibility" warnings that
+    // vite throws when building for production.
+    // commonjsOptions: {
+    //   // Ignore built-in modules in Node.js. Fix copied from the workerpool documentation:
+    //   // https://github.com/josdejong/workerpool/blob/master/examples/vite/vite.config.ts
+    //   ignore: ["os", "child_process", "worker_threads"],
+    // },
     rollupOptions: {
       input: {
         // TODO: Currently 404.html imports all of the same JS chunks as index.html.

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,11 @@ process.env = {
 
 export default defineConfig({
   build: {
+    commonjsOptions: {
+      // Ignore built-in modules in Node.js. Fix copied from the workerpool documentation:
+      // https://github.com/josdejong/workerpool/blob/master/examples/vite/vite.config.ts
+      ignore: ["os", "child_process", "worker_threads"],
+    },
     rollupOptions: {
       input: {
         // TODO: Currently 404.html imports all of the same JS chunks as index.html.


### PR DESCRIPTION
Problem
=======
Closes #416, a bug where the progress bar would be blocked when loading Parquet data. The underlying problem was that the Parquet data would all arrive at once and need to be decoded by the main thread, causing the UI to block. This change adds multithreading using workers to parallelize this step!

Here's some stats on the new load times:
| Dataset | JSON Load | Parquet Load |
| --- | --- | --- |
| Small | 4.54s | 1.38s |
| Medium | 5.25s | 1.66s |
| Large | 5.85s | 1.68s | 

*Estimated size: medium, 20-30 minutes*


Solution
========
This one ended up a tad bit bigger than I would have liked, but that's the magic of ✨TYPE WRANGLING✨! In my initial attempt at this, I found that the UI was still stalling when the workers finished because they were copying the data arrays back to the main thread. To solve this, I wanted to transfer the arrays, which required that the arrays be `TypedArrays`.

This kicked off a big types refactor, but ultimately the `ArraySource`, `IArrayLoader`, and other interfaces/classes were updated to be generic on a `FeatureDataType` provided at initialization. This meant that I could specify the required data array type when handing off work to the worker threads and receive the expected type when they completed.


## Changes
- Installs the `workerpool` library for handling workers.
- Moves loading + parsing for both JSON and Parquet data to worker threads.
- Edits many of the Array loading types to specify a `FeatureDataType` at initialization.
- Data arrays no longer use `Infinity` as a placeholder for `NaN` values for data at rest.
  -  `NaN`s are converted to `Infinity` only when writing to Textures.

I have one more change I'd like to make where I also move the packing of Textures into squares to the worker threads, but I'll handle that later once these initial changes are approved.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-420/
2. Copy in the following URL and click load: `https://animatedcell-test-data.s3.us-west-2.amazonaws.com/parquet/collection.json`.
3. Switch between the JSON and Parquet datasets from the dropdown to compare the load times!

Keyfiles (delete if not relevant):
-----------------------
1. `ILoader.ts` -> changes to interface to account for new type interactions
5. `UrlArrayLoader.ts` -> big changes to `UrlArraySource` (it's much simpler than before, basically a data container!), removes old parsing code
6. `urlLoadWorker.ts` -> The new worker script. Copied code from `UrlArrayLoader` with updated handlers for types.

Thanks for contributing!
