### PR TITLE
feature: Error and alert formatting

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -685,6 +685,10 @@ function Viewer(): ReactElement {
             description: result.errorMessage,
             placement: "bottomLeft",
             duration: 12,
+            style: {
+              backgroundColor: theme.color.alert.fill.error,
+              border: `1px solid ${theme.color.alert.border.error}`,
+            },
           });
         }
         setIsDatasetLoading(false);

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -802,6 +802,10 @@ function Viewer(): ReactElement {
       placement: "bottomLeft",
       duration: 4,
       icon: <CheckCircleOutlined style={{ color: theme.color.text.success }} />,
+      style: {
+        backgroundColor: theme.color.alert.fill.success,
+        border: `1px solid ${theme.color.alert.border.success}`,
+      },
     });
   };
 

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -534,7 +534,7 @@ function Viewer(): ReactElement {
         if (datasetParam && urlUtils.isUrl(datasetParam) && !collectionUrlParam) {
           // Dataset is a URL and no collection URL is provided;
           // Make a dummy collection that will include only this dataset
-          newCollection = Collection.makeCollectionFromSingleDataset(datasetParam);
+          newCollection = await Collection.makeCollectionFromSingleDataset(datasetParam);
           datasetKey = newCollection.getDefaultDatasetKey();
         } else {
           if (!collectionUrlParam) {

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -331,7 +331,7 @@ export default class Collection {
    * @returns a new Collection, where the only dataset is that of the provided `datasetUrl`.
    * The `url` field of the Collection will also be set to `null`.
    */
-  public static async makeCollectionFromSingleDataset(datasetUrl: string): Promise<Collection> {
+  public static makeCollectionFromSingleDataset(datasetUrl: string): Collection {
     // Add the default filename if the url is not a .JSON path.
     if (!isJson(datasetUrl)) {
       datasetUrl = formatPath(datasetUrl) + "/" + DEFAULT_DATASET_FILENAME;
@@ -419,7 +419,7 @@ export default class Collection {
     // Could not load as a collection, attempt to load as a dataset.
     if (!result) {
       try {
-        const collection = await Collection.makeCollectionFromSingleDataset(url);
+        const collection = Collection.makeCollectionFromSingleDataset(url);
         // Attempt to load the default dataset immediately to surface any loading errors.
         const loadResult = await collection.tryLoadDataset(collection.getDefaultDatasetKey());
         if (!loadResult.loaded) {

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -306,6 +306,7 @@ export default class Collection {
       throw new Error(LoadErrorMessage.COLLECTION_HAS_NO_DATASETS);
     }
     const collectionData: Map<string, CollectionEntry> = new Map();
+    const duplicateDatasetNames = new Set<string>();
     for (const entry of collection.datasets) {
       collectionData.set(entry.name, entry);
     }
@@ -331,7 +332,7 @@ export default class Collection {
    * @returns a new Collection, where the only dataset is that of the provided `datasetUrl`.
    * The `url` field of the Collection will also be set to `null`.
    */
-  public static makeCollectionFromSingleDataset(datasetUrl: string): Collection {
+  public static async makeCollectionFromSingleDataset(datasetUrl: string): Promise<Collection> {
     // Add the default filename if the url is not a .JSON path.
     if (!isJson(datasetUrl)) {
       datasetUrl = formatPath(datasetUrl) + "/" + DEFAULT_DATASET_FILENAME;
@@ -419,7 +420,7 @@ export default class Collection {
     // Could not load as a collection, attempt to load as a dataset.
     if (!result) {
       try {
-        const collection = Collection.makeCollectionFromSingleDataset(url);
+        const collection = await Collection.makeCollectionFromSingleDataset(url);
         // Attempt to load the default dataset immediately to surface any loading errors.
         const loadResult = await collection.tryLoadDataset(collection.getDefaultDatasetKey());
         if (!loadResult.loaded) {

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -306,7 +306,6 @@ export default class Collection {
       throw new Error(LoadErrorMessage.COLLECTION_HAS_NO_DATASETS);
     }
     const collectionData: Map<string, CollectionEntry> = new Map();
-    const duplicateDatasetNames = new Set<string>();
     for (const entry of collection.datasets) {
       collectionData.set(entry.name, entry);
     }

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -466,7 +466,7 @@ export default class Dataset {
       // Report warning of all the files that couldn't be loaded and their associated errors.
       options.reportWarning?.("Some data files failed to load.", [
         "The following data file(s) failed to load, which may cause the viewer to behave unexpectedly:",
-        ...unloadableDataFiles.map((fileType) => `  - ${fileType}`),
+        ...unloadableDataFiles.map((fileType) => ` - ${fileType}`),
         LoadTroubleshooting.CHECK_FILE_OR_NETWORK,
       ]);
     }

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -29,10 +29,14 @@ const palette = {
   link: "#0094FF",
   linkDark: "#007FD6",
   warning: "#faad14",
-  successLight: "#b7eb8f",
-  errorLight: "#ffa39e",
-  infoLight: "#91d5ff",
-  warningLight: "#ffe58f",
+  successMedium: "#b7eb8f",
+  successLight: "#f6ffed",
+  errorMedium: "#ffa39e",
+  errorLight: "#fff2f0",
+  infoMedium: "#91d5ff",
+  infoLight: "#e6f4ff",
+  warningMedium: "#ffe58f",
+  warningLight: "#fffbe6",
 };
 
 // Note: Some advanced version of this could swap different theme objects, and
@@ -93,10 +97,16 @@ const theme = {
     },
     alert: {
       border: {
-        info: palette.infoLight,
-        warning: palette.warningLight,
+        info: palette.infoMedium,
+        warning: palette.warningMedium,
+        error: palette.errorMedium,
+        success: palette.successMedium,
+      },
+      fill: {
         error: palette.errorLight,
+        warning: palette.warningLight,
         success: palette.successLight,
+        info: palette.infoLight,
       },
     },
   },
@@ -191,6 +201,10 @@ const CssContainer = styled.div`
   --color-alert-warning-border: ${theme.color.alert.border.warning};
   --color-alert-error-border: ${theme.color.alert.border.error};
   --color-alert-success-border: ${theme.color.alert.border.success};
+  --color-alert-error-fill: ${theme.color.alert.fill.error};
+  --color-alert-warning-fill: ${theme.color.alert.fill.warning};
+  --color-alert-success-fill: ${theme.color.alert.fill.success};
+  --color-alert-info-fill: ${theme.color.alert.fill.info};
 
   /* Fonts */
   --default-font: ${theme.font.family};

--- a/src/components/Banner/AlertBanner.tsx
+++ b/src/components/Banner/AlertBanner.tsx
@@ -4,6 +4,7 @@ import styled, { css } from "styled-components";
 
 import { Spread } from "../../colorizer/utils/type_utils";
 import { FlexColumn, FlexRowAlignCenter } from "../../styles/utils";
+import { renderStringArrayAsJsx } from "../../utils/formatting";
 
 // Adjusts alignment of items within the Alert.
 // Alerts are structured like this:
@@ -129,21 +130,7 @@ export default function AlertBanner(props: AlertBannerProps): ReactElement {
     newProps.closable = true;
   }
 
-  const propsDescription = props.description;
-  let description: ReactElement | undefined = undefined;
-  if (Array.isArray(propsDescription) && propsDescription.length > 0) {
-    description = (
-      <>
-        {propsDescription.map((text: string, index: number) => (
-          <p key={index}>{text}</p>
-        ))}
-      </>
-    );
-  } else if (!Array.isArray(propsDescription) && propsDescription) {
-    // Ignore empty text or undefined
-    description = <p>{propsDescription}</p>;
-  }
-
+  const description = renderStringArrayAsJsx(props.description);
   const message = (
     <FlexColumn>
       <FlexRowAlignCenter $wrap={"wrap"} $gap={4}>

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -9,6 +9,7 @@ import { Dataset } from "../colorizer";
 import { ReportWarningCallback } from "../colorizer/types";
 import { useRecentCollections } from "../colorizer/utils/react_utils";
 import { convertAllenPathToHttps, isAllenPath } from "../colorizer/utils/url_utils";
+import { renderStringArrayAsJsx } from "../utils/formatting";
 
 import Collection from "../colorizer/Collection";
 import { AppThemeContext } from "./AppStyle";
@@ -87,16 +88,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
   const setErrorText = useCallback((newErrorText: ReactNode) => {
     if (typeof newErrorText === "string") {
       const splitText = newErrorText.split("\n");
-      _setErrorText(
-        // TODO: Add parsing and formatting for bullet points as `ul` and `li` elements.
-        // This should be handled in all areas where we print error messages directly onscreen
-        // e.g. AlertBanner, popup handlers in Viewer, and here.
-        splitText.map((text, index) => (
-          <p key={index} style={{ marginBottom: "8px" }}>
-            {text}
-          </p>
-        ))
-      );
+      _setErrorText(renderStringArrayAsJsx(splitText));
     } else {
       _setErrorText(newErrorText);
     }

--- a/src/utils/formatting.tsx
+++ b/src/utils/formatting.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ReactElement, ReactNode } from "react";
 import styled from "styled-components";
 
 export const RenderedStringContainer = styled.div`
@@ -22,9 +22,9 @@ export const RenderedStringContainer = styled.div`
  * will be wrapped in a unordered list (`ul`) element.
  * - Otherwise, the item is wrapped in a `p` element.
  */
-export function renderStringArrayAsJsx(items: string[] | string | undefined): ReactNode {
-  if (!items) {
-    return undefined;
+export function renderStringArrayAsJsx(items: string[] | string | undefined): ReactElement {
+  if (!items || items.length === 0) {
+    return <></>;
   }
   if (typeof items === "string") {
     return (

--- a/src/utils/formatting.tsx
+++ b/src/utils/formatting.tsx
@@ -1,0 +1,54 @@
+import React, { ReactNode } from "react";
+import styled from "styled-components";
+
+export const RenderedStringContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+
+  & > p,
+  & > ul {
+    margin: 0;
+  }
+`;
+
+/**
+ * Renders a text string array as JSX elements, handling formatting for lists and paragraph text.
+ * @param items List of string text items to render.
+ * @param containerStyle optional CSS properties object that will be applied to the container div.
+ * @returns A list of one or more text elements, wrapped in a styled div.
+ * String items will be returned as one of the following:
+ * - If it starts with ` - `, the item will be rendered as a `li` element. Groups of `li` elements will be wrapped in a `ul` element.
+ * - Otherwise, the item is wrapped in a `p` element.
+ */
+export function renderStringArrayAsJsx(items: string[] | string | undefined): ReactNode {
+  if (!items) {
+    return undefined;
+  }
+  if (typeof items === "string") {
+    return <p>{items}</p>;
+  }
+
+  const elements: ReactNode[] = [];
+  let listElements: ReactNode[] = [];
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (item.startsWith(" - ")) {
+      listElements.push(<li key={listElements.length}>{item.substring(3)}</li>);
+      continue;
+    } else {
+      if (listElements.length > 0) {
+        elements.push(<ul key={i - 1}>{listElements}</ul>);
+        listElements = [];
+      }
+      elements.push(<p key={i}>{item}</p>);
+    }
+  }
+
+  if (listElements.length > 0) {
+    elements.push(<ul key={items.length}>{listElements}</ul>);
+  }
+
+  return <RenderedStringContainer>{elements}</RenderedStringContainer>;
+}

--- a/src/utils/formatting.tsx
+++ b/src/utils/formatting.tsx
@@ -22,9 +22,9 @@ export const RenderedStringContainer = styled.div`
  * will be wrapped in a unordered list (`ul`) element.
  * - Otherwise, the item is wrapped in a `p` element.
  */
-export function renderStringArrayAsJsx(items: string[] | string | undefined): ReactElement {
+export function renderStringArrayAsJsx(items: string[] | string | undefined): ReactElement | undefined {
   if (!items || items.length === 0) {
-    return <></>;
+    return undefined;
   }
   if (typeof items === "string") {
     return (
@@ -41,7 +41,6 @@ export function renderStringArrayAsJsx(items: string[] | string | undefined): Re
     const item = items[i].trim();
     if (item.startsWith("- ")) {
       currListElements.push(<li key={currListElements.length}>{item.substring(2)}</li>);
-      continue;
     } else {
       if (currListElements.length > 0) {
         elements.push(<ul key={i - 1}>{currListElements}</ul>);

--- a/src/utils/formatting.tsx
+++ b/src/utils/formatting.tsx
@@ -13,12 +13,12 @@ export const RenderedStringContainer = styled.div`
 `;
 
 /**
- * Renders a text string array as JSX elements, handling formatting for lists and paragraph text.
+ * Renders a text string array as JSX react elements, handling formatting for lists and paragraph text.
  * @param items List of string text items to render.
  * @param containerStyle optional CSS properties object that will be applied to the container div.
  * @returns A list of one or more text elements, wrapped in a styled div.
  * String items will be returned as one of the following:
- * - If it starts with ` - `, the item will be rendered as a `li` element. Groups of `li` elements will be wrapped in a `ul` element.
+ * - If it starts with "- ", the item will be rendered as a `li` element. Groups of `li` elements will be wrapped in a `ul` element.
  * - Otherwise, the item is wrapped in a `p` element.
  */
 export function renderStringArrayAsJsx(items: string[] | string | undefined): ReactNode {
@@ -33,9 +33,9 @@ export function renderStringArrayAsJsx(items: string[] | string | undefined): Re
   let listElements: ReactNode[] = [];
 
   for (let i = 0; i < items.length; i++) {
-    const item = items[i];
-    if (item.startsWith(" - ")) {
-      listElements.push(<li key={listElements.length}>{item.substring(3)}</li>);
+    const item = items[i].trim();
+    if (item.startsWith("- ")) {
+      listElements.push(<li key={listElements.length}>{item.substring(2)}</li>);
       continue;
     } else {
       if (listElements.length > 0) {

--- a/src/utils/formatting.tsx
+++ b/src/utils/formatting.tsx
@@ -16,9 +16,10 @@ export const RenderedStringContainer = styled.div`
  * Renders a text string array as JSX react elements, handling formatting for lists and paragraph text.
  * @param items List of string text items to render.
  * @param containerStyle optional CSS properties object that will be applied to the container div.
- * @returns A list of one or more text elements, wrapped in a styled div.
+ * @returns A list of one or more text elements, wrapped in a styling div.
  * String items will be returned as one of the following:
- * - If it starts with "- ", the item will be rendered as a `li` element. Groups of `li` elements will be wrapped in a `ul` element.
+ * - If it starts with "- ", the item will be rendered as a list item (`li`) element. Groups of `li` elements
+ * will be wrapped in a unordered list (`ul`) element.
  * - Otherwise, the item is wrapped in a `p` element.
  */
 export function renderStringArrayAsJsx(items: string[] | string | undefined): ReactNode {
@@ -26,28 +27,32 @@ export function renderStringArrayAsJsx(items: string[] | string | undefined): Re
     return undefined;
   }
   if (typeof items === "string") {
-    return <p>{items}</p>;
+    return (
+      <RenderedStringContainer>
+        <p>{items}</p>;
+      </RenderedStringContainer>
+    );
   }
 
   const elements: ReactNode[] = [];
-  let listElements: ReactNode[] = [];
+  let currListElements: ReactNode[] = [];
 
   for (let i = 0; i < items.length; i++) {
     const item = items[i].trim();
     if (item.startsWith("- ")) {
-      listElements.push(<li key={listElements.length}>{item.substring(2)}</li>);
+      currListElements.push(<li key={currListElements.length}>{item.substring(2)}</li>);
       continue;
     } else {
-      if (listElements.length > 0) {
-        elements.push(<ul key={i - 1}>{listElements}</ul>);
-        listElements = [];
+      if (currListElements.length > 0) {
+        elements.push(<ul key={i - 1}>{currListElements}</ul>);
+        currListElements = [];
       }
       elements.push(<p key={i}>{item}</p>);
     }
   }
 
-  if (listElements.length > 0) {
-    elements.push(<ul key={items.length}>{listElements}</ul>);
+  if (currListElements.length > 0) {
+    elements.push(<ul key={items.length}>{currListElements}</ul>);
   }
 
   return <RenderedStringContainer>{elements}</RenderedStringContainer>;

--- a/tests/Collection.test.ts
+++ b/tests/Collection.test.ts
@@ -150,10 +150,10 @@ describe("Collection", () => {
     });
   });
 
-  describe("makeCollectionFromSingleDataset", () => {
-    it("makes a collection with indirect dataset paths", () => {
+  describe("makeCollectionFromSingleDataset", async () => {
+    it("makes a collection with indirect dataset paths", async () => {
       const datasetPath = "http://website.com/data";
-      const collection = Collection.makeCollectionFromSingleDataset(datasetPath);
+      const collection = await Collection.makeCollectionFromSingleDataset(datasetPath);
       const fullPath = datasetPath + "/" + DEFAULT_DATASET_FILENAME;
 
       expect(collection.getDatasetKeys().length).to.equal(1);
@@ -161,18 +161,18 @@ describe("Collection", () => {
       expect(collection.getAbsoluteDatasetPath(fullPath)).to.equal(fullPath);
     });
 
-    it("makes a collection with absolute dataset paths", () => {
+    it("makes a collection with absolute dataset paths", async () => {
       const datasetPath = "http://website.com/data/some-manifest.json";
-      const collection = Collection.makeCollectionFromSingleDataset(datasetPath);
+      const collection = await Collection.makeCollectionFromSingleDataset(datasetPath);
 
       expect(collection.getDatasetKeys().length).to.equal(1);
       expect(collection.hasDataset(datasetPath)).to.be.true;
       expect(collection.getAbsoluteDatasetPath(datasetPath)).to.equal(datasetPath);
     });
 
-    it("sets the URL to null", () => {
+    it("sets the URL to null", async () => {
       const datasetPath = "http://website.com/data/some-manifest.json";
-      const collection = Collection.makeCollectionFromSingleDataset(datasetPath);
+      const collection = await Collection.makeCollectionFromSingleDataset(datasetPath);
 
       expect(collection.url).to.be.null;
     });

--- a/tests/formatting.test.ts
+++ b/tests/formatting.test.ts
@@ -7,12 +7,10 @@ function doElementsHaveSharedParent(elements: HTMLElement[]): boolean {
   if (elements.length === 0) {
     return false;
   }
-
   const parent = elements[0].parentElement;
   if (!parent) {
     return false;
   }
-
   return elements.every((element) => element.parentElement === parent);
 }
 
@@ -61,7 +59,7 @@ describe("renderStringArrayAsJsx", () => {
 
     const listItems = renderedElements.getAllByRole("listitem");
     expect(listItems.length).toBe(5);
-    // Should have two different unordered list elements
+    // Should have two different unordered lists
     expect(doElementsHaveSharedParent(listItems)).toBe(false);
     expect(listItems[0].parentElement!.nodeName).toBe("UL");
     expect(doElementsHaveSharedParent([listItems[0], listItems[1], listItems[2]])).toBe(true);

--- a/tests/formatting.test.ts
+++ b/tests/formatting.test.ts
@@ -1,0 +1,71 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { renderStringArrayAsJsx } from "../src/utils/formatting";
+
+function doElementsHaveSharedParent(elements: HTMLElement[]): boolean {
+  if (elements.length === 0) {
+    return false;
+  }
+
+  const parent = elements[0].parentElement;
+  if (!parent) {
+    return false;
+  }
+
+  return elements.every((element) => element.parentElement === parent);
+}
+
+describe("renderStringArrayAsJsx", () => {
+  it("handles empty array", () => {
+    const elements = renderStringArrayAsJsx([]);
+    render(elements);
+  });
+
+  it("handles undefined", () => {
+    const elements = renderStringArrayAsJsx(undefined);
+    render(elements);
+  });
+
+  it("handles single text element", () => {
+    const elements = renderStringArrayAsJsx("hi");
+    const renderedElements = render(elements);
+    expect(renderedElements.getByText("hi")).toBeInTheDocument();
+    expect(renderedElements.getByText("hi").nodeName).toBe("P");
+  });
+
+  it("handles multiple text elements", () => {
+    const elements = renderStringArrayAsJsx(["1", "2", "3"]);
+    const renderedElements = render(elements);
+    expect(renderedElements.getByText("1").nodeName).toBe("P");
+    expect(renderedElements.getByText("2").nodeName).toBe("P");
+    expect(renderedElements.getByText("3").nodeName).toBe("P");
+  });
+
+  it("handles list elements", () => {
+    const elements = renderStringArrayAsJsx(["- 1", "- 2", "- 3"]);
+    const renderedElements = render(elements);
+    const listItems = renderedElements.getAllByRole("listitem");
+    expect(listItems.length).toBe(3);
+    // Elements should all be grouped under one parent
+    expect(listItems[0].parentElement!.nodeName).toBe("UL");
+    expect(doElementsHaveSharedParent(listItems)).toBe(true);
+  });
+
+  it("handles mixed list and text elements", () => {
+    const elements = renderStringArrayAsJsx(["- 1", "- 2", "- 3", "a", "b", "- 4", "- 5"]);
+    const renderedElements = render(elements);
+
+    expect(renderedElements.getByText("a").nodeName).toBe("P");
+    expect(renderedElements.getByText("b").nodeName).toBe("P");
+
+    const listItems = renderedElements.getAllByRole("listitem");
+    expect(listItems.length).toBe(5);
+    // Should have two different unordered list elements
+    expect(doElementsHaveSharedParent(listItems)).toBe(false);
+    expect(listItems[0].parentElement!.nodeName).toBe("UL");
+    expect(doElementsHaveSharedParent([listItems[0], listItems[1], listItems[2]])).toBe(true);
+    expect(listItems[3].parentElement!.nodeName).toBe("UL");
+    expect(doElementsHaveSharedParent([listItems[3], listItems[4]])).toBe(true);
+  });
+});

--- a/tests/formatting.test.ts
+++ b/tests/formatting.test.ts
@@ -17,24 +17,26 @@ function doElementsHaveSharedParent(elements: HTMLElement[]): boolean {
 describe("renderStringArrayAsJsx", () => {
   it("handles empty array", () => {
     const elements = renderStringArrayAsJsx([]);
-    render(elements);
+    expect(elements).toBeUndefined();
   });
 
   it("handles undefined", () => {
     const elements = renderStringArrayAsJsx(undefined);
-    render(elements);
+    expect(elements).toBeUndefined();
   });
 
   it("handles single text element", () => {
     const elements = renderStringArrayAsJsx("hi");
-    const renderedElements = render(elements);
+    expect(elements).not.toBeUndefined();
+    const renderedElements = render(elements!);
     expect(renderedElements.getByText("hi")).toBeInTheDocument();
     expect(renderedElements.getByText("hi").nodeName).toBe("P");
   });
 
   it("handles multiple text elements", () => {
     const elements = renderStringArrayAsJsx(["1", "2", "3"]);
-    const renderedElements = render(elements);
+    expect(elements).not.toBeUndefined();
+    const renderedElements = render(elements!);
     expect(renderedElements.getByText("1").nodeName).toBe("P");
     expect(renderedElements.getByText("2").nodeName).toBe("P");
     expect(renderedElements.getByText("3").nodeName).toBe("P");
@@ -42,7 +44,8 @@ describe("renderStringArrayAsJsx", () => {
 
   it("handles list elements", () => {
     const elements = renderStringArrayAsJsx(["- 1", "- 2", "- 3"]);
-    const renderedElements = render(elements);
+    expect(elements).not.toBeUndefined();
+    const renderedElements = render(elements!);
     const listItems = renderedElements.getAllByRole("listitem");
     expect(listItems.length).toBe(3);
     // Elements should all be grouped under one parent
@@ -52,7 +55,8 @@ describe("renderStringArrayAsJsx", () => {
 
   it("handles mixed list and text elements", () => {
     const elements = renderStringArrayAsJsx(["- 1", "- 2", "- 3", "a", "b", "- 4", "- 5"]);
-    const renderedElements = render(elements);
+    expect(elements).not.toBeUndefined();
+    const renderedElements = render(elements!);
 
     expect(renderedElements.getByText("a").nodeName).toBe("P");
     expect(renderedElements.getByText("b").nodeName).toBe("P");


### PR DESCRIPTION
Problem
=======
Follow up to #453 that applies some additional styling. Adds bullet point formatting and styles error message notifications.

*Estimated size: small, 10-15 minutes*

Solution
========
- Adds the new `renderStringArrayAsJsx` function which can parse string arrays into lists of `p` and `li` elements.
  - Also added unit tests for the new function.
- Styled popup notifications with the same fill + outline colors as the alert banners

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------

1. Open https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-454/ and try loading the URL `https://dev-aics-dtp-001.int.allencell.org/dan-data/colorizer/data/test/bad-data/empty-ambiguous.json`. You should see an error message with two bullet points.
2. Open https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-454/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Ftest%2Fbad-data%2Fcollection.json and click through all the different datasets. The alert notification popups and warning banners will appear with the new formatting.

Screenshots (optional):
-----------------------
New bullet points:
![image](https://github.com/user-attachments/assets/fca5d775-dfb9-4c73-b352-8ab1c3840e9b)
![image](https://github.com/user-attachments/assets/3dfec80e-77d5-458c-a857-eca6b62a290f)


New popup notification styling:

![image](https://github.com/user-attachments/assets/7f56b496-061b-447f-8fab-0e68a73445cb)

![image](https://github.com/user-attachments/assets/43b684f9-7cb5-4872-9e85-67b57250588a)

