### PR TITLE
fix: Fixed blurry bold text caused by Lato not loading from Google Fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,10 @@
       })(window, document, "script", "dataLayer", "GTM-KB579ZN7");
     </script>
 
+    <style>
+      @import url("https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&display=swap");
+    </style>
+
     <title>Timelapse Feature Explorer</title>
     <link rel="icon" type="image/svg+xml" href="/images/aics-logo.svg" />
     <link rel="stylesheet" href="src/styles/cookie-banner.css" />

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -34,7 +34,7 @@ import { useConstructor, useDebounce, useRecentCollections } from "./colorizer/u
 import * as urlUtils from "./colorizer/utils/url_utils";
 import { SCATTERPLOT_TIME_FEATURE } from "./components/Tabs/scatter_plot_data_utils";
 import { DEFAULT_PLAYBACK_FPS } from "./constants";
-import { FlexRowAlignCenter } from "./styles/utils";
+import { FlexRow, FlexRowAlignCenter } from "./styles/utils";
 import { LocationState } from "./types";
 
 import Collection from "./colorizer/Collection";
@@ -51,6 +51,7 @@ import ColorRampDropdown from "./components/Dropdowns/ColorRampDropdown";
 import HelpDropdown from "./components/Dropdowns/HelpDropdown";
 import SelectionDropdown from "./components/Dropdowns/SelectionDropdown";
 import Export from "./components/Export";
+import GlossaryPanel from "./components/GlossaryPanel";
 import Header from "./components/Header";
 import HoverTooltip from "./components/HoverTooltip";
 import IconButton from "./components/IconButton";
@@ -834,19 +835,37 @@ function Viewer(): ReactElement {
             items={collection?.getDatasetKeys() || []}
             onChange={handleDatasetChange}
           />
-          <SelectionDropdown
-            disabled={disableUi}
-            label="Feature"
-            selected={featureKey}
-            items={getFeatureDropdownData()}
-            onChange={(value) => {
-              if (value !== featureKey && dataset) {
-                replaceFeature(dataset, value);
-                resetColorRampRangeToDefaults(dataset, value);
-                reportFeatureSelected(dataset, value);
-              }
-            }}
-          />
+          <FlexRow $gap={6}>
+            <SelectionDropdown
+              disabled={disableUi}
+              label="Feature"
+              showTooltip={true}
+              // TODO: Once dropdowns are refactored, add description into tooltips
+              // dataset?.getFeatureData(featureKey)?.description ? (
+              //   // Show as larger element with subtitle if description is given
+              //   <FlexColumn>
+              //     <span style={{ fontSize: "14px" }}>
+              //       {featureKey && dataset?.getFeatureNameWithUnits(featureKey)}
+              //     </span>
+              //     <span style={{ fontSize: "13px", opacity: "0.9" }}>
+              //       {dataset?.getFeatureData(featureKey)?.description}
+              //     </span>
+              //   </FlexColumn>
+              // ) : (
+              //   dataset?.getFeatureNameWithUnits(featureKey)
+              // )
+              selected={featureKey}
+              items={getFeatureDropdownData()}
+              onChange={(value) => {
+                if (value !== featureKey && dataset) {
+                  replaceFeature(dataset, value);
+                  resetColorRampRangeToDefaults(dataset, value);
+                  reportFeatureSelected(dataset, value);
+                }
+              }}
+            />
+            <GlossaryPanel dataset={dataset} />
+          </FlexRow>
 
           <ColorRampDropdown
             knownColorRamps={KNOWN_COLOR_RAMPS}

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -29,6 +29,7 @@ export type FeatureData = {
   unit: string;
   type: FeatureType;
   categories: string[] | null;
+  description: string | null;
 };
 
 type BackdropData = {
@@ -159,9 +160,10 @@ export default class Dataset {
         data: source.getBuffer(),
         min: source.getMin(),
         max: source.getMax(),
-        unit: metadata?.unit || "",
+        unit: metadata.unit || "",
         type: featureType,
         categories: featureCategories || null,
+        description: metadata.description || null,
       },
     ];
   }

--- a/src/colorizer/utils/dataset_utils.ts
+++ b/src/colorizer/utils/dataset_utils.ts
@@ -64,8 +64,11 @@ type ManifestFileV1_0_0 = Omit<ManifestFileV0_0_0, "features" | "featureMetadata
     unit?: string;
     type?: string;
     categories?: string[];
+    // Added in v1.3.0
     min?: number | null;
     max?: number | null;
+    // Added in v1.4.2
+    description?: string;
   }[];
   /** Optional list of backdrop/overlay images. */
   backdrops?: { name: string; key: string; frames: string[] }[];

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -132,8 +132,6 @@ export const DocumentContext = createContext<DocumentContextType>({ modalContain
 
 /** Applies theme as CSS variables that affect the rest of the document. */
 const CssContainer = styled.div`
-  @import url("https://fonts.googleapis.com/css2?family=Lato&display=swap");
-
   @font-face {
     font-family: LatoExtended;
     font-style: normal;

--- a/src/components/GlossaryPanel.tsx
+++ b/src/components/GlossaryPanel.tsx
@@ -1,0 +1,113 @@
+import { ReadOutlined } from "@ant-design/icons";
+import { Divider, Drawer, Radio, RadioChangeEvent, Tooltip } from "antd";
+import React, { ReactElement, useContext, useMemo, useState } from "react";
+import styled from "styled-components";
+
+import { Dataset } from "../colorizer";
+import { FlexColumn, FlexRowAlignCenter } from "../styles/utils";
+
+import { AppThemeContext } from "./AppStyle";
+import IconButton from "./IconButton";
+
+type GlossaryPanelProps = {
+  dataset: Dataset | null;
+};
+
+const StyledDrawer = styled(Drawer)`
+  .ant-drawer-body {
+    padding-top: 16px;
+  }
+
+  .ant-drawer-header-title {
+    // Move the close button to the right corner of the header
+    display: flex;
+    flex-direction: row-reverse;
+  }
+
+  p {
+    margin: 0;
+  }
+`;
+
+export default function GlossaryPanel(props: GlossaryPanelProps): ReactElement {
+  const [showPanel, setShowPanel] = useState(false);
+  const [alphabetizeFeatures, setAlphabetizeFeatures] = useState(false);
+
+  const theme = useContext(AppThemeContext);
+
+  const drawerContent = useMemo(() => {
+    const dataset = props.dataset;
+    if (dataset === null) {
+      return null;
+    }
+    const allFeatureData = dataset.featureKeys.map((featureKey) => dataset.getFeatureData(featureKey)!);
+    if (alphabetizeFeatures) {
+      allFeatureData.sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    return (
+      <FlexColumn $gap={15}>
+        {allFeatureData.map((featureData) => {
+          const hasDescription = featureData.description && featureData.description !== "";
+          const key = featureData.key;
+          return (
+            <p style={{ lineHeight: "1.5", margin: "0" }} key={key}>
+              <Tooltip title={hasDescription ? null : "No description provided"} placement="right">
+                <span style={{ fontWeight: "bold" }}>{dataset.getFeatureNameWithUnits(key)}</span>
+              </Tooltip>
+              <br />
+              {featureData.description}
+            </p>
+          );
+        })}
+      </FlexColumn>
+    );
+  }, [props.dataset, alphabetizeFeatures]);
+
+  return (
+    <>
+      <Tooltip placement="top" title="Open feature glossary" trigger={["hover", "focus"]}>
+        <IconButton
+          type="link"
+          onClick={() => {
+            setShowPanel(true);
+          }}
+          disabled={!props.dataset}
+        >
+          <ReadOutlined style={{ marginTop: "1px" }} /* Visually align with other elements*/ />
+        </IconButton>
+      </Tooltip>
+      <StyledDrawer
+        zIndex={2000}
+        width={"calc(min(75vw, 1000px))"}
+        onClose={() => {
+          setShowPanel(false);
+        }}
+        title={<span style={{ fontSize: "20px" }}>Feature glossary</span>}
+        open={showPanel}
+        size="large"
+        style={{ color: theme.color.text.primary }}
+      >
+        <FlexColumn $gap={16}>
+          <FlexRowAlignCenter $gap={8}>
+            <h3 style={{ margin: 0, fontWeight: "normal" }} id="glossary-sortby-label">
+              Sort by
+            </h3>
+            <Radio.Group
+              buttonStyle="solid"
+              // TODO: Why does Ant not support aria-label on Radio.Group?
+              // "aria-label"="glossary-sortby-label"
+              value={alphabetizeFeatures}
+              onChange={(e: RadioChangeEvent) => setAlphabetizeFeatures(e.target.value)}
+            >
+              <Radio.Button value={false}>Feature order</Radio.Button>
+              <Radio.Button value={true}>Alphabetical</Radio.Button>
+            </Radio.Group>
+          </FlexRowAlignCenter>
+          <Divider />
+          {drawerContent}
+        </FlexColumn>
+      </StyledDrawer>
+    </>
+  );
+}

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -1,5 +1,3 @@
-import { faUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Button, Divider, Tooltip } from "antd";
 import React, { lazy, ReactElement, Suspense } from "react";
 import { Link, useNavigate } from "react-router-dom";
@@ -7,7 +5,7 @@ import styled from "styled-components";
 
 import { Dataset } from "../colorizer";
 import { paramsToUrlQueryString } from "../colorizer/utils/url_utils";
-import { FlexColumn, FlexColumnAlignCenter, FlexRowAlignCenter, VisuallyHidden } from "../styles/utils";
+import { ExternalLink, FlexColumn, FlexColumnAlignCenter, FlexRowAlignCenter, VisuallyHidden } from "../styles/utils";
 import { DatasetEntry, LocationState, ProjectEntry } from "../types";
 import { PageRoutes } from "./index";
 
@@ -253,12 +251,7 @@ export default function LandingPage(): ReactElement {
     const publicationElement = project.publicationLink ? (
       <p>
         Related publication:{" "}
-        <a href={project.publicationLink.toString()} target="_blank" rel="noopener noreferrer">
-          {project.publicationName}
-          {/* Icon offset slightly to align with text */}
-          <FontAwesomeIcon icon={faUpRightFromSquare} size="sm" style={{ marginBottom: "-1px", marginLeft: "3px" }} />
-          <VisuallyHidden>(opens in new tab)</VisuallyHidden>
-        </a>
+        <ExternalLink href={project.publicationLink.toString()}>{project.publicationName}</ExternalLink>
       </p>
     ) : null;
 

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -92,7 +92,7 @@ const FeatureHighlightsItem = styled(FlexColumn)`
   grid-row: span 2;
 
   & > h3 {
-    font-weight: 600;
+    font-weight: bold;
   }
 `;
 
@@ -127,7 +127,7 @@ const ProjectCard = styled.li`
   gap: 0px;
 
   & h3 {
-    font-weight: 600;
+    font-weight: bold;
   }
 
   & p,
@@ -188,7 +188,7 @@ const InReviewFlag = styled(FlexRowAlignCenter)`
   & > p {
     color: var(--color-flag-text);
     font-size: 10px;
-    font-weight: 700;
+    font-weight: bold;
     white-space: nowrap;
   }
 `;

--- a/src/styles/utils.tsx
+++ b/src/styles/utils.tsx
@@ -82,6 +82,7 @@ export function ExternalLink(props: { href: string; children: React.ReactNode })
     <a href={props.href} style={{ whiteSpace: "nowrap" }} rel="noopener noreferrer" target="_blank">
       {props.children}
       <FontAwesomeIcon icon={faUpRightFromSquare} size="sm" style={{ marginBottom: "0px", marginLeft: "3px" }} />
+      <VisuallyHidden>(opens in new tab)</VisuallyHidden>
     </a>
   );
 }


### PR DESCRIPTION
Fixes an issue where bolded fonts looked blurry. The root issue was that the font (Lato) was not actually being loaded from Google Fonts, and it was using a fallback font file (without bolding) instead. The browser was using a default bolding algorithm that looked bad at smaller sizes.

*Estimated review size: tiny, <5 minutes*

Before:
![image](https://github.com/user-attachments/assets/6fdab412-f917-465d-bbd8-e781f8728d9b)

After:
![image](https://github.com/user-attachments/assets/678fb1ae-e234-4bc3-b6d4-9dc165d98652)
