### PR TITLE
fix: Updated download-artifact dependency to v4.1.8

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -81,7 +81,7 @@ jobs:
               fi          
 
           - name: Download build artifacts
-            uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+            uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
             with:
               name: aws-deploy-files
               path: ./dist

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: production-files
           path: ./dist


### PR DESCRIPTION
I updated the `upload-artifact` dependency to v4 in a previous PR to fix a deprecation warning, but I also needed to update `download-artifact` to v4 as well for compatibility.