### PR TITLE
feature: Improved load errors

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -23,6 +23,7 @@ import {
   FeatureThreshold,
   getDefaultScatterPlotConfig,
   isThresholdNumeric,
+  LoadTroubleshooting,
   ReportWarningCallback,
   ScatterPlotConfig,
   TabType,
@@ -379,8 +380,7 @@ function Viewer(): ReactElement {
         errorMessage
           ? `Encountered the following error when loading the dataset: "${errorMessage}"`
           : "Encountered an error when loading the dataset.",
-        "Check your network connection and access to the dataset path, or use the browser console to view details." +
-          " Otherwise, contact the dataset creator as there may be missing files.",
+        LoadTroubleshooting.CHECK_FILE_OR_NETWORK,
       ];
 
       showAlert({

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -403,7 +403,7 @@ function Viewer(): ReactElement {
         });
       });
     },
-    [notificationApi, showAlert]
+    [showAlert]
   );
 
   /**
@@ -552,7 +552,9 @@ function Viewer(): ReactElement {
           // Try loading the collection, with the default collection as a fallback.
 
           try {
-            newCollection = await Collection.loadCollection(collectionUrlParam);
+            newCollection = await Collection.loadCollection(collectionUrlParam, {
+              reportWarning: showDatasetLoadWarning,
+            });
             datasetKey = datasetParam || newCollection.getDefaultDatasetKey();
           } catch (error) {
             console.error(error);
@@ -843,7 +845,11 @@ function Viewer(): ReactElement {
         <h3>{collection?.metadata.name ?? null}</h3>
         <FlexRowAlignCenter $gap={12} $wrap="wrap">
           <FlexRowAlignCenter $gap={2} $wrap="wrap">
-            <LoadDatasetButton onLoad={handleDatasetLoad} currentResourceUrl={collection?.url || datasetKey} />
+            <LoadDatasetButton
+              onLoad={handleDatasetLoad}
+              currentResourceUrl={collection?.url || datasetKey}
+              reportWarning={showDatasetLoadWarning}
+            />
             <Export
               totalFrames={dataset?.numberOfFrames || 0}
               setFrame={setFrameAndRender}

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -161,7 +161,8 @@ function Viewer(): ReactElement {
   const [notificationApi, notificationContextHolder] = notification.useNotification(notificationConfig);
 
   const { bannerElement, showAlert, clearBanners } = useAlertBanner();
-  const queuedAlerts = useRef<(() => void)[]>([]);
+  /** Alerts that should be shown for a dataset that is currently being loaded but is not yet displayed. */
+  const pendingAlerts = useRef<(() => void)[]>([]);
 
   const [isRecording, setIsRecording] = useState(false);
   const timeControls = useConstructor(() => new TimeControls(canv!, playbackFps));
@@ -376,16 +377,17 @@ function Viewer(): ReactElement {
     (errorMessage?: string): void => {
       const description: string[] = [
         errorMessage
-          ? 'Encountered the following error when loading the dataset: "' + errorMessage + '"'
+          ? `Encountered the following error when loading the dataset: "${errorMessage}"`
           : "Encountered an error when loading the dataset.",
-        "Check your network connection and access to the dataset path, or use the browser console to view details. Otherwise, contact the dataset creator as there may be missing files.",
+        "Check your network connection and access to the dataset path, or use the browser console to view details." +
+          " Otherwise, contact the dataset creator as there may be missing files.",
       ];
 
       showAlert({
-        message: "Dataset could not be loaded.",
         type: "error",
-        closable: false,
+        message: "Dataset could not be loaded.",
         description,
+        closable: false,
         action: <Link to="/">Return to homepage</Link>,
       });
     },
@@ -394,12 +396,12 @@ function Viewer(): ReactElement {
 
   const showDatasetLoadWarning: ReportWarningCallback = useCallback(
     (message: string, description: string | string[]) => {
-      queuedAlerts.current.push(() => {
+      pendingAlerts.current.push(() => {
         showAlert({
-          message: message,
           type: "warning",
-          closable: true,
+          message: message,
           description: description,
+          closable: true,
         });
       });
     },
@@ -422,14 +424,15 @@ function Viewer(): ReactElement {
       if (dataset !== null) {
         dataset.dispose();
       }
-      // State updates
+
+      // Manage dataset-related alert banners
       clearBanners();
-      if (queuedAlerts.current.length > 0) {
-        for (const alert of queuedAlerts.current) {
-          alert();
-        }
-        queuedAlerts.current = [];
+      for (const alert of pendingAlerts.current) {
+        alert();
       }
+      pendingAlerts.current = [];
+
+      // State updates
       setDataset(newDataset);
       setDatasetKey(newDatasetKey);
 
@@ -531,7 +534,7 @@ function Viewer(): ReactElement {
         if (datasetParam && urlUtils.isUrl(datasetParam) && !collectionUrlParam) {
           // Dataset is a URL and no collection URL is provided;
           // Make a dummy collection that will include only this dataset
-          newCollection = await Collection.makeCollectionFromSingleDataset(datasetParam);
+          newCollection = Collection.makeCollectionFromSingleDataset(datasetParam);
           datasetKey = newCollection.getDefaultDatasetKey();
         } else {
           if (!collectionUrlParam) {
@@ -675,7 +678,7 @@ function Viewer(): ReactElement {
         if (result.loaded) {
           await replaceDataset(result.dataset, newDatasetKey);
         } else {
-          // TODO: What happens when you try to load a bad dataset from the dropdown? Notifications?
+          // Show notification popup for datasets that can't be loaded.
           console.error(result.errorMessage);
           notificationApi["error"]({
             message: "Dataset load failed",

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -365,6 +365,21 @@ function Viewer(): ReactElement {
     [featureThresholds, config.keepRangeBetweenDatasets]
   );
 
+  /** Handle startup behaviors for tabs when changed. */
+  const onTabChanged = useCallback(
+    (key: string) => {
+      if (key === TabType.SCATTER_PLOT) {
+        // When opening scatterplot tab, plot the current feature against
+        // time if no x/y axis is set.
+        if (!scatterPlotConfig.xAxis && !scatterPlotConfig.yAxis) {
+          updateScatterPlotConfig({ xAxis: SCATTERPLOT_TIME_FEATURE.key, yAxis: featureKey });
+        }
+      }
+      updateConfig({ openTab: key as TabType });
+    },
+    [updateConfig, featureKey]
+  );
+
   // DATASET LOADING ///////////////////////////////////////////////////////
 
   const handleProgressUpdate = useCallback((complete: number, total: number): void => {
@@ -1101,7 +1116,7 @@ function Viewer(): ReactElement {
                 style={{ marginBottom: 0, width: "100%" }}
                 size="large"
                 activeKey={config.openTab}
-                onChange={(key) => updateConfig({ openTab: key as TabType })}
+                onChange={onTabChanged}
                 items={[
                   {
                     label: "Track plot",

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -365,21 +365,6 @@ function Viewer(): ReactElement {
     [featureThresholds, config.keepRangeBetweenDatasets]
   );
 
-  /** Handle startup behaviors for tabs when changed. */
-  const onTabChanged = useCallback(
-    (key: string) => {
-      if (key === TabType.SCATTER_PLOT) {
-        // When opening scatterplot tab, plot the current feature against
-        // time if no x/y axis is set.
-        if (!scatterPlotConfig.xAxis && !scatterPlotConfig.yAxis) {
-          updateScatterPlotConfig({ xAxis: SCATTERPLOT_TIME_FEATURE.key, yAxis: featureKey });
-        }
-      }
-      updateConfig({ openTab: key as TabType });
-    },
-    [updateConfig, featureKey]
-  );
-
   // DATASET LOADING ///////////////////////////////////////////////////////
 
   const handleProgressUpdate = useCallback((complete: number, total: number): void => {
@@ -1116,7 +1101,7 @@ function Viewer(): ReactElement {
                 style={{ marginBottom: 0, width: "100%" }}
                 size="large"
                 activeKey={config.openTab}
-                onChange={onTabChanged}
+                onChange={(key) => updateConfig({ openTab: key as TabType })}
                 items={[
                   {
                     label: "Track plot",

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -856,6 +856,7 @@ function Viewer(): ReactElement {
             <Export
               totalFrames={dataset?.numberOfFrames || 0}
               setFrame={setFrameAndRender}
+              getCanvasExportDimensions={() => [canv.domElement.width, canv.domElement.height]}
               getCanvas={() => canv.domElement}
               // Stop playback when exporting
               onClick={() => timeControls.pause()}

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -681,7 +681,7 @@ function Viewer(): ReactElement {
             message: "Dataset load failed",
             description: result.errorMessage,
             placement: "bottomLeft",
-            duration: 4,
+            duration: 12,
           });
         }
         setIsDatasetLoading(false);

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -279,7 +279,7 @@ export default class Collection {
     // Convert JSON array into map
     if (!collection.datasets || collection.datasets.length === 0) {
       throw new Error(
-        `The collection JSON was loaded but no datasets were found. At least one dataset must be defined in the collection.`
+        `Collection JSON was loaded but no datasets were found. At least one dataset must be defined in the collection.`
       );
     }
     const collectionData: Map<string, CollectionEntry> = new Map();
@@ -389,11 +389,8 @@ export default class Collection {
     console.error(`URL '${url}' could not be loaded as a collection or dataset.`);
     throw new Error(
       `Could not load the provided URL as either a collection or a dataset.
-      \n
-      \nIf this is a collection:
-      \n\t${collectionLoadError?.message || "N/A"}
-      \nIf this is a dataset:
-      \n\t${datasetLoadError?.message || "N/A"}`
+      \nIf this is a collection: ${collectionLoadError?.message || "N/A"}
+      \nIf this is a dataset: ${datasetLoadError?.message || "N/A"}`
     );
   }
 }

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -288,9 +288,8 @@ export default class Collection {
     }
     if (!response.ok) {
       throw new Error(
-        `Received a ${response.status} (${response.statusText}) code from the server while retrieving collections JSON from url '${absoluteCollectionUrl}'.` +
-          " " +
-          LoadTroubleshooting.CHECK_FILE_EXISTS
+        `Received a ${response.status} (${response.statusText}) code from the server while retrieving` +
+          ` collections JSON from url '${absoluteCollectionUrl}'. ${LoadTroubleshooting.CHECK_FILE_EXISTS}`
       );
     }
 

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -338,6 +338,52 @@ export default class Collection {
   }
 
   /**
+   * Merges and formats error messages from a failed collection and dataset load.
+   */
+  private static formatLoadingError(url: string, collectionLoadError: Error, datasetLoadError: Error): Error {
+    if (url.endsWith(DEFAULT_COLLECTION_FILENAME)) {
+      // Assume that this was a collection because the URL ended with "collection.json."
+      return collectionLoadError;
+    } else if (url.endsWith(DEFAULT_DATASET_FILENAME)) {
+      // Assume that this was a dataset because the URL ended with "dataset.json."
+      return datasetLoadError;
+    } else if (
+      collectionLoadError.message.startsWith(LoadErrorMessage.UNREACHABLE_COLLECTION) &&
+      datasetLoadError.message.includes(LoadErrorMessage.UNREACHABLE_MANIFEST)
+    ) {
+      // Handle TypeError from failed fetch, likely due to server being unreachable.
+      return new Error(
+        "Could not access either a collection or a dataset JSON at the provided URL." +
+          " This may be due to a network issue, the server being unreachable, or a misconfigured URL." +
+          " Please check your network access."
+      );
+    } else if (
+      // Merge 404 errors from both collection and dataset fetches
+      collectionLoadError.message.includes("404 (Not Found)") &&
+      datasetLoadError.message.includes("404 (Not Found)")
+    ) {
+      return new Error(
+        "Could not load the provided URL as either a collection or a dataset. Server returned a 404 (Not Found) code."
+      );
+    } else {
+      // Format and return a message containing both errors.
+      console.error(`URL '${url}' could not be loaded as a collection or dataset.`);
+      const collectionMessage =
+        uncapitalizeFirstLetter(collectionLoadError?.message) ||
+        "(no error message provided; this is likely a bug and should be reported)";
+      const datasetMessage =
+        uncapitalizeFirstLetter(datasetLoadError?.message) ||
+        "(no error message provided; this is likely a bug and should be reported)";
+
+      return new Error(
+        `Could not load the provided URL as either a collection or a dataset.
+        \n- If this is a collection, ${collectionMessage}
+        \n- If this is a dataset, ${datasetMessage}`
+      );
+    }
+  }
+
+  /**
    * Attempt to load an ambiguous URL as either a collection or dataset, and return a new
    * Collection representing its contents (either the loaded collection or a dummy collection
    * containing just the dataset).
@@ -359,10 +405,13 @@ export default class Collection {
       throw new Error(`Provided resource '${url}' is not a URL and cannot be loaded.`);
     }
 
+    let result: Collection | null = null;
     let collectionLoadError: Error | null = null;
     let datasetLoadError: Error | null = null;
+
+    // Try loading as a collection
     try {
-      return await Collection.loadCollection(url, options);
+      result = await Collection.loadCollection(url, options);
     } catch (e) {
       collectionLoadError = e as Error;
       console.warn(e);
@@ -370,61 +419,24 @@ export default class Collection {
     }
 
     // Could not load as a collection, attempt to load as a dataset.
-    try {
-      const collection = Collection.makeCollectionFromSingleDataset(url);
-      // Attempt to load the default dataset immediately to surface any loading errors.
-      const loadResult = await collection.tryLoadDataset(collection.getDefaultDatasetKey());
-      if (!loadResult.loaded) {
-        throw new Error(loadResult.errorMessage);
+    if (!result) {
+      try {
+        const collection = Collection.makeCollectionFromSingleDataset(url);
+        // Attempt to load the default dataset immediately to surface any loading errors.
+        const loadResult = await collection.tryLoadDataset(collection.getDefaultDatasetKey());
+        if (!loadResult.loaded) {
+          throw new Error(loadResult.errorMessage);
+        }
+        return collection;
+      } catch (e) {
+        datasetLoadError = e as Error;
       }
-      return collection;
-    } catch (e) {
-      datasetLoadError = e as Error;
     }
 
-    // Assumption: if both loads failed and the file matches one of the default filenames,
-    // show only the relevant load error.
-    if (url.endsWith(DEFAULT_COLLECTION_FILENAME)) {
-      throw collectionLoadError;
-    } else if (url.endsWith(DEFAULT_DATASET_FILENAME)) {
-      throw datasetLoadError;
+    if (!result) {
+      throw Collection.formatLoadingError(url, collectionLoadError!, datasetLoadError!);
     }
 
-    // Handle TypeError from failed fetch -> likely due to server being unreachable.
-    if (
-      collectionLoadError.message.startsWith(LoadErrorMessage.UNREACHABLE_COLLECTION) &&
-      datasetLoadError.message.includes(LoadErrorMessage.UNREACHABLE_MANIFEST)
-    ) {
-      throw new Error(
-        "Could not access either a collection or a dataset JSON at the provided URL." +
-          " This may be due to a network issue, the server being unreachable, or a misconfigured URL." +
-          " Please check your network access."
-      );
-    }
-
-    // Handle 404 errors from both collection and dataset fetches
-    if (
-      collectionLoadError.message.includes("404 (Not Found)") &&
-      datasetLoadError.message.includes("404 (Not Found)")
-    ) {
-      throw new Error(
-        "Could not load the provided URL as either a collection or a dataset. Server returned a 404 (Not Found) code."
-      );
-    }
-
-    // Could not load as a dataset either; surface the errors.
-    console.error(`URL '${url}' could not be loaded as a collection or dataset.`);
-    const collectionMessage =
-      uncapitalizeFirstLetter(collectionLoadError?.message) ||
-      "(no error message provided; this is likely a bug and should be reported)";
-    const datasetMessage =
-      uncapitalizeFirstLetter(datasetLoadError?.message) ||
-      "(no error message provided; this is likely a bug and should be reported)";
-
-    throw new Error(
-      `Could not load the provided URL as either a collection or a dataset.
-      \n- If this is a collection, ${collectionMessage}
-      \n- If this is a dataset, ${datasetMessage}`
-    );
+    return result;
   }
 }

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_COLLECTION_FILENAME, DEFAULT_DATASET_FILENAME } from "../constants";
-import { ReportWarningCallback } from "./types";
+import { LoadErrorMessage, ReportWarningCallback } from "./types";
 import { AnalyticsEvent, triggerAnalyticsEvent } from "./utils/analytics";
 import {
   CollectionEntry,
@@ -261,7 +261,7 @@ export default class Collection {
       response = await fetchMethod(absoluteCollectionUrl, DEFAULT_FETCH_TIMEOUT_MS);
     } catch (e) {
       throw new Error(
-        "The expected collection JSON file could not be reached. " +
+        LoadErrorMessage.UNREACHABLE_COLLECTION +
           " This may be due to a network issue, the server being unreachable, or a misconfigured URL." +
           " Please check your network access."
       );
@@ -392,8 +392,8 @@ export default class Collection {
 
     // Handle TypeError from failed fetch -> likely due to server being unreachable.
     if (
-      collectionLoadError.message.includes("JSON file could not be reached") &&
-      datasetLoadError.message.includes("JSON file could not be reached")
+      collectionLoadError.message.startsWith(LoadErrorMessage.UNREACHABLE_COLLECTION) &&
+      datasetLoadError.message.includes(LoadErrorMessage.UNREACHABLE_MANIFEST)
     ) {
       throw new Error(
         "Could not access either a collection or a dataset JSON at the provided URL." +

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -7,7 +7,7 @@ import {
   CollectionFileMetadata,
   updateCollectionVersion,
 } from "./utils/collection_utils";
-import { uncapitalizeFirstLetter } from "./utils/data_utils";
+import { formatAsBulletList, uncapitalizeFirstLetter } from "./utils/data_utils";
 import { DEFAULT_FETCH_TIMEOUT_MS, fetchWithTimeout, formatPath, isJson, isUrl } from "./utils/url_utils";
 
 import Dataset from "./Dataset";
@@ -120,7 +120,7 @@ export default class Collection {
   /**
    * Attempts to load and return the dataset specified by the key.
    * @param datasetKey string key of the dataset.
-   * @param config Optional configuration, containing any of the following keys:
+   * @param options Optional configuration, containing any of the following properties:
    *  - `onLoadProgress` optional callback for loading progress.
    *  - `arrayLoader` optional array loader to use for loading the dataset.
    *  - `reportWarning` optional callback for reporting warning messages during loading (potential errors
@@ -134,7 +134,7 @@ export default class Collection {
    */
   public async tryLoadDataset(
     datasetKey: string,
-    config: Partial<{
+    options: Partial<{
       onLoadProgress?: (complete: number, total: number) => void;
       arrayLoader?: IArrayLoader;
       reportWarning?: ReportWarningCallback;
@@ -155,13 +155,13 @@ export default class Collection {
     };
     const onLoadComplete = (): void => {
       completedLoadItems++;
-      config.onLoadProgress?.(completedLoadItems, totalLoadItems);
+      options.onLoadProgress?.(completedLoadItems, totalLoadItems);
     };
 
     // TODO: Override fetch method
     try {
-      const dataset = new Dataset(path, undefined, config.arrayLoader);
-      await dataset.open({ onLoadStart, onLoadComplete, reportWarning: config.reportWarning });
+      const dataset = new Dataset(path, undefined, options.arrayLoader);
+      await dataset.open({ onLoadStart, onLoadComplete, reportWarning: options.reportWarning });
       console.timeEnd("loadDataset");
       return { loaded: true, dataset: dataset };
     } catch (e) {
@@ -243,7 +243,9 @@ export default class Collection {
    * Asynchronously loads a Collection object from the provided URL.
    * @param collectionParam The URL of the resource. This can either be a direct path to
    * collection JSON file or the path of a directory containing `collection.json`.
-   * @param fetchMethod Optional. The fetch command used to retrieve the URL.
+   * @param options Optional configuration, containing any of the following properties:
+   * - `fetchMethod` optional override for the fetch method, used to retrieve the URL.
+   * - `reportWarning` optional callback for reporting warning messages during loading.
    * @throws Error if the JSON could not be retrieved or is an unrecognized format.
    * @returns A new Collection object containing the retrieved data.
    */
@@ -288,19 +290,19 @@ export default class Collection {
       );
     }
     const collectionData: Map<string, CollectionEntry> = new Map();
-    const duplicateCollectionNames = new Set<string>();
+    const duplicateDatasetNames = new Set<string>();
     for (const entry of collection.datasets) {
       if (collectionData.has(entry.name)) {
-        duplicateCollectionNames.add(entry.name);
+        duplicateDatasetNames.add(entry.name);
         console.warn(`Duplicate dataset name ${entry.name} found in collection JSON; skipping.`);
       }
       collectionData.set(entry.name, entry);
     }
 
-    if (duplicateCollectionNames.size > 0) {
+    if (duplicateDatasetNames.size > 0) {
       options.reportWarning?.(`Duplicate dataset names were found in the collection.`, [
         "The following dataset(s) had duplicate names and were skipped when loading the collection:",
-        ...Array.from(duplicateCollectionNames).map((name) => `- ${name}`),
+        ...formatAsBulletList(Array.from(duplicateDatasetNames), 5),
         "If you are the dataset author, please ensure that every dataset has a unique name in the collection.",
       ]);
     }
@@ -325,7 +327,7 @@ export default class Collection {
    * @returns a new Collection, where the only dataset is that of the provided `datasetUrl`.
    * The `url` field of the Collection will also be set to `null`.
    */
-  public static async makeCollectionFromSingleDataset(datasetUrl: string): Promise<Collection> {
+  public static makeCollectionFromSingleDataset(datasetUrl: string): Collection {
     // Add the default filename if the url is not a .JSON path.
     if (!isJson(datasetUrl)) {
       datasetUrl = formatPath(datasetUrl) + "/" + DEFAULT_DATASET_FILENAME;
@@ -369,7 +371,7 @@ export default class Collection {
 
     // Could not load as a collection, attempt to load as a dataset.
     try {
-      const collection = await Collection.makeCollectionFromSingleDataset(url);
+      const collection = Collection.makeCollectionFromSingleDataset(url);
       // Attempt to load the default dataset immediately to surface any loading errors.
       const loadResult = await collection.tryLoadDataset(collection.getDefaultDatasetKey());
       if (!loadResult.loaded) {
@@ -412,8 +414,12 @@ export default class Collection {
 
     // Could not load as a dataset either; surface the errors.
     console.error(`URL '${url}' could not be loaded as a collection or dataset.`);
-    const collectionMessage = uncapitalizeFirstLetter(collectionLoadError?.message) || "(no error message provided)";
-    const datasetMessage = uncapitalizeFirstLetter(datasetLoadError?.message) || "(no error message provided)";
+    const collectionMessage =
+      uncapitalizeFirstLetter(collectionLoadError?.message) ||
+      "(no error message provided; this is likely a bug and should be reported)";
+    const datasetMessage =
+      uncapitalizeFirstLetter(datasetLoadError?.message) ||
+      "(no error message provided; this is likely a bug and should be reported)";
 
     throw new Error(
       `Could not load the provided URL as either a collection or a dataset.

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -163,7 +163,7 @@ export default class Collection {
         return {
           loaded: false,
           dataset: null,
-          errorMessage: `Error: Could not load dataset manifest '${datasetKey}'. ("${e}")`,
+          errorMessage: e.message,
         };
       } else {
         return { loaded: false, dataset: null };

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -122,7 +122,8 @@ export default class Collection {
    * @param config Optional configuration, containing any of the following keys:
    *  - `onLoadProgress` optional callback for loading progress.
    *  - `arrayLoader` optional array loader to use for loading the dataset.
-   *  - `report
+   *  - `reportWarning` optional callback for reporting warning messages during loading (potential errors
+   * that are non-blocking).
    * @returns A promise of a `DatasetLoadResult`.
    * - On a success, returns an object with a Dataset `dataset` and the `loaded` flag set to true.
    * - On a failure, returns an object with a null `dataset` and `loaded` set to false, as well as

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -261,9 +261,9 @@ export default class Collection {
       response = await fetchMethod(absoluteCollectionUrl, DEFAULT_FETCH_TIMEOUT_MS);
     } catch (e) {
       throw new Error(
-        `The expected collection JSON file could not be reached. ` +
-          ` This may be due to a network issue, the server being unreachable, or a misconfigured URL.` +
-          ` Please check your network access.`
+        "The expected collection JSON file could not be reached. " +
+          " This may be due to a network issue, the server being unreachable, or a misconfigured URL." +
+          " Please check your network access."
       );
     }
     if (!response.ok) {
@@ -286,7 +286,7 @@ export default class Collection {
     // Convert JSON array into map
     if (!collection.datasets || collection.datasets.length === 0) {
       throw new Error(
-        `Collection JSON was loaded but no datasets were found. At least one dataset must be defined in the collection.`
+        "Collection JSON was loaded but no datasets were found. At least one dataset must be defined in the collection."
       );
     }
     const collectionData: Map<string, CollectionEntry> = new Map();
@@ -300,7 +300,7 @@ export default class Collection {
     }
 
     if (duplicateDatasetNames.size > 0) {
-      options.reportWarning?.(`Duplicate dataset names were found in the collection.`, [
+      options.reportWarning?.("Duplicate dataset names were found in the collection.", [
         "The following dataset(s) had duplicate names and were skipped when loading the collection:",
         ...formatAsBulletList(Array.from(duplicateDatasetNames), 5),
         "If you are the dataset author, please ensure that every dataset has a unique name in the collection.",
@@ -396,9 +396,9 @@ export default class Collection {
       datasetLoadError.message.includes("JSON file could not be reached")
     ) {
       throw new Error(
-        `Could not access either a collection or a dataset JSON at the provided URL.` +
-          ` This may be due to a network issue, the server being unreachable, or a misconfigured URL.` +
-          ` Please check your network access.`
+        "Could not access either a collection or a dataset JSON at the provided URL." +
+          " This may be due to a network issue, the server being unreachable, or a misconfigured URL." +
+          " Please check your network access."
       );
     }
 
@@ -408,7 +408,7 @@ export default class Collection {
       datasetLoadError.message.includes("404 (Not Found)")
     ) {
       throw new Error(
-        `Could not load the provided URL as either a collection or a dataset. Server returned a 404 (Not Found) code.`
+        "Could not load the provided URL as either a collection or a dataset. Server returned a 404 (Not Found) code."
       );
     }
 

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -427,7 +427,7 @@ export default class Dataset {
     // Load feature data
     if (manifest.features.length === 0) {
       throw new Error(
-        "The dataset's manifest JSON was loaded but no features found were found. At least one feature must be defined."
+        "The dataset's manifest JSON was loaded but no features were found. At least one feature must be defined."
       );
     }
     const featuresPromises: Promise<[string, FeatureData]>[] = Array.from(manifest.features).map((data) =>

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -1,7 +1,13 @@
 import { RGBAFormat, RGBAIntegerFormat, Texture, Vector2 } from "three";
 
 import { MAX_FEATURE_CATEGORIES } from "../constants";
-import { FeatureArrayType, FeatureDataType, ReportWarningCallback } from "./types";
+import {
+  FeatureArrayType,
+  FeatureDataType,
+  LoadErrorMessage,
+  LoadTroubleshooting,
+  ReportWarningCallback,
+} from "./types";
 import { AnalyticsEvent, triggerAnalyticsEvent } from "./utils/analytics";
 import { formatAsBulletList, getKeyFromName } from "./utils/data_utils";
 import { ManifestFile, ManifestFileMetadata, updateManifestVersion } from "./utils/dataset_utils";
@@ -425,9 +431,7 @@ export default class Dataset {
 
     // Load feature data
     if (manifest.features.length === 0) {
-      throw new Error(
-        "The dataset's manifest JSON was loaded but no features were found. At least one feature must be defined."
-      );
+      throw new Error(LoadErrorMessage.MANIFEST_HAS_NO_FEATURES);
     }
     const featuresPromises: Promise<[string, FeatureData]>[] = Array.from(manifest.features).map((data) =>
       reportLoadProgress(this.loadFeature(data))
@@ -463,7 +467,7 @@ export default class Dataset {
       options.reportWarning?.("Some data files failed to load.", [
         "The following data file(s) failed to load, which may cause the viewer to behave unexpectedly:",
         ...unloadableDataFiles.map((fileType) => `  - ${fileType}`),
-        "This may be because of an unsupported format, missing files, or server and network issues. Please see the developer console for more details.",
+        LoadTroubleshooting.CHECK_FILE_OR_NETWORK,
       ]);
     }
 
@@ -485,7 +489,7 @@ export default class Dataset {
       options.reportWarning?.("Some features failed to load.", [
         "The following feature(s) could not be loaded and will not be shown: ",
         ...formatAsBulletList(missingFeatureNames, 5),
-        "This may be because of an unsupported format or a missing file.",
+        LoadTroubleshooting.CHECK_FILE_OR_NETWORK,
       ]);
     }
 

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -390,6 +390,8 @@ export default class Dataset {
     const startTime = new Date();
 
     const manifest = updateManifestVersion(await options.manifestLoader(this.manifestUrl));
+    console.log(manifest);
+
     this.frameFiles = manifest.frames;
     this.outlierFile = manifest.outliers;
     this.metadata = { ...defaultMetadata, ...manifest.metadata };
@@ -402,9 +404,9 @@ export default class Dataset {
       for (const { name, key, frames } of manifest.backdrops) {
         this.backdropData.set(key, { name, frames });
         if (frames.length !== this.frameFiles.length || 0) {
-          // TODO: Show error message in the UI when this happens.
           throw new Error(
-            `Number of frames (${this.frameFiles.length}) does not match number of images (${frames.length}) for backdrop '${key}'.`
+            `Number of frames (${this.frameFiles.length}) does not match number of images (${frames.length}) for backdrop '${key}'. ` +
+              ` If you are a dataset author, please ensure that the number of frames in the manifest matches the number of images for each backdrop.`
           );
         }
       }
@@ -423,7 +425,9 @@ export default class Dataset {
 
     // Load feature data
     if (manifest.features.length === 0) {
-      throw new Error("No features found in dataset manifest. At least one feature must be defined.");
+      throw new Error(
+        "The dataset's manifest JSON was loaded but no features found were found. At least one feature must be defined."
+      );
     }
     const featuresPromises: Promise<[string, FeatureData]>[] = Array.from(manifest.features).map((data) =>
       reportLoadProgress(this.loadFeature(data))

--- a/src/colorizer/loaders/workers/urlLoadWorker.ts
+++ b/src/colorizer/loaders/workers/urlLoadWorker.ts
@@ -23,6 +23,11 @@ type LoadedData<T extends FeatureDataType> = {
 
 async function loadFromJsonUrl<T extends FeatureDataType>(url: string, type: T): Promise<LoadedData<T>> {
   const result = await fetch(url);
+
+  if (!result.ok) {
+    throw new Error(`Failed to load JSON data from URL '${url}': ${result.status} ${result.statusText}`);
+  }
+
   const text = await result.text();
   // JSON does not support `NaN` so we use `null` as a placeholder for it while parsing, then convert back.
   const parseResult: FeatureDataJson = JSON.parse(nanToNull(text));
@@ -52,6 +57,11 @@ async function loadFromJsonUrl<T extends FeatureDataType>(url: string, type: T):
 
 async function loadFromParquetUrl<T extends FeatureDataType>(url: string, type: T): Promise<LoadedData<T>> {
   const result = await fetch(url);
+
+  if (!result.ok) {
+    throw new Error(`Failed to load Parquet data from URL '${url}': ${result.status} ${result.statusText}`);
+  }
+
   const arrayBuffer = await result.arrayBuffer();
   let data: FeatureArrayType[T] = new featureTypeSpecs[type].ArrayConstructor(0);
   let dataMin: number = Number.POSITIVE_INFINITY;

--- a/src/colorizer/recorders/Mp4VideoRecorder.ts
+++ b/src/colorizer/recorders/Mp4VideoRecorder.ts
@@ -59,7 +59,7 @@ export default class Mp4VideoRecorder extends CanvasRecorder {
     const codecs: [string, "avc" | "vp9" | "av1"][] = [
       // 42 = baseline profile, 32 = level 5.0 (allows 128 MB/s max bitrate)
       ["avc1.420032", "avc"],
-      ["vp09.00.10.08", "vp9"],
+      ["vp09.01.10.08", "vp9"],
       ["av01.0.04M.08", "av1"],
     ];
     const accelerations: ("prefer-hardware" | "prefer-software")[] = ["prefer-hardware", "prefer-software"];

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -1,3 +1,4 @@
+import { message } from "antd";
 import {
   Color,
   FloatType,
@@ -199,3 +200,5 @@ export const getDefaultScatterPlotConfig = (): ScatterPlotConfig => ({
   yAxis: null,
   rangeType: PlotRangeType.ALL_TIME,
 });
+
+export type ReportWarningCallback = (message: string | string[]) => void;

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -206,3 +206,8 @@ export const getDefaultScatterPlotConfig = (): ScatterPlotConfig => ({
  * is provided for the description, each string should be displayed on a new line.
  */
 export type ReportWarningCallback = (message: string, description: string | string[]) => void;
+
+export enum LoadErrorMessage {
+  UNREACHABLE_MANIFEST = "The expected manifest JSON file could not be reached.",
+  UNREACHABLE_COLLECTION = "The expected collection JSON file could not be reached.",
+}

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -1,4 +1,3 @@
-import { message } from "antd";
 import {
   Color,
   FloatType,
@@ -201,4 +200,9 @@ export const getDefaultScatterPlotConfig = (): ScatterPlotConfig => ({
   rangeType: PlotRangeType.ALL_TIME,
 });
 
-export type ReportWarningCallback = (message: string | string[]) => void;
+/**
+ * Callback used to report warnings to the user. The message is the title
+ * of the warning, and the description is the body of the warning. If an array
+ * is provided for the description, each string should be displayed on a new line.
+ */
+export type ReportWarningCallback = (message: string, description: string | string[]) => void;

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -207,7 +207,20 @@ export const getDefaultScatterPlotConfig = (): ScatterPlotConfig => ({
  */
 export type ReportWarningCallback = (message: string, description: string | string[]) => void;
 
+export enum LoadTroubleshooting {
+  CHECK_NETWORK = "This may be due to a network issue, the server being unreachable, or a misconfigured URL." +
+    " Please check your network access.",
+  CHECK_FILE_EXISTS = "Please check if the file exists and if you have access to it, or see the developer console for more details.",
+  CHECK_FILE_OR_NETWORK = "This may be because of an unsupported format, missing files, or server and network issues. Please see the developer console for more details.",
+}
+
 export enum LoadErrorMessage {
   UNREACHABLE_MANIFEST = "The expected manifest JSON file could not be reached.",
   UNREACHABLE_COLLECTION = "The expected collection JSON file could not be reached.",
+  BOTH_UNREACHABLE = "Could not access either a collection or a dataset JSON at the provided URL.",
+  BOTH_404 = "Could not load the provided URL as either a collection or a dataset. Server returned a 404 (Not Found) code.",
+  COLLECTION_HAS_NO_DATASETS = "Collection JSON was loaded but no datasets were found. At least one dataset must be defined in the collection.",
+  MANIFEST_HAS_NO_FEATURES = "The dataset's manifest JSON was loaded but no features were found. At least one feature must be defined.",
+  COLLECTION_JSON_PARSE_FAILED = "Parsing failed for the collections JSON file with the following error. Please check that the JSON syntax is correct: ",
+  MANIFEST_JSON_PARSE_FAILED = "Parsing failed for the manifest JSON file with the following error. Please check that the JSON syntax is correct: ",
 }

--- a/src/colorizer/utils/data_utils.ts
+++ b/src/colorizer/utils/data_utils.ts
@@ -143,3 +143,11 @@ export function getInRangeLUT(dataset: Dataset, thresholds: FeatureThreshold[]):
 export function getKeyFromName(name: string): string {
   return name.toLowerCase().replaceAll(/[^a-z0-9_]/g, "_");
 }
+
+/** Changes the first letter of a string to lower case. */
+export function uncapitalizeFirstLetter(str: string): string {
+  if (!str) {
+    return str;
+  }
+  return str.charAt(0).toLowerCase() + str.slice(1);
+}

--- a/src/colorizer/utils/data_utils.ts
+++ b/src/colorizer/utils/data_utils.ts
@@ -151,3 +151,21 @@ export function uncapitalizeFirstLetter(str: string): string {
   }
   return str.charAt(0).toLowerCase() + str.slice(1);
 }
+
+/**
+ * Formats a list of string items as a bulleted list, with an optional maximum number of items to display.
+ * If the maximum count is exceeded, the list will be truncated and add a message indicating the number of items omitted.
+ * @param items String list of items to format.
+ * @param maxDisplayCount Maximum number of items to display. Default is `Number.POSITIVE_INFINITY`.
+ * @returns A list of string items formatted as a bulleted list, with the prefix " - ".
+ */
+export function formatAsBulletList(items: string[], maxDisplayCount: number = Number.POSITIVE_INFINITY): string[] {
+  const itemDisplayText = [];
+  for (let i = 0; i < Math.min(maxDisplayCount, items.length); i++) {
+    itemDisplayText.push(` - ${items[i]}`);
+  }
+  if (items.length > maxDisplayCount) {
+    itemDisplayText.push(` - ...and ${items.length - 5} more.`);
+  }
+  return itemDisplayText;
+}

--- a/src/colorizer/utils/dataset_utils.ts
+++ b/src/colorizer/utils/dataset_utils.ts
@@ -95,7 +95,11 @@ export type AnyManifestFile = ManifestFileV0_0_0 | ManifestFileV1_0_0 | Manifest
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function isV0_0_0(manifest: AnyManifestFile): manifest is ManifestFileV0_0_0 {
-  return typeof Object.values(manifest.features)[0] === "string";
+  if (!manifest.features) {
+    throw new Error("Manifest JSON is missing the required 'features' field.");
+  }
+  const values = Object.values(manifest.features);
+  return values.length === 0 || typeof values[0] === "string";
 }
 
 /**
@@ -107,7 +111,7 @@ export const updateManifestVersion = (manifest: AnyManifestFile): ManifestFile =
   if (isV0_0_0(manifest)) {
     // Parse feature metadata into the new features format
     const features: ManifestFile["features"] = [];
-    for (const [featureName, featurePath] of Object.entries(manifest.features)) {
+    for (const [featureName, featurePath] of Object.entries(manifest.features || {})) {
       const featureMetadata = manifest.featureMetadata?.[featureName];
       features.push({
         name: featureName,

--- a/src/colorizer/utils/dataset_utils.ts
+++ b/src/colorizer/utils/dataset_utils.ts
@@ -95,9 +95,6 @@ export type AnyManifestFile = ManifestFileV0_0_0 | ManifestFileV1_0_0 | Manifest
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function isV0_0_0(manifest: AnyManifestFile): manifest is ManifestFileV0_0_0 {
-  if (!manifest.features) {
-    throw new Error("Manifest JSON is missing the required 'features' field.");
-  }
   const values = Object.values(manifest.features);
   return values.length === 0 || typeof values[0] === "string";
 }
@@ -108,10 +105,13 @@ function isV0_0_0(manifest: AnyManifestFile): manifest is ManifestFileV0_0_0 {
  * @returns An object with fields reflecting the most recent ManifestFile spec.
  */
 export const updateManifestVersion = (manifest: AnyManifestFile): ManifestFile => {
+  if (!manifest.features) {
+    throw new Error("Manifest JSON is missing the required 'features' field.");
+  }
   if (isV0_0_0(manifest)) {
     // Parse feature metadata into the new features format
     const features: ManifestFile["features"] = [];
-    for (const [featureName, featurePath] of Object.entries(manifest.features || {})) {
+    for (const [featureName, featurePath] of Object.entries(manifest.features)) {
       const featureMetadata = manifest.featureMetadata?.[featureName];
       features.push({
         name: featureName,

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -108,9 +108,9 @@ export async function fetchManifestJson(url: string): Promise<AnyManifestFile> {
   } catch (error) {
     console.error(`Fetching manifest JSON from url '${url}' failed with the following error:`, error);
     throw new Error(
-      `The expected manifest JSON file could not be reached. ` +
-        ` This may be due to a network issue, the server being unreachable, or a misconfigured URL.` +
-        ` Please check your network access.`
+      "The expected manifest JSON file could not be reached. " +
+        " This may be due to a network issue, the server being unreachable, or a misconfigured URL." +
+        " Please check your network access."
     );
   }
 
@@ -126,7 +126,7 @@ export async function fetchManifestJson(url: string): Promise<AnyManifestFile> {
   } catch (error) {
     console.error(`Failed to parse manifest file from url '${url}':`, error);
     throw new Error(
-      `Parsing failed for the manifest JSON file. Please check that the JSON syntax is correct: ` + error
+      "Parsing failed for the manifest JSON file. Please check that the JSON syntax is correct: " + error
     );
   }
 }

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -102,9 +102,31 @@ export function fetchWithTimeout(
  * Fetches a manifest JSON file from a given URL and returns the parsed JSON object.
  */
 export async function fetchManifestJson(url: string): Promise<AnyManifestFile> {
-  // TODO: Should this report error states if load failed?
-  const response = await fetchWithTimeout(url, DEFAULT_FETCH_TIMEOUT_MS);
-  return await JSON.parse(nanToNull(await response.text()));
+  let response;
+  try {
+    response = await fetchWithTimeout(url, DEFAULT_FETCH_TIMEOUT_MS);
+  } catch (error) {
+    console.error(`Failed to fetch manifest file from url '${url}':`, error);
+    throw new Error(
+      `Could not fetch expected manifest JSON file. Please check if the file exists and if you have network access to it, or see the developer console for more details.`
+    );
+  }
+
+  if (response.status !== 200) {
+    console.error(`Failed to fetch manifest file from url '${url}':`, response);
+    throw new Error(
+      `Received a ${response.status} (${response.statusText}) code from the server while retrieving manifest JSON. Please check if the file exists and if you have network access to it, or see the developer console for more details.`
+    );
+  }
+
+  try {
+    return await JSON.parse(nanToNull(await response.text()));
+  } catch (error) {
+    console.error(`Failed to parse manifest file from url '${url}':`, error);
+    throw new Error(
+      `Parsing failed for the manifest JSON file. Please check that the JSON syntax is correct: ` + error
+    );
+  }
 }
 
 /**

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -16,6 +16,7 @@ import {
   isDrawMode,
   isTabType,
   isThresholdCategorical,
+  LoadErrorMessage,
   PlotRangeType,
   ScatterPlotConfig,
   ThresholdType,
@@ -108,7 +109,7 @@ export async function fetchManifestJson(url: string): Promise<AnyManifestFile> {
   } catch (error) {
     console.error(`Fetching manifest JSON from url '${url}' failed with the following error:`, error);
     throw new Error(
-      "The expected manifest JSON file could not be reached. " +
+      LoadErrorMessage.UNREACHABLE_MANIFEST +
         " This may be due to a network issue, the server being unreachable, or a misconfigured URL." +
         " Please check your network access."
     );

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -106,16 +106,18 @@ export async function fetchManifestJson(url: string): Promise<AnyManifestFile> {
   try {
     response = await fetchWithTimeout(url, DEFAULT_FETCH_TIMEOUT_MS);
   } catch (error) {
-    console.error(`Failed to fetch manifest file from url '${url}':`, error);
+    console.error(`Fetching manifest JSON from url '${url}' failed with the following error:`, error);
     throw new Error(
-      `Could not fetch expected manifest JSON file. Please check if the file exists and if you have network access to it, or see the developer console for more details.`
+      `The expected manifest JSON file could not be reached. ` +
+        ` This may be due to a network issue, the server being unreachable, or a misconfigured URL.` +
+        ` Please check your network access.`
     );
   }
 
   if (!response.ok) {
     console.error(`Failed to fetch manifest file from url '${url}':`, response);
     throw new Error(
-      `Received a ${response.status} (${response.statusText}) code from the server while retrieving manifest JSON. Please check if the file exists and if you have network access to it, or see the developer console for more details.`
+      `Received a ${response.status} (${response.statusText}) code from the server while retrieving manifest JSON. Please check if the file exists and if you have access to it, or see the developer console for more details.`
     );
   }
 

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -112,7 +112,7 @@ export async function fetchManifestJson(url: string): Promise<AnyManifestFile> {
     );
   }
 
-  if (response.status !== 200) {
+  if (!response.ok) {
     console.error(`Failed to fetch manifest file from url '${url}':`, response);
     throw new Error(
       `Received a ${response.status} (${response.statusText}) code from the server while retrieving manifest JSON. Please check if the file exists and if you have network access to it, or see the developer console for more details.`

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -17,6 +17,7 @@ import {
   isTabType,
   isThresholdCategorical,
   LoadErrorMessage,
+  LoadTroubleshooting,
   PlotRangeType,
   ScatterPlotConfig,
   ThresholdType,
@@ -108,17 +109,13 @@ export async function fetchManifestJson(url: string): Promise<AnyManifestFile> {
     response = await fetchWithTimeout(url, DEFAULT_FETCH_TIMEOUT_MS);
   } catch (error) {
     console.error(`Fetching manifest JSON from url '${url}' failed with the following error:`, error);
-    throw new Error(
-      LoadErrorMessage.UNREACHABLE_MANIFEST +
-        " This may be due to a network issue, the server being unreachable, or a misconfigured URL." +
-        " Please check your network access."
-    );
+    throw new Error(LoadErrorMessage.UNREACHABLE_MANIFEST + " " + LoadTroubleshooting.CHECK_NETWORK);
   }
 
   if (!response.ok) {
     console.error(`Failed to fetch manifest file from url '${url}':`, response);
     throw new Error(
-      `Received a ${response.status} (${response.statusText}) code from the server while retrieving manifest JSON. Please check if the file exists and if you have access to it, or see the developer console for more details.`
+      `Received a ${response.status} (${response.statusText}) code from the server while retrieving manifest JSON. ${LoadTroubleshooting.CHECK_FILE_EXISTS}`
     );
   }
 
@@ -126,9 +123,7 @@ export async function fetchManifestJson(url: string): Promise<AnyManifestFile> {
     return await JSON.parse(nanToNull(await response.text()));
   } catch (error) {
     console.error(`Failed to parse manifest file from url '${url}':`, error);
-    throw new Error(
-      "Parsing failed for the manifest JSON file. Please check that the JSON syntax is correct: " + error
-    );
+    throw new Error(LoadErrorMessage.MANIFEST_JSON_PARSE_FAILED + error);
   }
 }
 

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -131,13 +131,13 @@ export async function fetchManifestJson(url: string): Promise<AnyManifestFile> {
 
 /**
  * Returns the value of a promise if it was resolved, or logs a warning and returns null if it was rejected.
- * TODO: Pass in a callback to handle the error case instead of just logging a warning.
  */
-export function getPromiseValue<T>(promise: PromiseSettledResult<T>, failureWarning?: string): T | null {
+export function getPromiseValue<T>(
+  promise: PromiseSettledResult<T>,
+  onFailure?: (rejectionReason: any) => void
+): T | null {
   if (promise.status === "rejected") {
-    if (failureWarning) {
-      console.warn(failureWarning, promise.reason);
-    }
+    onFailure?.(promise.reason);
     return null;
   }
   return promise.value;

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -47,7 +47,7 @@ const theme = {
     text: {
       primary: palette.gray60,
       secondary: palette.gray50,
-      hint: palette.gray30,
+      hint: palette.gray40,
       disabled: palette.gray30,
       button: palette.gray0,
       error: palette.error,

--- a/src/components/Banner/AlertBanner.tsx
+++ b/src/components/Banner/AlertBanner.tsx
@@ -66,6 +66,21 @@ const StyledAlert = styled(Alert)<{ type: "info" | "warning" | "error" | "succes
   }
 `;
 
+const ReadMoreButton = styled(Button)`
+  padding: 0px;
+  margin: 0 10px 0 0;
+  border: 0;
+  color: var(--color-text-link);
+
+  &:hover {
+    color: var(--color-text-link-hover);
+  }
+
+  &:focus {
+    text-decoration: underline;
+  }
+`;
+
 export type AlertBannerProps = Spread<
   Omit<AlertProps, "onClose" | "afterClose" | "message" | "description" | "banner"> & {
     message: string;
@@ -134,13 +149,9 @@ export default function AlertBanner(props: AlertBannerProps): ReactElement {
       <FlexRowAlignCenter $wrap={"wrap"} $gap={4}>
         <h3 style={{ margin: 0 }}>{props.message}</h3>
         {!showFullContent && (
-          <Button
-            type="link"
-            style={{ padding: "0px", margin: "0 10px 0 0", border: 0, color: "var(--color-text-link)" }}
-            onClick={() => setShowFullContent(true)}
-          >
+          <ReadMoreButton type="link" onClick={() => setShowFullContent(true)}>
             <h3>Read More</h3>
-          </Button>
+          </ReadMoreButton>
         )}
       </FlexRowAlignCenter>
       {showFullContent && <FlexColumn>{description}</FlexColumn>}

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -7,7 +7,7 @@ import { clamp } from "three/src/math/MathUtils";
 
 import { NoImageSVG } from "../assets";
 import { ColorRamp, Dataset, Track } from "../colorizer";
-import { ViewerConfig } from "../colorizer/types";
+import { LoadTroubleshooting, ViewerConfig } from "../colorizer/types";
 import * as mathUtils from "../colorizer/utils/math_utils";
 import { FlexColumn, FlexColumnAlignCenter, VisuallyHidden } from "../styles/utils";
 
@@ -169,8 +169,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
         props.showAlert({
           type: "warning",
           message: "Warning: One or more frames failed to load.",
-          description:
-            "Check your network connection and access to the dataset path, or use the browser console to view details. Otherwise, contact the dataset creator as there may be missing files.",
+          description: LoadTroubleshooting.CHECK_FILE_OR_NETWORK,
           showDoNotShowAgainCheckbox: true,
           closable: true,
         });

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -6,6 +6,7 @@ import styled from "styled-components";
 import { useClickAnyWhere } from "usehooks-ts";
 
 import { Dataset } from "../colorizer";
+import { ReportWarningCallback } from "../colorizer/types";
 import { useRecentCollections } from "../colorizer/utils/react_utils";
 import { convertAllenPathToHttps, isAllenPath } from "../colorizer/utils/url_utils";
 
@@ -24,6 +25,7 @@ type LoadDatasetButtonProps = {
   onLoad: (collection: Collection, datasetKey: string, dataset: Dataset) => void;
   /** The URL of the currently loaded resource, used to indicate it on the recent datasets dropdown. */
   currentResourceUrl: string;
+  reportWarning?: ReportWarningCallback;
 };
 
 const defaultProps: Partial<LoadDatasetButtonProps> = {};
@@ -86,9 +88,13 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
     if (typeof newErrorText === "string") {
       const splitText = newErrorText.split("\n");
       _setErrorText(
-        splitText.map((text) => {
+        splitText.map((text, index) => {
           const hasIndent = text.startsWith("\t");
-          return <p style={{ marginLeft: hasIndent ? "30px" : "" }}>{text}</p>;
+          return (
+            <p key={index} style={{ marginLeft: hasIndent ? "30px" : "" }}>
+              {text}
+            </p>
+          );
         })
       );
     } else {
@@ -131,7 +137,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
    */
   const handleLoadRequest = async (url: string): Promise<[string, Collection, Dataset]> => {
     console.log("Loading '" + url + "'.");
-    const newCollection = await Collection.loadFromAmbiguousUrl(url);
+    const newCollection = await Collection.loadFromAmbiguousUrl(url, { reportWarning: props.reportWarning });
     const newDatasetKey = newCollection.getDefaultDatasetKey();
     const loadResult = await newCollection.tryLoadDataset(newDatasetKey);
     if (!loadResult.loaded) {

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -88,14 +88,11 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
     if (typeof newErrorText === "string") {
       const splitText = newErrorText.split("\n");
       _setErrorText(
-        splitText.map((text, index) => {
-          const hasIndent = text.startsWith("\t");
-          return (
-            <p key={index} style={{ marginLeft: hasIndent ? "30px" : "" }}>
-              {text}
-            </p>
-          );
-        })
+        splitText.map((text, index) => (
+          <p key={index} style={{ marginBottom: "8px" }}>
+            {text}
+          </p>
+        ))
       );
     } else {
       _setErrorText(newErrorText);

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -81,7 +81,20 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
   const [recentCollections, registerCollection] = useRecentCollections();
 
   const [isLoading, setIsLoading] = useState(false);
-  const [errorText, setErrorText] = useState<string>("");
+  const [errorText, _setErrorText] = useState<ReactNode>("");
+  const setErrorText = useCallback((newErrorText: ReactNode) => {
+    if (typeof newErrorText === "string") {
+      const splitText = newErrorText.split("\n");
+      _setErrorText(
+        splitText.map((text) => {
+          const hasIndent = text.startsWith("\t");
+          return <p style={{ marginLeft: hasIndent ? "30px" : "" }}>{text}</p>;
+        })
+      );
+    } else {
+      _setErrorText(newErrorText);
+    }
+  }, []);
 
   const [isLoadModalOpen, setIsLoadModalOpen] = useState(false);
 

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -88,6 +88,9 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
     if (typeof newErrorText === "string") {
       const splitText = newErrorText.split("\n");
       _setErrorText(
+        // TODO: Add parsing and formatting for bullet points as `ul` and `li` elements.
+        // This should be handled in all areas where we print error messages directly onscreen
+        // e.g. AlertBanner, popup handlers in Viewer, and here.
         splitText.map((text, index) => (
           <p key={index} style={{ marginBottom: "8px" }}>
             {text}

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -282,7 +282,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
           <div ref={dropdownContextRef} style={{ position: "relative" }}>
             <p>
               <i>
-                <span style={{ color: theme.color.text.hint }}> Click below to show recent datasets</span>
+                <span style={{ color: theme.color.text.hint }}> Click to show recent datasets</span>
               </i>
             </p>
             <div style={{ display: "flex", flexDirection: "row", gap: "6px" }}>

--- a/src/components/SpinBox.module.css
+++ b/src/components/SpinBox.module.css
@@ -5,7 +5,8 @@
 
   position: relative;
   height: calc(var(--button-height-small) - 2px);
-  width: 80px;
+  width: 100%;
+  max-width: 80px;
   min-width: 80px;
 
   display: flex;

--- a/src/components/SpinBox.tsx
+++ b/src/components/SpinBox.tsx
@@ -18,6 +18,7 @@ type SpinBoxProps = {
    * will do nothing, and values will be clamped to the min/max.
    */
   wrapIncrement?: boolean;
+  width?: string;
 };
 
 const defaultProps: Partial<SpinBoxProps> = {
@@ -102,7 +103,10 @@ export default function SpinBox(propsInput: SpinBoxProps): ReactElement {
   }, []);
 
   return (
-    <div className={styles.spinBox + " " + (props.disabled ? styles.disabled : "")}>
+    <div
+      className={styles.spinBox + " " + (props.disabled ? styles.disabled : "")}
+      style={props.width ? { maxWidth: props.width } : undefined}
+    >
       <input
         type="number"
         min={props.min}

--- a/src/components/Tabs/ScatterPlotTab.tsx
+++ b/src/components/Tabs/ScatterPlotTab.tsx
@@ -1,7 +1,7 @@
 import { Button, Tooltip } from "antd";
 import { MenuItemType } from "antd/es/menu/hooks/useItems";
 import Plotly, { PlotData, PlotMarker } from "plotly.js-dist-min";
-import React, { memo, ReactElement, useContext, useEffect, useRef, useState, useTransition } from "react";
+import React, { memo, ReactElement, useContext, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import styled from "styled-components";
 import { Color, ColorRepresentation, HexColorString } from "three";
 
@@ -127,6 +127,15 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
   const dataset = useDebounce(props.dataset, 500);
   const colorRampMin = useDebounce(props.colorRampMin, 100);
   const colorRampMax = useDebounce(props.colorRampMax, 100);
+
+  useMemo(() => {
+    if (props.scatterPlotConfig.xAxis === null && props.scatterPlotConfig.yAxis === null && props.selectedFeatureKey) {
+      props.updateScatterPlotConfig({
+        yAxis: props.selectedFeatureKey,
+        xAxis: SCATTERPLOT_TIME_FEATURE.key,
+      });
+    }
+  }, [props.selectedFeatureKey]);
 
   // Trigger render spinner when playback starts, but only if the render is being delayed.
   // If a render is allowed to happen (such as in the current-track- or current-frame-only

--- a/tests/Collection.test.ts
+++ b/tests/Collection.test.ts
@@ -77,7 +77,7 @@ describe("Collection", () => {
         it("collects datasets", async () => {
           const url = "https://e.com/collection.json";
           const mockFetch = makeMockFetchMethod(url, collectionJson);
-          const collection = await Collection.loadCollection(url, mockFetch);
+          const collection = await Collection.loadCollection(url, { fetchMethod: mockFetch });
 
           expect(collection.getDatasetKeys().length).to.equal(datasets.length);
           expect(collection.getDatasetKeys()).to.deep.equal([
@@ -92,7 +92,7 @@ describe("Collection", () => {
         it("should parse dataset paths correctly", async () => {
           const url = "https://e.com/collection.json/";
           const mockFetch = makeMockFetchMethod("https://e.com/collection.json", collectionJson);
-          const collection = await Collection.loadCollection(url, mockFetch);
+          const collection = await Collection.loadCollection(url, { fetchMethod: mockFetch });
 
           expect(collection.getAbsoluteDatasetPath("dataset1")).to.equal("https://e.com/dir1/manifest.json");
           expect(collection.getAbsoluteDatasetPath("dataset2")).to.equal(
@@ -106,7 +106,7 @@ describe("Collection", () => {
         it("retrieves metadata", async () => {
           const url = "https://e.com/collection.json";
           const mockFetch = makeMockFetchMethod(url, collectionJson);
-          const collection = await Collection.loadCollection(url, mockFetch);
+          const collection = await Collection.loadCollection(url, { fetchMethod: mockFetch });
 
           if (version === "v0.0.0") {
             expect(collection.metadata).deep.equals({});
@@ -129,7 +129,7 @@ describe("Collection", () => {
     it("returns an empty metadata object for v0.0.0", async () => {
       const url = "https://e.com/collection.json";
       const mockFetch = makeMockFetchMethod(url, collectionFormats[0].collectionJson);
-      const collection = await Collection.loadCollection(url, mockFetch);
+      const collection = await Collection.loadCollection(url, { fetchMethod: mockFetch });
 
       expect(collection.metadata).deep.equals({});
     });
@@ -139,21 +139,21 @@ describe("Collection", () => {
       // Will only allow this exact fetch URL or else it will throw an error
       const mockFetch = makeMockFetchMethod("https://e.com/" + DEFAULT_COLLECTION_FILENAME, [{ name: "", path: "" }]);
 
-      await Collection.loadCollection(url, mockFetch);
+      await Collection.loadCollection(url, { fetchMethod: mockFetch });
     });
 
     it("Throws an error when loading a collection with no datasets", async () => {
       const url = "https://e.com/collection.json";
       const mockFetch = makeMockFetchMethod(url, { datasets: [] });
-      const tryLoad = Collection.loadCollection(url, mockFetch);
+      const tryLoad = Collection.loadCollection(url, { fetchMethod: mockFetch });
       expect(tryLoad).rejects.toMatch(ANY_ERROR);
     });
   });
 
-  describe("makeCollectionFromSingleDataset", () => {
-    it("makes a collection with indirect dataset paths", () => {
+  describe("makeCollectionFromSingleDataset", async () => {
+    it("makes a collection with indirect dataset paths", async () => {
       const datasetPath = "http://website.com/data";
-      const collection = Collection.makeCollectionFromSingleDataset(datasetPath);
+      const collection = await Collection.makeCollectionFromSingleDataset(datasetPath);
       const fullPath = datasetPath + "/" + DEFAULT_DATASET_FILENAME;
 
       expect(collection.getDatasetKeys().length).to.equal(1);
@@ -161,18 +161,18 @@ describe("Collection", () => {
       expect(collection.getAbsoluteDatasetPath(fullPath)).to.equal(fullPath);
     });
 
-    it("makes a collection with absolute dataset paths", () => {
+    it("makes a collection with absolute dataset paths", async () => {
       const datasetPath = "http://website.com/data/some-manifest.json";
-      const collection = Collection.makeCollectionFromSingleDataset(datasetPath);
+      const collection = await Collection.makeCollectionFromSingleDataset(datasetPath);
 
       expect(collection.getDatasetKeys().length).to.equal(1);
       expect(collection.hasDataset(datasetPath)).to.be.true;
       expect(collection.getAbsoluteDatasetPath(datasetPath)).to.equal(datasetPath);
     });
 
-    it("sets the URL to null", () => {
+    it("sets the URL to null", async () => {
       const datasetPath = "http://website.com/data/some-manifest.json";
-      const collection = Collection.makeCollectionFromSingleDataset(datasetPath);
+      const collection = await Collection.makeCollectionFromSingleDataset(datasetPath);
 
       expect(collection.url).to.be.null;
     });

--- a/tests/Collection.test.ts
+++ b/tests/Collection.test.ts
@@ -150,10 +150,10 @@ describe("Collection", () => {
     });
   });
 
-  describe("makeCollectionFromSingleDataset", async () => {
-    it("makes a collection with indirect dataset paths", async () => {
+  describe("makeCollectionFromSingleDataset", () => {
+    it("makes a collection with indirect dataset paths", () => {
       const datasetPath = "http://website.com/data";
-      const collection = await Collection.makeCollectionFromSingleDataset(datasetPath);
+      const collection = Collection.makeCollectionFromSingleDataset(datasetPath);
       const fullPath = datasetPath + "/" + DEFAULT_DATASET_FILENAME;
 
       expect(collection.getDatasetKeys().length).to.equal(1);
@@ -161,18 +161,18 @@ describe("Collection", () => {
       expect(collection.getAbsoluteDatasetPath(fullPath)).to.equal(fullPath);
     });
 
-    it("makes a collection with absolute dataset paths", async () => {
+    it("makes a collection with absolute dataset paths", () => {
       const datasetPath = "http://website.com/data/some-manifest.json";
-      const collection = await Collection.makeCollectionFromSingleDataset(datasetPath);
+      const collection = Collection.makeCollectionFromSingleDataset(datasetPath);
 
       expect(collection.getDatasetKeys().length).to.equal(1);
       expect(collection.hasDataset(datasetPath)).to.be.true;
       expect(collection.getAbsoluteDatasetPath(datasetPath)).to.equal(datasetPath);
     });
 
-    it("sets the URL to null", async () => {
+    it("sets the URL to null", () => {
       const datasetPath = "http://website.com/data/some-manifest.json";
-      const collection = await Collection.makeCollectionFromSingleDataset(datasetPath);
+      const collection = Collection.makeCollectionFromSingleDataset(datasetPath);
 
       expect(collection.url).to.be.null;
     });

--- a/tests/Export.test.tsx
+++ b/tests/Export.test.tsx
@@ -26,7 +26,7 @@ describe("ExportButton", () => {
       const exportButton = screen.getByRole("button");
       fireEvent.click(exportButton); // open modal
 
-      const prefixInput: HTMLInputElement = screen.getByLabelText(/[pP]refix/);
+      const prefixInput: HTMLInputElement = screen.getByLabelText(/[fF]ilename/);
       expect(prefixInput.value).to.equal("prefix-1-");
 
       rerender(makeExportButtonWithImagePrefix("prefix-2"));
@@ -38,7 +38,7 @@ describe("ExportButton", () => {
       const exportButton = screen.getByRole("button");
       fireEvent.click(exportButton); // open modal
 
-      const prefixInput: HTMLInputElement = screen.getByLabelText(/[pP]refix/);
+      const prefixInput: HTMLInputElement = screen.getByLabelText(/[fF]ilename/);
       fireEvent.input(prefixInput, { target: { value: "my new prefix" } });
       expect(prefixInput.value).to.equal("my new prefix");
 

--- a/tests/Export.test.tsx
+++ b/tests/Export.test.tsx
@@ -16,6 +16,7 @@ describe("ExportButton", () => {
             throw new Error("Function not implemented.");
           }}
           getCanvas={vi.fn()}
+          getCanvasExportDimensions={vi.fn()}
           currentFrame={0}
         />
       );


### PR DESCRIPTION
Problem
=======
Closes #411, "Show more informative errors when datasets fail to load".

This change adds additional catches for errors and adds more informative messages that can be shown to users. It also adds explicit onscreen warnings for issues that were previously only logged to the console.

*Estimated size: medium, 30 minutes*

Solution
========
- Added callbacks for errors and warnings in the Viewer which can be passed to the Collection + Dataset classes during load operations.
- Added server error handlers in file loaders for 404 errors, etc.
- Datasets can now load even when the times data is missing. (This causes the scatterplot and plot views to not work correctly.)

New warnings and errors:
- Added warnings for missing and duplicated feature and data files.
- Added explicit error messages for missing properties in collection and dataset files.
- The load dialog now displays error messages for both collection and dataset files when the file type is ambiguous.

## Type of change
* New feature (non-breaking change which adds functionality)

Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
Preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-453

| Name | Test Steps | Expected behavior/error message | 
| -- | -- | -- |
| 404 error | 1. Open the preview link and open the load dialog. <br/>2. Paste in this URL: https://dev-aics-dtp-001.int.allencell.org/dan-data/colorizer/data/test/bad-data/no-exist | "Error: Could not load the provided URL as either a collection or a dataset: server returned a 404 (Not Found) code." |
| Empty collection | 1. Open the preview link and open the load dialog. <br/>2. Paste in this URL: https://dev-aics-dtp-001.int.allencell.org/dan-data/colorizer/data/test/bad-data/empty-collection.json | "The collection JSON was loaded but no datasets were found. At least one dataset must be defined in the collection." |
| Duplicate collection keys | 1. Open this link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-453/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Ftest%2Fbad-data%2Fcollection-with-duplicates.json | You should see a warning banner with the text "Duplicate dataset names were found in the collection." |
| Bad manifest when loading datasets | 1. Open this link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-453/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Ftest%2Fbad-data%2Fcollection.json&dataset=Malformed+JSON+manifest | An error banner should appear instead of a popup warning about the dataset load issue |

More interactive examples here: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-453/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Ftest%2Fbad-data%2Fcollection.json

Screenshots (optional):
-----------------------


![image](https://github.com/user-attachments/assets/13066171-12f4-47d1-b84e-1dfdc4dda9da)


**Video talk-through (🔊):**

https://github.com/user-attachments/assets/039c6daf-974d-446a-9325-4a89c955fcab



