### PR TITLE
feat: Scatterplot tab plots currently selected feature if no axes are selected

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -362,6 +362,21 @@ function Viewer(): ReactElement {
     [featureThresholds, config.keepRangeBetweenDatasets]
   );
 
+  /** Handle startup behaviors for tabs when changed. */
+  const onTabChanged = useCallback(
+    (key: string) => {
+      if (key === TabType.SCATTER_PLOT) {
+        // When opening scatterplot tab, plot the current feature against
+        // time if no x/y axis is set.
+        if (!scatterPlotConfig.xAxis && !scatterPlotConfig.yAxis) {
+          updateScatterPlotConfig({ xAxis: SCATTERPLOT_TIME_FEATURE.key, yAxis: featureKey });
+        }
+      }
+      updateConfig({ openTab: key as TabType });
+    },
+    [updateConfig, featureKey]
+  );
+
   // DATASET LOADING ///////////////////////////////////////////////////////
 
   const handleProgressUpdate = useCallback((complete: number, total: number): void => {
@@ -1055,7 +1070,7 @@ function Viewer(): ReactElement {
                 style={{ marginBottom: 0, width: "100%" }}
                 size="large"
                 activeKey={config.openTab}
-                onChange={(key) => updateConfig({ openTab: key as TabType })}
+                onChange={onTabChanged}
                 items={[
                   {
                     label: "Track plot",

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -362,21 +362,6 @@ function Viewer(): ReactElement {
     [featureThresholds, config.keepRangeBetweenDatasets]
   );
 
-  /** Handle startup behaviors for tabs when changed. */
-  const onTabChanged = useCallback(
-    (key: string) => {
-      if (key === TabType.SCATTER_PLOT) {
-        // When opening scatterplot tab, plot the current feature against
-        // time if no x/y axis is set.
-        if (!scatterPlotConfig.xAxis && !scatterPlotConfig.yAxis) {
-          updateScatterPlotConfig({ xAxis: SCATTERPLOT_TIME_FEATURE.key, yAxis: featureKey });
-        }
-      }
-      updateConfig({ openTab: key as TabType });
-    },
-    [updateConfig, featureKey]
-  );
-
   // DATASET LOADING ///////////////////////////////////////////////////////
 
   const handleProgressUpdate = useCallback((complete: number, total: number): void => {
@@ -1070,7 +1055,7 @@ function Viewer(): ReactElement {
                 style={{ marginBottom: 0, width: "100%" }}
                 size="large"
                 activeKey={config.openTab}
-                onChange={onTabChanged}
+                onChange={(key) => updateConfig({ openTab: key as TabType })}
                 items={[
                   {
                     label: "Track plot",

--- a/src/components/Tabs/ScatterPlotTab.tsx
+++ b/src/components/Tabs/ScatterPlotTab.tsx
@@ -1,7 +1,7 @@
 import { Button, Tooltip } from "antd";
 import { MenuItemType } from "antd/es/menu/hooks/useItems";
 import Plotly, { PlotData, PlotMarker } from "plotly.js-dist-min";
-import React, { memo, ReactElement, useContext, useEffect, useRef, useState, useTransition } from "react";
+import React, { memo, ReactElement, useContext, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import styled from "styled-components";
 import { Color, ColorRepresentation, HexColorString } from "three";
 
@@ -127,6 +127,15 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
   const dataset = useDebounce(props.dataset, 500);
   const colorRampMin = useDebounce(props.colorRampMin, 100);
   const colorRampMax = useDebounce(props.colorRampMax, 100);
+
+  useMemo(() => {
+    if (props.scatterPlotConfig.xAxis === null && props.scatterPlotConfig.yAxis === null && props.selectedFeatureKey) {
+      props.updateScatterPlotConfig({
+        yAxis: props.selectedFeatureKey,
+        xAxis: SCATTERPLOT_TIME_FEATURE.key,
+      });
+    }
+  }, [props.selectedFeatureKey]);
 
   // Trigger render spinner when playback starts, but only if the render is being delayed.
   // If a render is allowed to happen (such as in the current-track- or current-frame-only


### PR DESCRIPTION
Problem
=======
Closes #451, "show selected feature in scatterplot on startup".

*Estimated size: tiny, <5 minutes*

Solution
========
- If no scatterplot axes are selected when the scatter plot tab is opened for the first time, the currently selected feature is plotted against time in the scatterplot.

## Type of change

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open preview link, select a feature, and switch to the scatterplot tab. You should see that feature plotted against time. https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-452/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&t=15&filters=growth_outlier_filter%3A%3A3%2Cbaseline_colonies_dataset_filter%3A%3A3%2Cfullinterphase_dataset_filter%3A%3A3%2Clineageannotated_dataset_filter%3A%3A3
2. Open this preview link which already has a feature selected and the scatterplot tab set to open. The scatterplot should immediately show that feature plotted against time. https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-452/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&feature=surface_area&t=15&tab=scatter_plot
3. Open this final preview link which has a different scatterplot axis (volume x height) plotted. It should not be overridden. https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-452/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&feature=surface_area&t=15&tab=scatter_plot&scatter-range=all&scatter-x=volume&scatter-y=height
