### PR TITLE
feature: Pick border color

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -69,6 +69,7 @@
     ],
     "no-unused-vars": 0, // Rely on typescript-eslint rule above
     "@typescript-eslint/explicit-function-return-type": ["error", { "allowExpressions": true }],
+    "@typescript-eslint/no-duplicate-enum-values": "error",
     "@typescript-eslint/typedef": ["error", { "parameters": true }],
     "prefer-const": 1,
     "radix": 1,

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -22,7 +22,14 @@ import {
 } from "three";
 
 import { MAX_FEATURE_CATEGORIES } from "../constants";
-import { DrawMode, FeatureDataType, OUT_OF_RANGE_COLOR_DEFAULT, OUTLIER_COLOR_DEFAULT } from "./types";
+import {
+  BACKGROUND_COLOR_DEFAULT,
+  DrawMode,
+  FeatureDataType,
+  OUT_OF_RANGE_COLOR_DEFAULT,
+  OUTLIER_COLOR_DEFAULT,
+  SELECTED_COLOR_DEFAULT,
+} from "./types";
 import { packDataTexture } from "./utils/texture_utils";
 
 import ColorRamp from "./ColorRamp";
@@ -33,8 +40,6 @@ import pickFragmentShader from "./shaders/cellId_RGBA8U.frag";
 import vertexShader from "./shaders/colorize.vert";
 import fragmentShader from "./shaders/colorize_RGBA8U.frag";
 
-const BACKGROUND_COLOR_DEFAULT = 0xffffff;
-const SELECTED_COLOR_DEFAULT = 0xff00ff;
 export const BACKGROUND_ID = -1;
 
 type ColorizeUniformTypes = {
@@ -62,6 +67,7 @@ type ColorizeUniformTypes = {
   canvasBackgroundColor: Color;
   outlierColor: Color;
   outOfRangeColor: Color;
+  outlineColor: Color;
   highlightedId: number;
   hideOutOfRange: boolean;
   outlierDrawMode: number;
@@ -100,6 +106,7 @@ const getDefaultUniforms = (): ColorizeUniforms => {
     highlightedId: new Uniform(-1),
     hideOutOfRange: new Uniform(false),
     backgroundColor: new Uniform(new Color(BACKGROUND_COLOR_DEFAULT)),
+    outlineColor: new Uniform(new Color(SELECTED_COLOR_DEFAULT)),
     canvasBackgroundColor: new Uniform(new Color(BACKGROUND_COLOR_DEFAULT)),
     outlierColor: new Uniform(new Color(OUTLIER_COLOR_DEFAULT)),
     outOfRangeColor: new Uniform(new Color(OUT_OF_RANGE_COLOR_DEFAULT)),
@@ -359,6 +366,19 @@ export default class ColorizeCanvas {
   setCategoricalColors(colors: Color[]): void {
     this.categoricalPalette.dispose();
     this.categoricalPalette = new ColorRamp(colors);
+  }
+
+  setOutlineColor(color: Color): void {
+    this.setUniform("outlineColor", color);
+
+    // Update line color
+    if (Array.isArray(this.line.material)) {
+      this.line.material.forEach((mat) => {
+        (mat as LineBasicMaterial).color = color;
+      });
+    } else {
+      (this.line.material as LineBasicMaterial).color = color;
+    }
   }
 
   setBackgroundColor(color: Color): void {

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -28,7 +28,7 @@ import {
   FeatureDataType,
   OUT_OF_RANGE_COLOR_DEFAULT,
   OUTLIER_COLOR_DEFAULT,
-  SELECTED_COLOR_DEFAULT,
+  OUTLINE_COLOR_DEFAULT,
 } from "./types";
 import { packDataTexture } from "./utils/texture_utils";
 
@@ -106,7 +106,7 @@ const getDefaultUniforms = (): ColorizeUniforms => {
     highlightedId: new Uniform(-1),
     hideOutOfRange: new Uniform(false),
     backgroundColor: new Uniform(new Color(BACKGROUND_COLOR_DEFAULT)),
-    outlineColor: new Uniform(new Color(SELECTED_COLOR_DEFAULT)),
+    outlineColor: new Uniform(new Color(OUTLINE_COLOR_DEFAULT)),
     canvasBackgroundColor: new Uniform(new Color(BACKGROUND_COLOR_DEFAULT)),
     outlierColor: new Uniform(new Color(OUTLIER_COLOR_DEFAULT)),
     outOfRangeColor: new Uniform(new Color(OUT_OF_RANGE_COLOR_DEFAULT)),
@@ -196,7 +196,7 @@ export default class ColorizeCanvas {
     const lineGeometry = new BufferGeometry();
     lineGeometry.setAttribute("position", new BufferAttribute(this.points, 3));
     const lineMaterial = new LineBasicMaterial({
-      color: SELECTED_COLOR_DEFAULT,
+      color: OUTLINE_COLOR_DEFAULT,
       linewidth: 1.0,
     });
 

--- a/src/colorizer/shaders/colorize_RGBA8U.frag
+++ b/src/colorizer/shaders/colorize_RGBA8U.frag
@@ -24,6 +24,7 @@ uniform float backdropBrightness;
 uniform float objectOpacity;
 
 uniform vec3 backgroundColor;
+uniform vec3 outlineColor;
 // Background color for the canvas, anywhere where the frame is not drawn.
 uniform vec3 canvasBackgroundColor;
 
@@ -161,7 +162,7 @@ vec4 getObjectColor(vec2 sUv) {
   ivec2 frameDims = textureSize(frame, 0);
   if (int(id) - 1 == highlightedId) {
     if (isEdge(sUv, frameDims)) {
-      return vec4(1.0, 0.0, 1.0, 1.0);
+      return vec4(outlineColor, 1.0);
     }
   }
 

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -11,6 +11,8 @@ import {
   UnsignedIntType,
 } from "three";
 
+export const BACKGROUND_COLOR_DEFAULT = 0xffffff;
+export const SELECTED_COLOR_DEFAULT = 0xff00ff;
 export const OUTLIER_COLOR_DEFAULT = 0xc0c0c0;
 export const OUT_OF_RANGE_COLOR_DEFAULT = 0xdddddd;
 
@@ -164,6 +166,8 @@ export type ViewerConfig = {
   objectOpacity: number;
   outOfRangeDrawSettings: DrawSettings;
   outlierDrawSettings: DrawSettings;
+  /** Hex color, as integer. */
+  outlineColor: number;
   openTab: TabType;
 };
 
@@ -182,6 +186,7 @@ export const defaultViewerConfig: ViewerConfig = {
   objectOpacity: 100,
   outOfRangeDrawSettings: { mode: DrawMode.USE_COLOR, color: new Color(OUT_OF_RANGE_COLOR_DEFAULT) },
   outlierDrawSettings: { mode: DrawMode.USE_COLOR, color: new Color(OUTLIER_COLOR_DEFAULT) },
+  outlineColor: SELECTED_COLOR_DEFAULT,
   openTab: TabType.TRACK_PLOT,
 };
 

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -11,8 +11,9 @@ import {
   UnsignedIntType,
 } from "three";
 
+// TODO: Move to dedicated constants file
 export const BACKGROUND_COLOR_DEFAULT = 0xffffff;
-export const SELECTED_COLOR_DEFAULT = 0xff00ff;
+export const OUTLINE_COLOR_DEFAULT = 0xff00ff;
 export const OUTLIER_COLOR_DEFAULT = 0xc0c0c0;
 export const OUT_OF_RANGE_COLOR_DEFAULT = 0xdddddd;
 
@@ -166,7 +167,6 @@ export type ViewerConfig = {
   objectOpacity: number;
   outOfRangeDrawSettings: DrawSettings;
   outlierDrawSettings: DrawSettings;
-  /** Hex color, as integer. */
   outlineColor: Color;
   openTab: TabType;
 };
@@ -186,7 +186,7 @@ export const defaultViewerConfig: ViewerConfig = {
   objectOpacity: 100,
   outOfRangeDrawSettings: { mode: DrawMode.USE_COLOR, color: new Color(OUT_OF_RANGE_COLOR_DEFAULT) },
   outlierDrawSettings: { mode: DrawMode.USE_COLOR, color: new Color(OUTLIER_COLOR_DEFAULT) },
-  outlineColor: new Color(SELECTED_COLOR_DEFAULT),
+  outlineColor: new Color(OUTLINE_COLOR_DEFAULT),
   openTab: TabType.TRACK_PLOT,
 };
 

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -167,7 +167,7 @@ export type ViewerConfig = {
   outOfRangeDrawSettings: DrawSettings;
   outlierDrawSettings: DrawSettings;
   /** Hex color, as integer. */
-  outlineColor: number;
+  outlineColor: Color;
   openTab: TabType;
 };
 
@@ -186,7 +186,7 @@ export const defaultViewerConfig: ViewerConfig = {
   objectOpacity: 100,
   outOfRangeDrawSettings: { mode: DrawMode.USE_COLOR, color: new Color(OUT_OF_RANGE_COLOR_DEFAULT) },
   outlierDrawSettings: { mode: DrawMode.USE_COLOR, color: new Color(OUTLIER_COLOR_DEFAULT) },
-  outlineColor: SELECTED_COLOR_DEFAULT,
+  outlineColor: new Color(SELECTED_COLOR_DEFAULT),
   openTab: TabType.TRACK_PLOT,
 };
 

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -340,7 +340,6 @@ function deserializeViewerConfig(params: URLSearchParams): Partial<ViewerConfig>
     const outlineColor = "#" + params.get(UrlParam.OUTLINE_COLOR);
     if (isHexColor(outlineColor)) {
       newConfig.outlineColor = new Color(outlineColor);
-      console.log(new Color(outlineColor));
     }
   }
   const openTab = params.get(UrlParam.OPEN_TAB);

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -45,6 +45,7 @@ enum UrlParam {
   OUTLIER_COLOR = "outlier-color",
   FILTERED_MODE = "filter-mode",
   FILTERED_COLOR = "filter-color",
+  OUTLINE_COLOR = "outline-color",
   SHOW_PATH = "path",
   SHOW_SCALEBAR = "scalebar",
   SHOW_TIMESTAMP = "timestamp",
@@ -271,6 +272,12 @@ function serializeViewerConfig(config: Partial<ViewerConfig>): string[] {
     parameters.push(`${UrlParam.FILTERED_COLOR}=${config.outOfRangeDrawSettings.color.getHexString()}`);
     parameters.push(`${UrlParam.FILTERED_MODE}=${config.outOfRangeDrawSettings.mode}`);
   }
+
+  // Color config
+  if (config.outlineColor) {
+    parameters.push(`${UrlParam.OUTLINE_COLOR}=${config.outlineColor.getHexString()}`);
+  }
+
   if (config.openTab) {
     parameters.push(`${UrlParam.OPEN_TAB}=${config.openTab}`);
   }
@@ -328,6 +335,13 @@ function deserializeViewerConfig(params: URLSearchParams): Partial<ViewerConfig>
       params.get(UrlParam.FILTERED_MODE),
       defaultViewerConfig.outOfRangeDrawSettings
     );
+  }
+  if (params.get(UrlParam.OUTLINE_COLOR)) {
+    const outlineColor = "#" + params.get(UrlParam.OUTLINE_COLOR);
+    if (isHexColor(outlineColor)) {
+      newConfig.outlineColor = new Color(outlineColor);
+      console.log(new Color(outlineColor));
+    }
   }
   const openTab = params.get(UrlParam.OPEN_TAB);
   if (openTab && isTabType(openTab)) {

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -284,8 +284,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   }, [props.config.showLegendDuringExport, props.isRecording]);
 
   useMemo(() => {
-    console.log("Outline color changed to", props.config.outlineColor);
-    canv.setOutlineColor(new Color(props.config.outlineColor));
+    canv.setOutlineColor(props.config.outlineColor);
   }, [props.config.outlineColor]);
 
   // CANVAS RESIZING /////////////////////////////////////////////////

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -283,6 +283,11 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
     canv.isFooterVisibleOnExport = props.config.showLegendDuringExport;
   }, [props.config.showLegendDuringExport, props.isRecording]);
 
+  useMemo(() => {
+    console.log("Outline color changed to", props.config.outlineColor);
+    canv.setOutlineColor(new Color(props.config.outlineColor));
+  }, [props.config.outlineColor]);
+
   // CANVAS RESIZING /////////////////////////////////////////////////
 
   /**

--- a/src/components/Dropdowns/DrawModeDropdown.tsx
+++ b/src/components/Dropdowns/DrawModeDropdown.tsx
@@ -3,7 +3,7 @@ import { ColorPicker } from "antd";
 import { PresetsItem } from "antd/es/color-picker/interface";
 import React, { ReactElement, useRef } from "react";
 import styled from "styled-components";
-import { Color as ThreeColor,ColorRepresentation } from "three";
+import { ColorRepresentation, Color as ThreeColor } from "three";
 
 import { DrawMode } from "../../colorizer/types";
 import { FlexRowAlignCenter } from "../../styles/utils";
@@ -27,6 +27,30 @@ const HorizontalDiv = styled(FlexRowAlignCenter)`
   flex-wrap: wrap;
 `;
 
+const defaultPresetColors = [
+  "#ffffff",
+  "#f0f0f0",
+  "#dddddd",
+  "#c0c0c0",
+  "#9d9d9d",
+  "#808080",
+  "#525252",
+  "#393939",
+  "#191919",
+  "#000000",
+];
+const presets: PresetsItem[] = [
+  {
+    label: "Presets",
+    colors: defaultPresetColors,
+  },
+];
+
+const items = [
+  { key: DrawMode.HIDE.toString(), label: "Hide" },
+  { key: DrawMode.USE_COLOR.toString(), label: "Use custom color" },
+];
+
 /**
  * UI element for choosing between different drawing modes, and provides callbacks for when
  * changes are made to selections.
@@ -37,31 +61,6 @@ export default function DrawModeSelector(propsInput: DrawModeSelectorProps): Rea
   const props = { ...defaultProps, ...propsInput } as Required<DrawModeSelectorProps>;
 
   const colorPickerRef = useRef<HTMLParagraphElement>(null);
-
-  const items = [
-    { key: DrawMode.HIDE.toString(), label: "Hide" },
-    { key: DrawMode.USE_COLOR.toString(), label: "Use custom color" },
-  ];
-
-  const defaultPresetColors = [
-    "#ffffff",
-    "#f0f0f0",
-    "#dddddd",
-    "#c0c0c0",
-    "#9d9d9d",
-    "#808080",
-    "#525252",
-    "#393939",
-    "#191919",
-    "#000000",
-  ];
-  const presets: PresetsItem[] = [
-    {
-      label: "Presets",
-      colors: defaultPresetColors,
-    },
-  ];
-
   const showColorPicker = props.selected === DrawMode.USE_COLOR;
 
   return (

--- a/src/components/Dropdowns/DrawModeDropdown.tsx
+++ b/src/components/Dropdowns/DrawModeDropdown.tsx
@@ -3,7 +3,7 @@ import { ColorPicker } from "antd";
 import { PresetsItem } from "antd/es/color-picker/interface";
 import React, { ReactElement, useRef } from "react";
 import styled from "styled-components";
-import { ColorRepresentation, Color as ThreeColor } from "three";
+import { Color as ThreeColor, ColorRepresentation } from "three";
 
 import { DrawMode } from "../../colorizer/types";
 import { FlexRowAlignCenter } from "../../styles/utils";

--- a/src/components/Tabs/SettingsTab.tsx
+++ b/src/components/Tabs/SettingsTab.tsx
@@ -1,9 +1,10 @@
-import { Checkbox } from "antd";
+import { Color as AntdColor } from "@rc-component/color-picker";
+import { Checkbox, ColorPicker } from "antd";
 import React, { ReactElement } from "react";
 import { Color } from "three";
 
 import { Dataset } from "../../colorizer";
-import { DrawMode, ViewerConfig } from "../../colorizer/types";
+import { DrawMode, SELECTED_COLOR_DEFAULT, ViewerConfig } from "../../colorizer/types";
 import { FlexColumn } from "../../styles/utils";
 
 import CustomCollapse from "../CustomCollapse";
@@ -19,6 +20,25 @@ const NO_BACKDROP = {
 
 const INDENT_PX = 24;
 const MAX_SLIDER_WIDTH = "250px";
+
+const defaultOutlinePresetColors = [
+  "#dddddd",
+  "#808080",
+  "#525252",
+  "#ff00ff",
+  "#ff0000",
+  "#ff8800",
+  "#ffcf00",
+  "#00ff00",
+  "#00ffff",
+  "#0048ff",
+];
+const outlineColorPresets = [
+  {
+    label: "Presets",
+    colors: defaultOutlinePresetColors,
+  },
+];
 
 type SettingsTabProps = {
   config: ViewerConfig;
@@ -47,7 +67,7 @@ export default function SettingsTab(props: SettingsTabProps): ReactElement {
   return (
     <FlexColumn $gap={5}>
       <CustomCollapse label="Backdrop">
-        <SettingsContainer indentPx={INDENT_PX} labelFormatter={h3Wrapper}>
+        <SettingsContainer indentPx={INDENT_PX} labelFormatter={h3Wrapper} gapPx={8}>
           <SettingsItem label="Backdrop images">
             <SelectionDropdown
               selected={props.selectedBackdropKey || NO_BACKDROP.key}
@@ -92,7 +112,22 @@ export default function SettingsTab(props: SettingsTabProps): ReactElement {
         </SettingsContainer>
       </CustomCollapse>
       <CustomCollapse label="Objects">
-        <SettingsContainer indentPx={INDENT_PX} labelFormatter={h3Wrapper}>
+        <SettingsContainer indentPx={INDENT_PX} labelFormatter={h3Wrapper} gapPx={8}>
+          <SettingsItem label="Outline color">
+            <div>
+              <ColorPicker
+                style={{ width: "min-content" }}
+                size="small"
+                disabledAlpha={true}
+                defaultValue={new AntdColor(SELECTED_COLOR_DEFAULT)}
+                onChange={(_color, hex) => {
+                  hex = hex.replace("#", "0x");
+                  props.updateConfig({ outlineColor: parseInt(hex, 16) });
+                }}
+                presets={outlineColorPresets}
+              />
+            </div>
+          </SettingsItem>
           <SettingsItem label="Filtered object color">
             <DrawModeDropdown
               selected={props.config.outOfRangeDrawSettings.mode}

--- a/src/components/Tabs/SettingsTab.tsx
+++ b/src/components/Tabs/SettingsTab.tsx
@@ -1,7 +1,7 @@
 import { Color as AntdColor } from "@rc-component/color-picker";
 import { Checkbox, ColorPicker } from "antd";
 import React, { ReactElement } from "react";
-import { Color } from "three";
+import { Color, ColorRepresentation } from "three";
 
 import { Dataset } from "../../colorizer";
 import { DrawMode, SELECTED_COLOR_DEFAULT, ViewerConfig } from "../../colorizer/types";
@@ -121,9 +121,9 @@ export default function SettingsTab(props: SettingsTabProps): ReactElement {
                 disabledAlpha={true}
                 defaultValue={new AntdColor(SELECTED_COLOR_DEFAULT)}
                 onChange={(_color, hex) => {
-                  hex = hex.replace("#", "0x");
-                  props.updateConfig({ outlineColor: parseInt(hex, 16) });
+                  props.updateConfig({ outlineColor: new Color(hex as ColorRepresentation) });
                 }}
+                value={new AntdColor(props.config.outlineColor.getHexString())}
                 presets={outlineColorPresets}
               />
             </div>

--- a/src/components/Tabs/SettingsTab.tsx
+++ b/src/components/Tabs/SettingsTab.tsx
@@ -4,7 +4,7 @@ import React, { ReactElement } from "react";
 import { Color, ColorRepresentation } from "three";
 
 import { Dataset } from "../../colorizer";
-import { DrawMode, SELECTED_COLOR_DEFAULT, ViewerConfig } from "../../colorizer/types";
+import { DrawMode, OUTLINE_COLOR_DEFAULT, ViewerConfig } from "../../colorizer/types";
 import { FlexColumn } from "../../styles/utils";
 
 import CustomCollapse from "../CustomCollapse";
@@ -119,7 +119,7 @@ export default function SettingsTab(props: SettingsTabProps): ReactElement {
                 style={{ width: "min-content" }}
                 size="small"
                 disabledAlpha={true}
-                defaultValue={new AntdColor(SELECTED_COLOR_DEFAULT)}
+                defaultValue={new AntdColor(OUTLINE_COLOR_DEFAULT)}
                 onChange={(_color, hex) => {
                   props.updateConfig({ outlineColor: new Color(hex as ColorRepresentation) });
                 }}


### PR DESCRIPTION
Problem
=======
Closes #165, "customize outline and path colors."

*Estimated size: small, 15 minutes*

Solution
========
- Adds an option to select the outline color in the settings tab.
- Adds the outline color as a variable in the viewer state config.
- Adds saving of the outline color to and parsing from the URL.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link and load a dataset. https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-466/
2. Go to the viewer settings. Click on a cell in the viewport and edit the outline color. You should see it update!
3. Copy the URL and open it in a new (incognito) window. The outline color should remain the same.

Screenshots (optional):
-----------------------

![image](https://github.com/user-attachments/assets/6e7f80a9-c2a7-470f-8007-1a00494109e6)

![image](https://github.com/user-attachments/assets/854867f2-7c8d-47bf-a1e4-1901bff0aa5e)

![image](https://github.com/user-attachments/assets/487ad603-9872-4ebe-ae48-ea03ac985e25)
