### PR TITLE
fix: Arrow keys no longer advance time when focused on an input

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -688,10 +688,13 @@ function Viewer(): ReactElement {
   timeControls.setFrameCallback(setFrame);
 
   const handleKeyDown = useCallback(
-    ({ key }: KeyboardEvent): void => {
-      if (key === "ArrowLeft" || key === "Left") {
+    (e: KeyboardEvent): void => {
+      if (e.target instanceof HTMLInputElement) {
+        return;
+      }
+      if (e.key === "ArrowLeft" || e.key === "Left") {
         timeControls.advanceFrame(-1);
-      } else if (key === "ArrowRight" || key === "Right") {
+      } else if (e.key === "ArrowRight" || e.key === "Right") {
         timeControls.advanceFrame(1);
       }
     },


### PR DESCRIPTION
Problem
=======
Closes #308, "arrow keys still change time when other inputs are being used."

*Estimated review size: tiny, 1-2 minutes*


## Type of change
* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open TFE and open the export field. Try editing the prefix and pressing the left or right arrow keys. The timestamp will change. https://timelapse.allencell.org/
2. Repeat with fixed (!!!) preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-444/ (The timestamp should not change!)
