### PR TITLE
fix: Pressing enter in load menu text input initiates load

### DIFF
--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -297,6 +297,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
                     onChange={(event) => setUrlInput(event.target.value)}
                     allowClear
                     disabled={isLoading}
+                    onPressEnter={handleLoadClicked}
                   />
                 </Dropdown>
                 <Button type="primary" onClick={handleLoadClicked} loading={isLoading}>


### PR DESCRIPTION
Problem
=======
Closes #487, "Pressing enter in load dialog input should activate load."

*Estimated review size: tiny, 2 minutes*

Solution
========
- Pressing enter in the input area of the load menu now initiates a load. (This does the same thing as pressing the "Load" button.)

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open the PR preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-506/
2. Click the load button. Paste in the following link, and then press enter. The dataset should start loading: `https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/timelapse_feature_explorer_datasets/full-interphase_dataset/collection.json`

![image](https://github.com/user-attachments/assets/0454244c-aa24-4add-86e3-a4d7815d978c)
