### PR TITLE
fix: Updates upload-artifact action to most recent release

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -41,7 +41,7 @@ jobs:
           run: npm ci && npx vite build
   
         - name: Upload build files
-          uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+          uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
           with:
             name: aws-deploy-files
             path: ./dist

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm ci && npx vite build --base=/timelapse-colorizer/
 
       - name: Upload build files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
         with:
           name: production-files
           path: ./dist


### PR DESCRIPTION
Problem
=======
The GH pages build failed due to `upload-artifact@v3` being deprecated. This PR updates it to the most recent release (`v4.5.0`).

See https://github.com/allen-cell-animated/timelapse-colorizer/actions/runs/12695689648.

Solution
========
- Updates `upload-artifact` action to `v4.5.0`.

## Type of change
* Bug fix (non-breaking change which fixes an issue)
