### PR TITLE
feature: Link styling adjustments

### DIFF
--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -161,6 +161,7 @@ const CssContainer = styled.div`
   --color-text-theme: ${theme.color.theme};
   --color-text-theme-dark: ${theme.color.themeDark};
   --color-text-link: ${theme.color.text.link};
+  --color-text-link-hover: ${theme.color.text.linkHover};
 
   /* Layout */
   --color-background-alt: ${theme.color.layout.backgroundAlt};
@@ -264,9 +265,9 @@ const CssContainer = styled.div`
   color: var(--color-text-primary);
 
   a {
-    &:focus,
     &:focus-visible {
       text-decoration: underline;
+      box-shadow: 0 0 0 3px var(--color-text-link);
     }
   }
 
@@ -329,6 +330,9 @@ export default function AppStyle(props: PropsWithChildren<AppStyleProps>): React
 
       <ConfigProvider
         theme={{
+          // Removes the css-dev-only- prefixed CSS classes. Enabling hashing is only
+          // necessary if there are multiple version of Ant being used in the same app.
+          hashed: false,
           token: {
             colorPrimary: theme.color.theme,
             colorLink: theme.color.text.link,

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -330,9 +330,6 @@ export default function AppStyle(props: PropsWithChildren<AppStyleProps>): React
 
       <ConfigProvider
         theme={{
-          // Removes the css-dev-only- prefixed CSS classes. Enabling hashing is only
-          // necessary if there are multiple version of Ant being used in the same app.
-          hashed: false,
           token: {
             colorPrimary: theme.color.theme,
             colorLink: theme.color.text.link,

--- a/src/components/Buttons/ButtonStyleLink.tsx
+++ b/src/components/Buttons/ButtonStyleLink.tsx
@@ -1,0 +1,34 @@
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
+/**
+ * `Link` component styled to look like an Ant primary button, while maintaining
+ * the semantics/behavior of links.
+ */
+export const ButtonStyleLink = styled(Link)`
+  display: inline-block;
+  width: fit-content;
+  padding: 2px 15px;
+
+  background-color: var(--color-button);
+  color: var(--color-text-button);
+  border-radius: 6px;
+  border: 1px solid var(--color-button);
+  text-decoration: none !important;
+
+  transition: box-shadow 0 none, 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
+
+  &:hover {
+    background-color: var(--color-button-hover);
+    border: 1px solid var(--color-button-hover);
+    color: var(--color-text-button);
+  }
+
+  &:active {
+    border: 1px solid var(--color-button);
+  }
+
+  &:focus-visible {
+    text-decoration: underline !important;
+  }
+`;

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -1,6 +1,6 @@
 import { Button, Divider, Tooltip } from "antd";
 import React, { lazy, ReactElement, Suspense } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
 import { Dataset } from "../colorizer";
@@ -10,6 +10,7 @@ import { DatasetEntry, LocationState, ProjectEntry } from "../types";
 import { PageRoutes } from "./index";
 
 import Collection from "../colorizer/Collection";
+import { ButtonStyleLink } from "../components/Buttons/ButtonStyleLink";
 import HelpDropdown from "../components/Dropdowns/HelpDropdown";
 import Header from "../components/Header";
 import LoadDatasetButton from "../components/LoadDatasetButton";
@@ -137,6 +138,7 @@ const ProjectCard = styled.li`
   & a {
     // Add 2px margin to maintain the same visual gap that text has
     margin: 2px 0 0 0;
+    text-decoration: underline;
   }
 `;
 
@@ -225,9 +227,9 @@ export default function LandingPage(): ReactElement {
       <DatasetCard key={index}>
         <h3>{dataset.name}</h3>
         <p>{dataset.description}</p>
-        <Link to={viewerLink} className="ant-btn-primary ant-btn">
+        <ButtonStyleLink to={viewerLink}>
           Load<VisuallyHidden> dataset {dataset.name}</VisuallyHidden>
-        </Link>
+        </ButtonStyleLink>
       </DatasetCard>
     );
   };
@@ -254,9 +256,9 @@ export default function LandingPage(): ReactElement {
     ) : null;
 
     const loadButton = project.loadParams ? (
-      <Link to={"viewer" + paramsToUrlQueryString(project.loadParams)} className="ant-btn-primary ant-btn">
+      <ButtonStyleLink to={"viewer" + paramsToUrlQueryString(project.loadParams)}>
         Load<VisuallyHidden> dataset {project.name}</VisuallyHidden>
-      </Link>
+      </ButtonStyleLink>
     ) : null;
 
     // TODO: Break up list of datasets when too long and hide under collapsible section.

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -225,10 +225,8 @@ export default function LandingPage(): ReactElement {
       <DatasetCard key={index}>
         <h3>{dataset.name}</h3>
         <p>{dataset.description}</p>
-        <Link to={viewerLink}>
-          <Button type="primary">
-            Load<VisuallyHidden> dataset {dataset.name}</VisuallyHidden>
-          </Button>
+        <Link to={viewerLink} className="ant-btn-primary ant-btn">
+          Load<VisuallyHidden> dataset {dataset.name}</VisuallyHidden>
         </Link>
       </DatasetCard>
     );
@@ -256,10 +254,8 @@ export default function LandingPage(): ReactElement {
     ) : null;
 
     const loadButton = project.loadParams ? (
-      <Link to={"viewer" + paramsToUrlQueryString(project.loadParams)}>
-        <Button type="primary">
-          Load<VisuallyHidden> dataset {project.name}</VisuallyHidden>
-        </Button>
+      <Link to={"viewer" + paramsToUrlQueryString(project.loadParams)} className="ant-btn-primary ant-btn">
+        Load<VisuallyHidden> dataset {project.name}</VisuallyHidden>
       </Link>
     ) : null;
 

--- a/src/styles/utils.tsx
+++ b/src/styles/utils.tsx
@@ -77,12 +77,22 @@ export const VisuallyHidden = styled.span`
   border-width: 0;
 `;
 
+const StyledLink = styled.a`
+  white-space: nowrap;
+  text-decoration: underline;
+
+  &:focus-visible,
+  &:focus-within {
+    color: var(--color-text-link-hover);
+  }
+`;
+
 export function ExternalLink(props: { href: string; children: React.ReactNode }): ReactElement {
   return (
-    <a href={props.href} style={{ whiteSpace: "nowrap" }} rel="noopener noreferrer" target="_blank">
+    <StyledLink href={props.href} rel="noopener noreferrer" target="_blank">
       {props.children}
       <FontAwesomeIcon icon={faUpRightFromSquare} size="sm" style={{ marginBottom: "0px", marginLeft: "3px" }} />
       <VisuallyHidden>(opens in new tab)</VisuallyHidden>
-    </a>
+    </StyledLink>
   );
 }

--- a/src/styles/utils.tsx
+++ b/src/styles/utils.tsx
@@ -81,8 +81,7 @@ const StyledLink = styled.a`
   white-space: nowrap;
   text-decoration: underline;
 
-  &:focus-visible,
-  &:focus-within {
+  &:focus-visible {
     color: var(--color-text-link-hover);
   }
 `;


### PR DESCRIPTION
Problem
=======
Fixes some accessibility issues with links on the landing page.

*Estimated review size: small, <5 minutes*

Solution
========
- Landing page load links no longer contain buttons, and instead copy button styling from Ant.
- All links now have some kind of baseline focus styling.
- Added underlines to the external links on the landing page.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open the preview link and use the tab key to navigate around the landing page: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-457/

Screenshots (optional):
-----------------------
**Default:**
![image](https://github.com/user-attachments/assets/4c32c59d-d1c2-43c6-a2c0-c69c758561c9)

**Focus styling:**
![image](https://github.com/user-attachments/assets/fed282df-2ca6-4ad9-8694-daa239a37470)

**Load links:**
![image](https://github.com/user-attachments/assets/bf1b30e3-aa28-4170-b448-a13e4f045925)
