### PR TITLE
fix: Fixes a dom validation warning caused by nested `p` tags.

### DIFF
--- a/src/routes/LandingPageContent.tsx
+++ b/src/routes/LandingPageContent.tsx
@@ -9,7 +9,7 @@ export const landingPageContent: ProjectEntry[] = [
     name: "Tracked hiPSC FOV-nuclei timelapse datasets",
     inReview: true,
     description: (
-      <p>
+      <>
         Maximum projections of tracked 3D segmentations of nuclei in growing hiPS cell colonies, with quantitative
         features of nuclear shape, size and more. The exploratory dataset includes all tracked nuclei, with the baseline
         colonies, full-interphase, and lineage-annotated datasets as subsets of this dataset, analyzed in the study of
@@ -26,7 +26,7 @@ export const landingPageContent: ProjectEntry[] = [
           our datasets hosted on Quilt
         </ExternalLink>
         .
-      </p>
+      </>
     ),
     // publicationLink: new URL("https://www.google.com"),
     // publicationName: "<NucMorph manuscript> (Publisher name, mm/dd/yyyy)",


### PR DESCRIPTION
Problem
=======

Fixes a warning emitted by `validateDOMNesting` caused by nested `p` tags.

*Estimated review size: tiny, 1 minute*

![image](https://github.com/user-attachments/assets/007ffe5b-c3b8-45ee-815a-b3323ad26d9b)
