### PR TITLE
fix: Adds language property to 404 HTML page, adds viewer build target to package.json

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Timelapse Feature Explorer</title>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "checks": "npm run lint & npm run typeCheck & npx vitest run",
     "build": "vite build",
     "build-internal": "vite build --base=/nucmorph-colorizer/ --config config/vite.internal-build.config.js",
-    "build-documentation": "vite build --base=/viewer/",
+    "build-colorizer-data-docs": "vite build --base=/viewer/",
     "preview": "vite preview",
     "deploy": "vite build --base=/timelapse-colorizer/ && gh-pages -d dist -a -m \"New gh-pages build; deployed via `deploy` script in `package.json`.\"",
     "lint": "eslint --config ./.eslintrc --ext .ts --ext .tsx --ext .js --ext .jsx .",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "checks": "npm run lint & npm run typeCheck & npx vitest run",
     "build": "vite build",
     "build-internal": "vite build --base=/nucmorph-colorizer/ --config config/vite.internal-build.config.js",
+    "build-documentation": "vite build --base=/viewer/",
     "preview": "vite preview",
     "deploy": "vite build --base=/timelapse-colorizer/ && gh-pages -d dist -a -m \"New gh-pages build; deployed via `deploy` script in `package.json`.\"",
     "lint": "eslint --config ./.eslintrc --ext .ts --ext .tsx --ext .js --ext .jsx .",


### PR DESCRIPTION
Tiny fix! Saw that the `lang="en"` tag was missing from our 404 HTML page.

*Estimated review size: tiny, 1 minute*