### PR TITLE
refactor: Moved tab rendering logic (annotations pt. 2)

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -45,7 +45,7 @@ import { getColorMap, getInRangeLUT, thresholdMatchFinder, validateThresholds } 
 import { useConstructor, useDebounce, useMotionDeltas, useRecentCollections } from "./colorizer/utils/react_utils";
 import * as urlUtils from "./colorizer/utils/url_utils";
 import { SCATTERPLOT_TIME_FEATURE } from "./components/Tabs/scatter_plot_data_utils";
-import { DEFAULT_PLAYBACK_FPS } from "./constants";
+import { DEFAULT_PLAYBACK_FPS, INTERNAL_BUILD } from "./constants";
 import { FlexRow, FlexRowAlignCenter } from "./styles/utils";
 import { LocationState } from "./types";
 
@@ -852,6 +852,94 @@ function Viewer(): ReactElement {
     return [threshold.min, threshold.max];
   };
 
+  const tabItems = [
+    {
+      label: "Track plot",
+      key: TabType.TRACK_PLOT,
+      children: (
+        <div className={styles.tabContent}>
+          <PlotTab
+            setFrame={setFrameAndRender}
+            findTrackInputText={findTrackInput}
+            setFindTrackInputText={setFindTrackInput}
+            findTrack={findTrack}
+            currentFrame={currentFrame}
+            dataset={dataset}
+            featureKey={featureKey}
+            selectedTrack={selectedTrack}
+            disabled={disableUi}
+          />
+        </div>
+      ),
+    },
+    {
+      label: "Scatter plot",
+      key: TabType.SCATTER_PLOT,
+      children: (
+        <div className={styles.tabContent}>
+          <ScatterPlotTab
+            dataset={dataset}
+            currentFrame={currentFrame}
+            selectedTrack={selectedTrack}
+            findTrack={findTrack}
+            setFrame={setFrameAndRender}
+            isVisible={config.openTab === TabType.SCATTER_PLOT}
+            isPlaying={timeControls.isPlaying() || isRecording}
+            selectedFeatureKey={featureKey}
+            colorRampMin={colorRampMin}
+            colorRampMax={colorRampMax}
+            colorRamp={getColorMap(colorRampData, colorRampKey, colorRampReversed)}
+            categoricalPalette={categoricalPalette}
+            inRangeIds={inRangeLUT}
+            viewerConfig={config}
+            scatterPlotConfig={scatterPlotConfig}
+            updateScatterPlotConfig={updateScatterPlotConfig}
+            showAlert={showAlert}
+          />
+        </div>
+      ),
+    },
+    {
+      label: `Filters ${featureThresholds.length > 0 ? `(${featureThresholds.length})` : ""}`,
+      key: TabType.FILTERS,
+      children: (
+        <div className={styles.tabContent}>
+          <FeatureThresholdsTab
+            featureThresholds={featureThresholds}
+            onChange={setFeatureThresholds}
+            dataset={dataset}
+            disabled={disableUi}
+            categoricalPalette={categoricalPalette}
+          />
+        </div>
+      ),
+    },
+    {
+      label: "Viewer settings",
+      key: TabType.SETTINGS,
+      children: (
+        <div className={styles.tabContent}>
+          <SettingsTab
+            config={config}
+            updateConfig={updateConfig}
+            dataset={dataset}
+            // TODO: This could be part of a dataset-specific settings object
+            selectedBackdropKey={selectedBackdropKey}
+            setSelectedBackdropKey={setSelectedBackdropKey}
+          />
+        </div>
+      ),
+    },
+  ];
+
+  if (INTERNAL_BUILD) {
+    tabItems.push({
+      label: "Annotations",
+      key: TabType.ANNOTATION,
+      children: <div className={styles.tabContent}>Coming soon</div>,
+    });
+  }
+
   let datasetHeader: ReactNode = null;
   if (collection && collection.metadata.name) {
     datasetHeader = collection.metadata.name;
@@ -1130,85 +1218,7 @@ function Viewer(): ReactElement {
                 size="large"
                 activeKey={config.openTab}
                 onChange={(key) => updateConfig({ openTab: key as TabType })}
-                items={[
-                  {
-                    label: "Track plot",
-                    key: TabType.TRACK_PLOT,
-                    children: (
-                      <div className={styles.tabContent}>
-                        <PlotTab
-                          setFrame={setFrameAndRender}
-                          findTrackInputText={findTrackInput}
-                          setFindTrackInputText={setFindTrackInput}
-                          findTrack={findTrack}
-                          currentFrame={currentFrame}
-                          dataset={dataset}
-                          featureKey={featureKey}
-                          selectedTrack={selectedTrack}
-                          disabled={disableUi}
-                        />
-                      </div>
-                    ),
-                  },
-                  {
-                    label: "Scatter plot",
-                    key: TabType.SCATTER_PLOT,
-                    children: (
-                      <div className={styles.tabContent}>
-                        <ScatterPlotTab
-                          dataset={dataset}
-                          currentFrame={currentFrame}
-                          selectedTrack={selectedTrack}
-                          findTrack={findTrack}
-                          setFrame={setFrameAndRender}
-                          isVisible={config.openTab === TabType.SCATTER_PLOT}
-                          isPlaying={timeControls.isPlaying() || isRecording}
-                          selectedFeatureKey={featureKey}
-                          colorRampMin={colorRampMin}
-                          colorRampMax={colorRampMax}
-                          colorRamp={getColorMap(colorRampData, colorRampKey, colorRampReversed)}
-                          categoricalPalette={categoricalPalette}
-                          inRangeIds={inRangeLUT}
-                          viewerConfig={config}
-                          scatterPlotConfig={scatterPlotConfig}
-                          updateScatterPlotConfig={updateScatterPlotConfig}
-                          showAlert={showAlert}
-                        />
-                      </div>
-                    ),
-                  },
-                  {
-                    label: `Filters ${featureThresholds.length > 0 ? `(${featureThresholds.length})` : ""}`,
-                    key: TabType.FILTERS,
-                    children: (
-                      <div className={styles.tabContent}>
-                        <FeatureThresholdsTab
-                          featureThresholds={featureThresholds}
-                          onChange={setFeatureThresholds}
-                          dataset={dataset}
-                          disabled={disableUi}
-                          categoricalPalette={categoricalPalette}
-                        />
-                      </div>
-                    ),
-                  },
-                  {
-                    label: "Viewer settings",
-                    key: TabType.SETTINGS,
-                    children: (
-                      <div className={styles.tabContent}>
-                        <SettingsTab
-                          config={config}
-                          updateConfig={updateConfig}
-                          dataset={dataset}
-                          // TODO: This could be part of a dataset-specific settings object
-                          selectedBackdropKey={selectedBackdropKey}
-                          setSelectedBackdropKey={setSelectedBackdropKey}
-                        />
-                      </div>
-                    ),
-                  },
-                ]}
+                items={tabItems}
               />
             </div>
           </div>

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -156,6 +156,7 @@ export enum TabType {
   TRACK_PLOT = "track_plot",
   SCATTER_PLOT = "scatter_plot",
   SETTINGS = "settings",
+  ANNOTATION = "annotation",
 }
 
 export const isTabType = (tab: string): tab is TabType => {


### PR DESCRIPTION
Problem
=======
Part 2 of ??? for #484, prototyping annotations.

This change is a simple code move, with a little extra placeholder for the annotation tab thrown in.

*Estimated review size: small, <10 minutes*

Solution
========
- Moved tab rendering logic out of returned JSX for readability.
- Added placeholder for Annotation tab that's only visible in internal build mode.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open internal preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview-internal/pr-500/
2. Compare with regular build. The annotation tab should not appear. https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-500/