### PR TITLE
fix: Fixed bug where the canvas overlay became blurry with zoom

### DIFF
--- a/src/colorizer/CanvasUIOverlay.ts
+++ b/src/colorizer/CanvasUIOverlay.ts
@@ -80,6 +80,8 @@ export default class CanvasOverlay {
   private scaleBarOptions: ScaleBarOptions;
   private timestampOptions: TimestampOptions;
   private backgroundOptions: OverlayFillOptions;
+  private canvasWidth: number;
+  private canvasHeight: number;
 
   constructor(
     scaleBarOptions: ScaleBarOptions = defaultScaleBarOptions,
@@ -90,14 +92,16 @@ export default class CanvasOverlay {
     this.scaleBarOptions = scaleBarOptions;
     this.timestampOptions = timestampOptions;
     this.backgroundOptions = overlayOptions;
+    this.canvasWidth = 1;
+    this.canvasHeight = 1;
   }
 
   /**
    * Set the size of the canvas overlay.
    */
   setSize(width: number, height: number): void {
-    this.canvas.width = width;
-    this.canvas.height = height;
+    this.canvasWidth = width;
+    this.canvasHeight = height;
   }
 
   updateScaleBarOptions(options: Partial<ScaleBarOptions>): void {
@@ -359,6 +363,9 @@ export default class CanvasOverlay {
       return;
     }
 
+    const devicePixelRatio = window.devicePixelRatio || 1;
+    this.canvas.width = this.canvasWidth * devicePixelRatio;
+    this.canvas.height = this.canvasHeight * devicePixelRatio;
     //Clear canvas
     ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
 

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -303,7 +303,7 @@ export default class ColorizeCanvas {
       // size of the frame relative to the canvas to determine the canvas' width in units.
       // We only consider X scaling here because the scale bar is always horizontal.
       const canvasWidthInUnits = frameDims.width / this.frameSizeInCanvasCoordinates.x;
-      const unitsPerScreenPixel = canvasWidthInUnits / this.canvasResolution.x;
+      const unitsPerScreenPixel = canvasWidthInUnits / this.canvasResolution.x / this.renderer.getPixelRatio();
       this.overlay.updateScaleBarOptions({ unitsPerScreenPixel, units: frameDims.units, visible: true });
     } else {
       this.overlay.updateScaleBarOptions({ visible: false });


### PR DESCRIPTION
Problem
=======
Fixes #414, "blurry canvas overlay on zoom levels other than 100%".

*Estimated size: tiny, 5 minutes*

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open the base build and try zooming in on the page itself: https://timelapse.allencell.org/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fbaseline_colonies_dataset%2Fcollection.json
2. Open the new fixed build and try zooming in on the page. The scale bar and time text should no longer appear blurry: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-440/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fbaseline_colonies_dataset%2Fcollection.json

Screenshots (optional):
-----------------------

https://github.com/user-attachments/assets/8f7af219-f7d0-43cc-b8b2-9424b65c9324


