### PR TITLE
refactor: Generalize worker pool

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -91,9 +91,9 @@
           // Relative imports - lowercase utilities and submodules
           ["^[.]+.*/[a-z]+[\\w]*$"],
           // Relative imports - other classes and components
-          ["^[./].*/[\\w]*$"],
+          ["^[./].*/[\\w?&]*$"],
           // Relative imports - resource files
-          ["^[.].*/[\\w?_\\-]*[.][\\w.?_\\-]*$"]
+          ["^[.].*/[\\w?_\\-]*[.][\\w.?&_\\-]*$"]
         ]
       }
     ],

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
   "printWidth": 120,
   "trailingComma": "es5",
   "tabWidth": 2,
-  "importOrder": ["^[./]+.*/[a-z]+[\\w]*$", "^[./].*/[\\w]*$", "^[./].*/[\\w_\\-?]*[.][\\w._\\-?]*$"],
+  "importOrder": ["^[./]+.*/[a-z]+[\\w]*$", "^[./].*/[\\w?&]*$", "^[./].*/[\\w_\\-?]*[.][\\w._\\-?&]*$"],
   "importOrderSeparation": true,
   "importOrderSortSpecifiers": true,
   "importOrderCaseInsensitive": true

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -45,6 +45,7 @@ import { BACKGROUND_ID } from "./colorizer/ColorizeCanvas";
 import { FeatureType } from "./colorizer/Dataset";
 import UrlArrayLoader from "./colorizer/loaders/UrlArrayLoader";
 import TimeControls from "./colorizer/TimeControls";
+import SharedWorkerPool from "./colorizer/workers/SharedWorkerPool";
 import { AppThemeContext } from "./components/AppStyle";
 import { useAlertBanner } from "./components/Banner";
 import TextButton from "./components/Buttons/TextButton";
@@ -85,8 +86,10 @@ function Viewer(): ReactElement {
   const [dataset, setDataset] = useState<Dataset | null>(null);
   const [datasetKey, setDatasetKey] = useState("");
   const [, addRecentCollection] = useRecentCollections();
-  // Shared array loader to manage worker pool
-  const arrayLoader = useConstructor(() => new UrlArrayLoader());
+
+  // Shared worker pool for background operations (e.g. loading data)
+  const workerPool = useConstructor(() => new SharedWorkerPool());
+  const arrayLoader = useConstructor(() => new UrlArrayLoader(workerPool));
 
   const [featureKey, setFeatureKey] = useState("");
   const [selectedTrack, setSelectedTrack] = useState<Track | null>(null);

--- a/src/colorizer/loaders/UrlArrayLoader.ts
+++ b/src/colorizer/loaders/UrlArrayLoader.ts
@@ -1,11 +1,10 @@
-// sort-imports-ignore
 import { DataTexture } from "three";
 
 import { FeatureArrayType, FeatureDataType } from "../types";
 import { infoToDataTexture } from "../utils/texture_utils";
 
-import { ArraySource, IArrayLoader } from "./ILoader";
 import SharedWorkerPool from "../workers/SharedWorkerPool";
+import { ArraySource, IArrayLoader } from "./ILoader";
 
 export class UrlArraySource<T extends FeatureDataType> implements ArraySource<T> {
   array: FeatureArrayType[T];
@@ -41,10 +40,10 @@ export class UrlArraySource<T extends FeatureDataType> implements ArraySource<T>
 
 export default class UrlArrayLoader implements IArrayLoader {
   private workerPool: SharedWorkerPool;
-  private disposeOfWorkerPool: boolean;
+  private cleanupWorkerPoolOnDispose: boolean;
 
   constructor(workerPool?: SharedWorkerPool) {
-    this.disposeOfWorkerPool = workerPool === undefined;
+    this.cleanupWorkerPoolOnDispose = workerPool === undefined;
     this.workerPool = workerPool ?? new SharedWorkerPool();
   }
 
@@ -65,14 +64,14 @@ export default class UrlArrayLoader implements IArrayLoader {
         `Encountered unsupported file format when loading data. URL must end in '.parquet' or '.json': ${url}`
       );
     }
-    const { data, textureInfo, min: newMin, max: newMax } = await this.workerPool.load(url, type);
+    const { data, textureInfo, min: newMin, max: newMax } = await this.workerPool.loadUrlData(url, type);
 
     const tex = infoToDataTexture(textureInfo);
     return new UrlArraySource<T>(data, tex, type, min ?? newMin, max ?? newMax);
   }
 
   dispose(): void {
-    if (this.disposeOfWorkerPool) {
+    if (this.cleanupWorkerPoolOnDispose) {
       this.workerPool.terminate();
     }
   }

--- a/src/colorizer/loaders/UrlArrayLoader.ts
+++ b/src/colorizer/loaders/UrlArrayLoader.ts
@@ -1,15 +1,11 @@
 // sort-imports-ignore
 import { DataTexture } from "three";
-import workerpool from "workerpool";
-
-// Vite import directive for worker files! See https://vitejs.dev/guide/features.html#import-with-query-suffixes.
-// @ts-ignore Ignore missing file warning
-import WorkerUrl from "./workers/urlLoadWorker?url&worker";
 
 import { FeatureArrayType, FeatureDataType } from "../types";
 import { infoToDataTexture } from "../utils/texture_utils";
 
 import { ArraySource, IArrayLoader } from "./ILoader";
+import SharedWorkerPool from "../workers/SharedWorkerPool";
 
 export class UrlArraySource<T extends FeatureDataType> implements ArraySource<T> {
   array: FeatureArrayType[T];
@@ -44,18 +40,12 @@ export class UrlArraySource<T extends FeatureDataType> implements ArraySource<T>
 }
 
 export default class UrlArrayLoader implements IArrayLoader {
-  private workerPool: workerpool.Pool;
+  private workerPool: SharedWorkerPool;
+  private disposeOfWorkerPool: boolean;
 
-  constructor() {
-    // TODO: Maintain a single worker pool for all loaders/all asynchronous operations in the app?
-    this.workerPool = workerpool.pool(WorkerUrl, {
-      workerOpts: {
-        // Set worker type to undefined (classic) in production to fix a Vite issue where the application
-        // crashes when loading a module worker.
-        // Copied from https://github.com/josdejong/workerpool/tree/master/examples/vite.
-        type: import.meta.env.PROD ? undefined : "module",
-      },
-    });
+  constructor(workerPool?: SharedWorkerPool) {
+    this.disposeOfWorkerPool = workerPool === undefined;
+    this.workerPool = workerPool ?? new SharedWorkerPool();
   }
 
   /**
@@ -71,15 +61,19 @@ export default class UrlArrayLoader implements IArrayLoader {
    */
   async load<T extends FeatureDataType>(url: string, type: T, min?: number, max?: number): Promise<UrlArraySource<T>> {
     if (!url.endsWith(".json") && !url.endsWith(".parquet")) {
-      throw new Error(`Unsupported file format for URL array loader: ${url}`);
+      throw new Error(
+        `Encountered unsupported file format when loading data. URL must end in '.parquet' or '.json': ${url}`
+      );
     }
-    const { data, textureInfo, min: newMin, max: newMax } = await this.workerPool.exec("load", [url, type]);
+    const { data, textureInfo, min: newMin, max: newMax } = await this.workerPool.load(url, type);
 
     const tex = infoToDataTexture(textureInfo);
     return new UrlArraySource<T>(data, tex, type, min ?? newMin, max ?? newMax);
   }
 
   dispose(): void {
-    this.workerPool.terminate();
+    if (this.disposeOfWorkerPool) {
+      this.workerPool.terminate();
+    }
   }
 }

--- a/src/colorizer/utils/data_load_utils.ts
+++ b/src/colorizer/utils/data_load_utils.ts
@@ -3,6 +3,8 @@ import { compressors } from "hyparquet-compressors";
 
 import { FeatureArrayType, FeatureDataType, featureTypeSpecs } from "../types";
 
+const isBoolArray = (arr: number[] | boolean[]): arr is boolean[] => typeof arr[0] === "boolean";
+
 type FeatureDataJson = {
   data: number[] | boolean[];
   min?: number;
@@ -14,8 +16,6 @@ export type LoadedData<T extends FeatureDataType> = {
   min: number;
   max: number;
 };
-
-const isBoolArray = (arr: number[] | boolean[]): arr is boolean[] => typeof arr[0] === "boolean";
 
 /**
  * Replaces all NaN in string text (such as the string representation of a JSON

--- a/src/colorizer/utils/data_load_utils.ts
+++ b/src/colorizer/utils/data_load_utils.ts
@@ -1,13 +1,7 @@
 import { parquetRead } from "hyparquet";
 import { compressors } from "hyparquet-compressors";
-import workerpool from "workerpool";
-import Transfer from "workerpool/types/transfer";
 
-import { FeatureArrayType, FeatureDataType, featureTypeSpecs } from "../../types";
-import { nanToNull } from "../../utils/json_utils";
-import { arrayToDataTextureInfo } from "../../utils/texture_utils";
-
-const isBoolArray = (arr: number[] | boolean[]): arr is boolean[] => typeof arr[0] === "boolean";
+import { FeatureArrayType, FeatureDataType, featureTypeSpecs } from "../types";
 
 type FeatureDataJson = {
   data: number[] | boolean[];
@@ -15,13 +9,21 @@ type FeatureDataJson = {
   max?: number;
 };
 
-type LoadedData<T extends FeatureDataType> = {
+export type LoadedData<T extends FeatureDataType> = {
   data: FeatureArrayType[T];
   min: number;
   max: number;
 };
 
-async function loadFromJsonUrl<T extends FeatureDataType>(url: string, type: T): Promise<LoadedData<T>> {
+const isBoolArray = (arr: number[] | boolean[]): arr is boolean[] => typeof arr[0] === "boolean";
+
+/**
+ * Replaces all NaN in string text (such as the string representation of a JSON
+ * object) with null. Can be used to safely parse JSON objects with NaN values.
+ */
+export const nanToNull = (json: string): string => json.replace(/NaN/g, "null");
+
+export async function loadFromJsonUrl<T extends FeatureDataType>(url: string, type: T): Promise<LoadedData<T>> {
   const result = await fetch(url);
 
   if (!result.ok) {
@@ -55,7 +57,7 @@ async function loadFromJsonUrl<T extends FeatureDataType>(url: string, type: T):
   return { data, min: min ?? dataMin, max: max ?? dataMax };
 }
 
-async function loadFromParquetUrl<T extends FeatureDataType>(url: string, type: T): Promise<LoadedData<T>> {
+export async function loadFromParquetUrl<T extends FeatureDataType>(url: string, type: T): Promise<LoadedData<T>> {
   const result = await fetch(url);
 
   if (!result.ok) {
@@ -85,26 +87,3 @@ async function loadFromParquetUrl<T extends FeatureDataType>(url: string, type: 
   });
   return { data, min: dataMin, max: dataMax };
 }
-
-async function load(url: string, type: FeatureDataType): Promise<Transfer> {
-  let result: LoadedData<typeof type>;
-  if (url.endsWith(".json")) {
-    result = await loadFromJsonUrl(url, type);
-  } else if (url.endsWith(".parquet")) {
-    result = await loadFromParquetUrl(url, type);
-  } else {
-    throw new Error(`Unsupported file format: ${url}`);
-  }
-
-  const { min, max, data } = result;
-  // Cannot directly transfer the DataTexture, since the class methods are not transferred.
-  // Instead, transfer the underlying image and reconstruct it on the main thread.
-  const textureInfo = arrayToDataTextureInfo(data, type);
-
-  // `Transfer` is used to transfer the data buffer to the main thread without copying.
-  return new workerpool.Transfer({ min, max, data, textureInfo }, [data.buffer, textureInfo.data.buffer]);
-}
-
-workerpool.worker({
-  load: load,
-});

--- a/src/colorizer/utils/json_utils.ts
+++ b/src/colorizer/utils/json_utils.ts
@@ -1,5 +1,0 @@
-/**
- * Replaces all NaN in string text (such as the string representation of a JSON
- * object) with null. Can be used to safely parse JSON objects with NaN values.
- */
-export const nanToNull = (json: string): string => json.replace(/NaN/g, "null");

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -23,8 +23,8 @@ import {
   ThresholdType,
   ViewerConfig,
 } from "../types";
+import { nanToNull } from "./data_load_utils";
 import { AnyManifestFile } from "./dataset_utils";
-import { nanToNull } from "./json_utils";
 import { numberToStringDecimal } from "./math_utils";
 
 enum UrlParam {

--- a/src/colorizer/workers/SharedWorkerPool.ts
+++ b/src/colorizer/workers/SharedWorkerPool.ts
@@ -1,10 +1,11 @@
-// Vite import directive for worker files! See https://vitejs.dev/guide/features.html#import-with-query-suffixes.
-// @ts-ignore Ignore missing file warning
-import WorkerUrl from "./workers/worker?url&worker";
 import workerpool from "workerpool";
 
 import { FeatureArrayType, FeatureDataType } from "../types";
 import { DataTextureInfo } from "../utils/texture_utils";
+
+// Vite import directive for worker files! See https://vitejs.dev/guide/features.html#import-with-query-suffixes.
+// @ts-ignore Ignore missing file warning
+import WorkerUrl from "./worker?url&worker";
 
 export default class SharedWorkerPool {
   private workerPool: workerpool.Pool;
@@ -12,8 +13,8 @@ export default class SharedWorkerPool {
   constructor() {
     this.workerPool = workerpool.pool(WorkerUrl, {
       workerOpts: {
-        // Set worker type to undefined (classic) in production to fix a Vite issue where the application
-        // crashes when loading a module worker.
+        // Set worker type to undefined (classic) in production to fix a Vite issue where the
+        // application crashes when loading a module worker.
         // Copied from https://github.com/josdejong/workerpool/tree/master/examples/vite.
         type: import.meta.env.PROD ? undefined : "module",
       },
@@ -32,11 +33,11 @@ export default class SharedWorkerPool {
    *  - `min`: The minimum value in the data array.
    *  - `max`: The maximum value in the data array.
    */
-  async load<T extends FeatureDataType>(
+  async loadUrlData<T extends FeatureDataType>(
     url: string,
     type: T
   ): Promise<{ data: FeatureArrayType[T]; textureInfo: DataTextureInfo<T>; min: number; max: number }> {
-    return await this.workerPool.exec("load", [url, type]);
+    return await this.workerPool.exec("loadUrlData", [url, type]);
   }
 
   terminate(): void {

--- a/src/colorizer/workers/SharedWorkerPool.ts
+++ b/src/colorizer/workers/SharedWorkerPool.ts
@@ -1,0 +1,45 @@
+// Vite import directive for worker files! See https://vitejs.dev/guide/features.html#import-with-query-suffixes.
+// @ts-ignore Ignore missing file warning
+import WorkerUrl from "./workers/worker?url&worker";
+import workerpool from "workerpool";
+
+import { FeatureArrayType, FeatureDataType } from "../types";
+import { DataTextureInfo } from "../utils/texture_utils";
+
+export default class SharedWorkerPool {
+  private workerPool: workerpool.Pool;
+
+  constructor() {
+    this.workerPool = workerpool.pool(WorkerUrl, {
+      workerOpts: {
+        // Set worker type to undefined (classic) in production to fix a Vite issue where the application
+        // crashes when loading a module worker.
+        // Copied from https://github.com/josdejong/workerpool/tree/master/examples/vite.
+        type: import.meta.env.PROD ? undefined : "module",
+      },
+    });
+  }
+
+  /**
+   * Loads array data from the specified URL, handling both JSON and Parquet files.
+   * @param url The URL to load data from. Must end in ".json" or ".parquet".
+   * @param type `FeatureDataType` for the returned array source (e.g. `F32` or `U8`).
+   * @throws Error if the file format is not supported (not JSON or Parquet).
+   * @returns an object containing the loaded data and metadata:
+   *  - `data`: The loaded data array.
+   *  - `textureInfo`: Texture data and metadata needed to create a `DataTexture`.
+   * Use with `infoToDataTexture()`.
+   *  - `min`: The minimum value in the data array.
+   *  - `max`: The maximum value in the data array.
+   */
+  async load<T extends FeatureDataType>(
+    url: string,
+    type: T
+  ): Promise<{ data: FeatureArrayType[T]; textureInfo: DataTextureInfo<T>; min: number; max: number }> {
+    return await this.workerPool.exec("load", [url, type]);
+  }
+
+  terminate(): void {
+    this.workerPool.terminate();
+  }
+}

--- a/src/colorizer/workers/worker.ts
+++ b/src/colorizer/workers/worker.ts
@@ -25,5 +25,5 @@ async function loadUrlData(url: string, type: FeatureDataType): Promise<Transfer
 }
 
 workerpool.worker({
-  loadUrlData: loadUrlData,
+  loadUrlData,
 });

--- a/src/colorizer/workers/worker.ts
+++ b/src/colorizer/workers/worker.ts
@@ -1,11 +1,11 @@
 import workerpool from "workerpool";
 import Transfer from "workerpool/types/transfer";
 
-import { FeatureDataType } from "../../types";
-import { LoadedData, loadFromJsonUrl, loadFromParquetUrl } from "../../utils/data_load_utils";
-import { arrayToDataTextureInfo } from "../../utils/texture_utils";
+import { FeatureDataType } from "../types";
+import { LoadedData, loadFromJsonUrl, loadFromParquetUrl } from "../utils/data_load_utils";
+import { arrayToDataTextureInfo } from "../utils/texture_utils";
 
-async function load(url: string, type: FeatureDataType): Promise<Transfer> {
+async function loadUrlData(url: string, type: FeatureDataType): Promise<Transfer> {
   let result: LoadedData<typeof type>;
   if (url.endsWith(".json")) {
     result = await loadFromJsonUrl(url, type);
@@ -25,5 +25,5 @@ async function load(url: string, type: FeatureDataType): Promise<Transfer> {
 }
 
 workerpool.worker({
-  load: load,
+  loadUrlData: loadUrlData,
 });

--- a/src/colorizer/workers/workers/worker.ts
+++ b/src/colorizer/workers/workers/worker.ts
@@ -1,0 +1,29 @@
+import workerpool from "workerpool";
+import Transfer from "workerpool/types/transfer";
+
+import { FeatureDataType } from "../../types";
+import { LoadedData, loadFromJsonUrl, loadFromParquetUrl } from "../../utils/data_load_utils";
+import { arrayToDataTextureInfo } from "../../utils/texture_utils";
+
+async function load(url: string, type: FeatureDataType): Promise<Transfer> {
+  let result: LoadedData<typeof type>;
+  if (url.endsWith(".json")) {
+    result = await loadFromJsonUrl(url, type);
+  } else if (url.endsWith(".parquet")) {
+    result = await loadFromParquetUrl(url, type);
+  } else {
+    throw new Error(`Unsupported file format: ${url}`);
+  }
+
+  const { min, max, data } = result;
+  // Cannot directly transfer the DataTexture, since the class methods are not transferred.
+  // Instead, transfer the underlying image and reconstruct it on the main thread.
+  const textureInfo = arrayToDataTextureInfo(data, type);
+
+  // `Transfer` is used to transfer the data buffer to the main thread without copying.
+  return new workerpool.Transfer({ min, max, data, textureInfo }, [data.buffer, textureInfo.data.buffer]);
+}
+
+workerpool.worker({
+  load: load,
+});


### PR DESCRIPTION
Problem
=======
First step towards #456 and #423, and for improving the scatterplot performance. This change makes the worker pool more general and allows for it to be extended with new background tasks in the near future. Most of the line count is just code being moved around!

*Estimated review size: small, 10 minutes*

Solution
========
- Moved worker-related logic out of `UrlArrayLoader` and into a new class, `SharedWorkerPool`.
- Renamed `urlLoadWorker` to `worker.ts` and moved most of the loading logic into its own utils file.
- Renamed some methods to be more specific.
- Fixes to auto-import sorting rules.

Steps to Verify:
----------------
1. Load any dataset from the example URL: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-458/