### PR TITLE
feat: Show dataset name if collection has no name in metadata

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -899,7 +899,7 @@ function Viewer(): ReactElement {
       <SmallScreenWarning />
 
       <Header alertElement={bannerElement} headerOpensInNewTab={true}>
-        <h3>{collection?.metadata.name ?? dataset?.metadata.name ?? null}</h3>
+        <h3>{collection?.metadata.name ?? dataset?.metadata.name ?? dataset ? "Unnamed dataset" : null}</h3>
         <FlexRowAlignCenter $gap={12} $wrap="wrap">
           <FlexRowAlignCenter $gap={2} $wrap="wrap">
             <LoadDatasetButton

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -8,7 +8,17 @@ import {
 } from "@ant-design/icons";
 import { Checkbox, notification, Slider, Tabs } from "antd";
 import { NotificationConfig } from "antd/es/notification/interface";
-import React, { ReactElement, useCallback, useContext, useEffect, useMemo, useReducer, useRef, useState } from "react";
+import React, {
+  ReactElement,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 import { Link, Location, useLocation, useSearchParams } from "react-router-dom";
 
 import {
@@ -893,9 +903,15 @@ function Viewer(): ReactElement {
     vectorTooltipText ? <p key="vector">{vectorTooltipText}</p> : null,
   ];
 
-  let datasetName = collection?.metadata.name ?? dataset?.metadata.name ?? null;
-  if (!datasetName && dataset) {
-    datasetName = "Unnamed dataset";
+  let datasetHeader: ReactNode = null;
+  if (collection && collection.metadata.name) {
+    datasetHeader = collection.metadata.name;
+  } else if (dataset && dataset.metadata.name) {
+    datasetHeader = dataset.metadata.name;
+  } else if (dataset) {
+    datasetHeader = <span style={{ color: theme.color.text.hint }}>Untitled dataset</span>;
+  } else {
+    datasetHeader = null;
   }
 
   return (
@@ -904,7 +920,7 @@ function Viewer(): ReactElement {
       <SmallScreenWarning />
 
       <Header alertElement={bannerElement} headerOpensInNewTab={true}>
-        <h3>{datasetName}</h3>
+        <h3>{datasetHeader}</h3>
         <FlexRowAlignCenter $gap={12} $wrap="wrap">
           <FlexRowAlignCenter $gap={2} $wrap="wrap">
             <LoadDatasetButton

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -899,7 +899,7 @@ function Viewer(): ReactElement {
       <SmallScreenWarning />
 
       <Header alertElement={bannerElement} headerOpensInNewTab={true}>
-        <h3>{collection?.metadata.name ?? null}</h3>
+        <h3>{collection?.metadata.name ?? dataset?.metadata.name ?? null}</h3>
         <FlexRowAlignCenter $gap={12} $wrap="wrap">
           <FlexRowAlignCenter $gap={2} $wrap="wrap">
             <LoadDatasetButton

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -893,13 +893,18 @@ function Viewer(): ReactElement {
     vectorTooltipText ? <p key="vector">{vectorTooltipText}</p> : null,
   ];
 
+  let datasetName = collection?.metadata.name ?? dataset?.metadata.name ?? null;
+  if (!datasetName && dataset) {
+    datasetName = "Unnamed dataset";
+  }
+
   return (
     <div>
       <div ref={notificationContainer}>{notificationContextHolder}</div>
       <SmallScreenWarning />
 
       <Header alertElement={bannerElement} headerOpensInNewTab={true}>
-        <h3>{collection?.metadata.name ?? dataset?.metadata.name ?? dataset ? "Unnamed dataset" : null}</h3>
+        <h3>{datasetName}</h3>
         <FlexRowAlignCenter $gap={12} $wrap="wrap">
           <FlexRowAlignCenter $gap={2} $wrap="wrap">
             <LoadDatasetButton


### PR DESCRIPTION
Problem
=======
Closes #350, "show dataset name at the top of the page."

*Estimated review size: tiny, <5 minutes*

Solution
========
- Use dataset name as a fallback if collection has no name.
- Adds a placeholder if no name is present at all.

Steps to Verify:
----------------
1. Open preview link with named collection: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-489/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Ffull-interphase_dataset%2Fcollection.json
2. Open preview link that's a direct dataset (you should see a different dataset name!): https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-489/viewer?dataset=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Ffull-interphase_dataset%2Fsmall%2Fmanifest.json
3. Open a final preview link where a dataset is not present: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-489/viewer?dataset=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Ftest%2F3500005828_25%2Fmanifest.json

Screenshots (optional):
-----------------------

![image](https://github.com/user-attachments/assets/0de90bb3-b737-4820-a027-b1aca48df79e)

