### PR TITLE
fix: Make PR preview link consistent

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -14,6 +14,7 @@ concurrency: preview-${{ github.ref }}
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
+    needs: [deploy-preview-internal]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
Problem
=======
Currently there's a GitHub action that builds two previews for the app, one in its public version and one for an internal version w/ experimental features. Before, both jobs were run at the same time, resulting in a race condition where the PR comment would either have the preview or the internal version randomly.

This change orders the steps so the standard, public build preview is always built last, and overrides the internal link. You can still access the internal version by adding `-internal` to a PR preview link:
- https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-490/
- https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview-internal/pr-490/

*Estimated review size: tiny, 1 minute*
