### PR TITLE
fix: Selected object outline has a consistent width with zoom

### DIFF
--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -45,6 +45,7 @@ export const BACKGROUND_ID = -1;
 type ColorizeUniformTypes = {
   /** Scales from canvas coordinates to frame coordinates. */
   canvasToFrameScale: Vector2;
+  canvasSizePx: Vector2;
   /** XY offset of the frame, in normalized frame coordinates. [-0.5, 0.5] range. */
   panOffset: Vector2;
   /** Image, mapping each pixel to an object ID using the RGBA values. */
@@ -91,6 +92,7 @@ const getDefaultUniforms = (): ColorizeUniforms => {
   return {
     panOffset: new Uniform(new Vector2(0, 0)),
     canvasToFrameScale: new Uniform(new Vector2(1, 1)),
+    canvasSizePx: new Uniform(new Vector2(1, 1)),
     frame: new Uniform(emptyFrame),
     featureData: new Uniform(emptyFeature),
     outlierData: new Uniform(emptyOutliers),
@@ -299,6 +301,7 @@ export default class ColorizeCanvas {
     if (!frameResolution || !canvasResolution) {
       return;
     }
+    this.setUniform("canvasSizePx", canvasResolution);
     // Both the frame and the canvas have coordinates in a range of [0, 1] in the x and y axis.
     // However, the canvas may have a different aspect ratio than the frame, so we need to scale
     // the frame to fit within the canvas while maintaining the aspect ratio.

--- a/src/colorizer/shaders/colorize_RGBA8U.frag
+++ b/src/colorizer/shaders/colorize_RGBA8U.frag
@@ -15,6 +15,7 @@ uniform float featureColorRampMin;
 uniform float featureColorRampMax;
 
 uniform vec2 canvasToFrameScale;
+uniform vec2 canvasSizePx;
 uniform vec2 panOffset;
 uniform sampler2D colorRamp;
 uniform sampler2D overlay;
@@ -25,6 +26,7 @@ uniform float objectOpacity;
 
 uniform vec3 backgroundColor;
 uniform vec3 outlineColor;
+uniform float outlineWidthPx;
 // Background color for the canvas, anywhere where the frame is not drawn.
 uniform vec3 canvasBackgroundColor;
 
@@ -91,8 +93,9 @@ vec4 getColorRamp(float val) {
 
 bool isEdge(vec2 uv, ivec2 frameDims) {
   float thickness = 2.0;
-  float wStep = 1.0 / float(frameDims.x);
-  float hStep = 1.0 / float(frameDims.y);        
+  // step size is equal to 1 onscreen canvas pixel     
+  float wStep = 1.0 / float(canvasSizePx.x) * float(canvasToFrameScale.x);
+  float hStep = 1.0 / float(canvasSizePx.y) * float(canvasToFrameScale.y);        
   // sample around the pixel to see if we are on an edge
   // TODO: Fix this so it samples using canvas pixel offsets instead of frame pixel offsets.
   // Currently, the edge detection is sparser when loading high-resolution frames.

--- a/src/colorizer/shaders/colorize_RGBA8U.frag
+++ b/src/colorizer/shaders/colorize_RGBA8U.frag
@@ -97,8 +97,6 @@ bool isEdge(vec2 uv, ivec2 frameDims) {
   float wStep = 1.0 / float(canvasSizePx.x) * float(canvasToFrameScale.x);
   float hStep = 1.0 / float(canvasSizePx.y) * float(canvasToFrameScale.y);        
   // sample around the pixel to see if we are on an edge
-  // TODO: Fix this so it samples using canvas pixel offsets instead of frame pixel offsets.
-  // Currently, the edge detection is sparser when loading high-resolution frames.
   int R = int(combineColor(texture(frame, uv + vec2(thickness * wStep, 0)))) - 1;
   int L = int(combineColor(texture(frame, uv + vec2(-thickness * wStep, 0)))) - 1;
   int T = int(combineColor(texture(frame, uv + vec2(0, thickness * hStep)))) - 1;

--- a/src/colorizer/shaders/colorize_RGBA8U.frag
+++ b/src/colorizer/shaders/colorize_RGBA8U.frag
@@ -91,7 +91,7 @@ vec4 getColorRamp(float val) {
   return texture(colorRamp, vec2(adjustedVal, 0.5));
 }
 
-bool isEdge(vec2 uv, ivec2 frameDims) {
+bool isEdge(vec2 uv) {
   float thickness = 2.0;
   // step size is equal to 1 onscreen canvas pixel     
   float wStep = 1.0 / float(canvasSizePx.x) * float(canvasToFrameScale.x);
@@ -160,9 +160,8 @@ vec4 getObjectColor(vec2 sUv, float opacity) {
   }
 
   // do an outline around highlighted object
-  ivec2 frameDims = textureSize(frame, 0);
   if (int(id) - 1 == highlightedId) {
-    if (isEdge(sUv, frameDims)) {
+    if (isEdge(sUv)) {
       // ignore opacity for edge color
       return vec4(outlineColor, 1.0);
     }


### PR DESCRIPTION
Problem
=======
Closes #187, "Outlines are inconsistently thin on high-resolution frames." 

We had an issue where the outlines were always 2 pixels wide in the dimensions of the original data. For very high-resolution images, this resulted in very thin outlines that were hard to see.

Outlines are now 2 pixels wide regardless of zoom level or image dimensions!

*Estimated review size: tiny, <5 minutes*

Solution
========
- Edge detection in the fragment shader now steps by onscreen canvas pixels instead of original frame pixels.

## Type of change

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open the preview link and zoom/interact with cells/resize the window: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-505/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fassay-dev%2Fcomputational%2Fdata%2Fendothileal_cell_data%2FTimelapse_20x_dataset%2Fcolorizer_outputs%2Fflow_change_movie%2Fcollections_all.json
2. Compare against the main build:  https://timelapse.allencell.org/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fassay-dev%2Fcomputational%2Fdata%2Fendothileal_cell_data%2FTimelapse_20x_dataset%2Fcolorizer_outputs%2Fflow_change_movie%2Fcollections_all.json

Screenshots (optional):
-----------------------
| Before | After |
| --- | --- |
| ![JohnPaul_20240305_flow_change_endo_cytosol_tubulin_model_combined_cell_model-track_id-000](https://github.com/user-attachments/assets/2297d92d-2f6a-46f3-8468-d6a3d09d7b96) | ![JohnPaul_20240305_flow_change_endo_cytosol_tubulin_model_combined_cell_model-track_id-000 (4)](https://github.com/user-attachments/assets/dbbc84b2-7186-4461-bf33-01d8e7329547) |
| ![JohnPaul_20240305_flow_change_endo_cytosol_tubulin_model_combined_cell_model-track_id-000 (3)](https://github.com/user-attachments/assets/baecc768-4d41-4ba3-ac67-ea24676fa30c) | ![JohnPaul_20240305_flow_change_endo_cytosol_tubulin_model_combined_cell_model-track_id-000 (6)](https://github.com/user-attachments/assets/16719607-adf3-4d32-839f-950b5e998776) |
