### PR TITLE
feat: Clicking on track plot now jumps to that time point

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -1110,6 +1110,7 @@ function Viewer(): ReactElement {
                     children: (
                       <div className={styles.tabContent}>
                         <PlotTab
+                          setFrame={setFrameAndRender}
                           findTrackInputText={findTrackInput}
                           setFindTrackInputText={setFindTrackInput}
                           findTrack={findTrack}

--- a/src/components/PlotWrapper.tsx
+++ b/src/components/PlotWrapper.tsx
@@ -78,9 +78,11 @@ export default function PlotWrapper(inputProps: PlotWrapperProps): ReactElement 
       props.setFrame(time);
     };
 
-    (plotDivRef.current as PlotlyHTMLElement | null)?.on("plotly_click", onClickPlot);
+    const plotDiv = plotDivRef.current as PlotlyHTMLElement | null;
+    plotDiv?.on("plotly_click", onClickPlot);
     return () => {
-      (plotDivRef.current as PlotlyHTMLElement | null)?.removeAllListeners("plotly_click");
+      const plotDiv = plotDivRef.current as PlotlyHTMLElement | null;
+      plotDiv?.removeAllListeners("plotly_click");
     };
   }, [props.setFrame]);
 

--- a/src/components/PlotWrapper.tsx
+++ b/src/components/PlotWrapper.tsx
@@ -44,9 +44,10 @@ export default function PlotWrapper(inputProps: PlotWrapperProps): ReactElement 
 
   // Handle updates to selected track and feature, updating/clearing the plot accordingly.
   useMemo(() => {
-    plot?.removePlot();
     if (props.selectedTrack) {
       plot?.plot(props.selectedTrack, props.featureKey, props.frame);
+    } else {
+      plot?.removePlot();
     }
   }, [props.selectedTrack, props.featureKey]);
 

--- a/src/components/PlotWrapper.tsx
+++ b/src/components/PlotWrapper.tsx
@@ -1,4 +1,4 @@
-import { PlotlyHTMLElement } from "plotly.js-dist-min";
+import Plotly, { PlotlyHTMLElement } from "plotly.js-dist-min";
 import React, { ReactElement, useEffect, useMemo, useRef, useState } from "react";
 
 import { Dataset, Plotting, Track } from "../colorizer";

--- a/src/components/PlotWrapper.tsx
+++ b/src/components/PlotWrapper.tsx
@@ -1,3 +1,4 @@
+import { PlotlyHTMLElement } from "plotly.js-dist-min";
 import React, { ReactElement, useEffect, useMemo, useRef, useState } from "react";
 
 import { Dataset, Plotting, Track } from "../colorizer";
@@ -7,6 +8,7 @@ type PlotWrapperProps = {
   dataset: Dataset | null;
   featureKey: string;
   selectedTrack: Track | null;
+  setFrame: (frame: number) => Promise<void>;
 };
 const defaultProps: Partial<PlotWrapperProps> = {};
 
@@ -65,6 +67,21 @@ export default function PlotWrapper(inputProps: PlotWrapperProps): ReactElement 
     // window.addEventListener("resize", updatePlotSize);
     // return () => window.removeEventListener("resize", updatePlotSize);
   }, [plot, plotDivRef.current]);
+
+  useEffect(() => {
+    const onClickPlot = (eventData: Plotly.PlotMouseEvent): void => {
+      if (eventData.points.length === 0) {
+        return;
+      }
+      const time = eventData.points[0].x as number;
+      props.setFrame(time);
+    };
+
+    (plotDivRef.current as PlotlyHTMLElement | null)?.on("plotly_click", onClickPlot);
+    return () => {
+      (plotDivRef.current as PlotlyHTMLElement | null)?.removeAllListeners("plotly_click");
+    };
+  }, [props.setFrame]);
 
   return <div ref={plotDivRef} style={{ width: "auto", height: "auto", zIndex: "0" }}></div>;
 }

--- a/src/components/Tabs/PlotTab.tsx
+++ b/src/components/Tabs/PlotTab.tsx
@@ -28,6 +28,7 @@ type PlotTabProps = {
   findTrackInputText: string;
   setFindTrackInputText: (text: string) => void;
   findTrack: (trackId: number, seekToFrame?: boolean) => void;
+  setFrame: (frame: number) => Promise<void>;
   currentFrame: number;
   dataset: Dataset | null;
   featureKey: string;
@@ -67,6 +68,7 @@ export default function PlotTab(props: PlotTabProps): ReactElement {
         </NoSpinnerContainer>
       </TrackTitleBar>
       <PlotWrapper
+        setFrame={props.setFrame}
         frame={props.currentFrame}
         dataset={props.dataset}
         featureKey={props.featureKey}


### PR DESCRIPTION
Problem
=======
Completes part 1 of #312, "improve track plot navigation." Clicking on the track plot should take you to that time point.

*Estimated size: tiny, 5 minutes*

Solution
========
- Clicking on the track plot now jumps to that time point.


## Type of change

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link and load any dataset: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-463/
2. Click on any cell to select its track.
3. From the track plot, click the line graph. You should jump to that point in the dataset.
