### PR TITLE
feature: Show crosshair when hovering on track

### DIFF
--- a/src/colorizer/Plotting.ts
+++ b/src/colorizer/Plotting.ts
@@ -20,9 +20,45 @@ const LINE_SPEC: Partial<Plotly.Shape> = {
   },
 };
 
+const CIRCLE_RADIUS = 4;
+
+const CROSSHAIR_RADIUS: number = 12;
+const X_CROSSHAIR_SPEC: Partial<Plotly.Shape> = {
+  ...LINE_SPEC,
+  xsizemode: "pixel",
+  ysizemode: "pixel",
+  yref: undefined,
+  y0: 0,
+  y1: 0,
+  x0: -CROSSHAIR_RADIUS,
+  x1: CROSSHAIR_RADIUS,
+  layer: "above",
+  opacity: 0.5,
+  line: {
+    color: "rgb(31,119,180)",
+    width: 2,
+    dash: "solid",
+  },
+};
+const Y_CROSSHAIR_SPEC: Partial<Plotly.Shape> = {
+  ...X_CROSSHAIR_SPEC,
+  y0: -CROSSHAIR_RADIUS,
+  y1: CROSSHAIR_RADIUS,
+  x0: 0,
+  x1: 0,
+};
+
 const CONFIG: Partial<Plotly.Config> = {
   displayModeBar: false,
   responsive: true,
+};
+
+export type TrackPlotLayoutConfig = {
+  time: number;
+  hover?: {
+    x: number;
+    y: number;
+  };
 };
 
 export default class Plotting {
@@ -82,17 +118,46 @@ export default class Plotting {
     Plotly.react(this.parentRef, [this.trace], layout, CONFIG);
   }
 
-  setTime(t: number): void {
-    const layout: Partial<Plotly.Layout> = {
-      shapes: [
+  updateLayout(config: TrackPlotLayoutConfig): void {
+    const shapes: Partial<Plotly.Shape>[] = [
+      {
+        ...LINE_SPEC,
+        x0: config.time,
+        x1: config.time,
+      },
+    ];
+    if (config.hover) {
+      shapes.push(
         {
-          ...LINE_SPEC,
-          x0: t,
-          x1: t,
+          ...X_CROSSHAIR_SPEC,
+          xanchor: config.hover.x,
+          yanchor: config.hover.y,
         },
-      ],
-    };
-    Plotly.relayout(this.parentRef, layout);
+        {
+          ...Y_CROSSHAIR_SPEC,
+          xanchor: config.hover.x,
+          yanchor: config.hover.y,
+        }
+      );
+
+      shapes.push({
+        type: "circle",
+        xanchor: config.hover.x,
+        yanchor: config.hover.y,
+        layer: "above",
+        xsizemode: "pixel",
+        ysizemode: "pixel",
+        fillcolor: "rgba(31,119,180, 0.4)",
+        line: {
+          width: 0,
+        },
+        x0: -CIRCLE_RADIUS,
+        x1: CIRCLE_RADIUS,
+        y0: -CIRCLE_RADIUS,
+        y1: CIRCLE_RADIUS,
+      });
+    }
+    Plotly.relayout(this.parentRef, { shapes });
     //Plotly.react(this.parentDivId, this.trace ? [this.trace] : [], layout);
   }
 

--- a/src/colorizer/Plotting.ts
+++ b/src/colorizer/Plotting.ts
@@ -20,30 +20,36 @@ const LINE_SPEC: Partial<Plotly.Shape> = {
   },
 };
 
+// TODO: Color the plot with the current color ramp?
+// TODO: Style the crosshair like the one in the Scatterplot?
+
 const CROSSHAIR_RADIUS: number = 12.5;
-const X_CROSSHAIR_SPEC: Partial<Plotly.Shape> = {
+const BASE_CROSSHAIR_SPEC: Partial<Plotly.Shape> = {
   ...LINE_SPEC,
   xsizemode: "pixel",
   ysizemode: "pixel",
   yref: undefined,
   y0: 0,
   y1: 0,
-  x0: -CROSSHAIR_RADIUS,
-  x1: CROSSHAIR_RADIUS,
+  x0: 0,
+  x1: 0,
   layer: "above",
   opacity: 0.5,
   line: {
-    color: "rgb(31,119,180)",
+    color: "rgb(31,119,180)", // default plotly color
     width: 2,
     dash: "solid",
   },
 };
+const X_CROSSHAIR_SPEC: Partial<Plotly.Shape> = {
+  ...BASE_CROSSHAIR_SPEC,
+  x0: -CROSSHAIR_RADIUS,
+  x1: CROSSHAIR_RADIUS,
+};
 const Y_CROSSHAIR_SPEC: Partial<Plotly.Shape> = {
-  ...X_CROSSHAIR_SPEC,
+  ...BASE_CROSSHAIR_SPEC,
   y0: -CROSSHAIR_RADIUS,
   y1: CROSSHAIR_RADIUS,
-  x0: 0,
-  x1: 0,
 };
 
 const CONFIG: Partial<Plotly.Config> = {

--- a/src/colorizer/Plotting.ts
+++ b/src/colorizer/Plotting.ts
@@ -20,9 +20,7 @@ const LINE_SPEC: Partial<Plotly.Shape> = {
   },
 };
 
-const CIRCLE_RADIUS = 4;
-
-const CROSSHAIR_RADIUS: number = 12;
+const CROSSHAIR_RADIUS: number = 12.5;
 const X_CROSSHAIR_SPEC: Partial<Plotly.Shape> = {
   ...LINE_SPEC,
   xsizemode: "pixel",
@@ -139,23 +137,6 @@ export default class Plotting {
           yanchor: config.hover.y,
         }
       );
-
-      shapes.push({
-        type: "circle",
-        xanchor: config.hover.x,
-        yanchor: config.hover.y,
-        layer: "above",
-        xsizemode: "pixel",
-        ysizemode: "pixel",
-        fillcolor: "rgba(31,119,180, 0.4)",
-        line: {
-          width: 0,
-        },
-        x0: -CIRCLE_RADIUS,
-        x1: CIRCLE_RADIUS,
-        y0: -CIRCLE_RADIUS,
-        y1: CIRCLE_RADIUS,
-      });
     }
     Plotly.relayout(this.parentRef, { shapes });
     //Plotly.react(this.parentDivId, this.trace ? [this.trace] : [], layout);

--- a/src/components/PlotWrapper.tsx
+++ b/src/components/PlotWrapper.tsx
@@ -57,7 +57,7 @@ export default function PlotWrapper(inputProps: PlotWrapperProps): ReactElement 
       }
     }
     plot?.updateLayout(config);
-  }, [props.frame, props.selectedTrack, props.featureKey, hoveredObjectId]);
+  }, [props.dataset, props.frame, props.selectedTrack, props.featureKey, hoveredObjectId]);
 
   // Handle updates to selected track and feature, updating/clearing the plot accordingly.
   useMemo(() => {

--- a/src/components/PlotWrapper.tsx
+++ b/src/components/PlotWrapper.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, useEffect, useMemo, useRef, useState } from "react
 
 import { Dataset, Plotting, Track } from "../colorizer";
 
-import { TrackPlotLayoutConfig } from "../colorizer/Plotting";
+import type { TrackPlotLayoutConfig } from "../colorizer/Plotting";
 
 type PlotWrapperProps = {
   frame: number;
@@ -42,20 +42,22 @@ export default function PlotWrapper(inputProps: PlotWrapperProps): ReactElement 
 
   // Update time and hovered value in plot
   useMemo(() => {
-    const config: TrackPlotLayoutConfig = {
-      time: props.frame,
-    };
+    let hover;
     if (hoveredObjectId) {
       const featureData = props.dataset?.getFeatureData(props.featureKey);
       const hoveredObjectTime = props.dataset?.getTime(hoveredObjectId);
       if (featureData && hoveredObjectTime) {
         const featureValue = featureData.data[hoveredObjectId];
-        config.hover = {
+        hover = {
           x: hoveredObjectTime,
           y: featureValue,
         };
       }
     }
+    const config: TrackPlotLayoutConfig = {
+      time: props.frame,
+      hover,
+    };
     plot?.updateLayout(config);
   }, [props.dataset, props.frame, props.selectedTrack, props.featureKey, hoveredObjectId]);
 

--- a/src/components/Tabs/PlotTab.tsx
+++ b/src/components/Tabs/PlotTab.tsx
@@ -1,12 +1,13 @@
 import { SearchOutlined } from "@ant-design/icons";
 import { Input } from "antd";
-import React, { ReactElement } from "react";
+import React, { ReactElement, useRef, useState } from "react";
 import styled from "styled-components";
 
 import { Dataset, Track } from "../../colorizer";
 import { FlexRowAlignCenter, NoSpinnerContainer } from "../../styles/utils";
 
 import IconButton from "../IconButton";
+import LoadingSpinner from "../LoadingSpinner";
 import PlotWrapper from "../PlotWrapper";
 
 const TrackTitleBar = styled(FlexRowAlignCenter)`
@@ -37,11 +38,23 @@ type PlotTabProps = {
 };
 
 export default function PlotTab(props: PlotTabProps): ReactElement {
+  const [isLoading, setIsLoading] = useState(false);
+  const pendingFrame = useRef<number>(props.currentFrame);
+
   const searchForTrack = (): void => {
     if (props.findTrackInputText === "") {
       return;
     }
     props.findTrack(parseInt(props.findTrackInputText, 10));
+  };
+
+  const setFrame = async (frame: number): Promise<void> => {
+    pendingFrame.current = frame;
+    setIsLoading(true);
+    await props.setFrame(frame);
+    if (pendingFrame.current === frame) {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -67,13 +80,17 @@ export default function PlotTab(props: PlotTabProps): ReactElement {
           </TrackSearch>
         </NoSpinnerContainer>
       </TrackTitleBar>
-      <PlotWrapper
-        setFrame={props.setFrame}
-        frame={props.currentFrame}
-        dataset={props.dataset}
-        featureKey={props.featureKey}
-        selectedTrack={props.selectedTrack}
-      />
+      <div>
+        <LoadingSpinner loading={isLoading}>
+          <PlotWrapper
+            setFrame={setFrame}
+            frame={props.currentFrame}
+            dataset={props.dataset}
+            featureKey={props.featureKey}
+            selectedTrack={props.selectedTrack}
+          />
+        </LoadingSpinner>
+      </div>
     </>
   );
 }

--- a/src/components/Tabs/PlotTab.tsx
+++ b/src/components/Tabs/PlotTab.tsx
@@ -52,6 +52,8 @@ export default function PlotTab(props: PlotTabProps): ReactElement {
     pendingFrame.current = frame;
     setIsLoading(true);
     await props.setFrame(frame);
+    // Continue to show loading spinner if other frames were requested
+    // while this one was loading.
     if (pendingFrame.current === frame) {
       setIsLoading(false);
     }

--- a/src/components/Tabs/scatter_plot_data_utils.ts
+++ b/src/components/Tabs/scatter_plot_data_utils.ts
@@ -177,6 +177,9 @@ export function makeLineTrace(
   };
 }
 
+// TODO: Crosshairs can be rendered using Plotly's layout shapes instead of traces,
+// which means time playback can run faster (assuming other plot params don't change).
+// See `Plotting.ts` for an example, and also https://plotly.com/javascript/reference/layout/shapes/.
 /**
  * Returns an array of Plotly traces that render a crosshair at the X,Y coordinates.
  */


### PR DESCRIPTION
Problem
=======
Closes #312, "improve track plot navigation".

This implements part 2 of the original spec by adding in a crosshair that shows the currently-hovered value.

*Estimated review size: small, 10-15 minutes*

Solution
========
- Changed `setTime` in `Plotting` to `updateLayout`, which renders both the dotted line (representing the current time) and the crosshair.
- Added state to track the currently hovered object in the plot (in `PlotWrapper`.)
- Added a loading spinner while the current frame is being loaded in `PlotTab`.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-465/
2. Open any dataset and select a track. Hover over the line.

Screenshots (optional):
-----------------------
![image](https://github.com/user-attachments/assets/b0a26928-cc97-4630-b674-ff9edcc149f2)

