### PR TITLE
feat: Async calculation of correlations on workers (correlations pt. 1)

### DIFF
--- a/src/colorizer/utils/correlation.ts
+++ b/src/colorizer/utils/correlation.ts
@@ -15,6 +15,8 @@ export function pearson(x: Float32Array, y: Float32Array): number {
   }
 
   const arrayLength = x.length;
+  // TODO: Could potentially optimize here by not re-initializing the arrays on
+  // every call.
   const xy = new Float32Array(arrayLength);
   const x2 = new Float32Array(arrayLength);
   const y2 = new Float32Array(arrayLength);
@@ -79,6 +81,7 @@ export function computeCorrelations(featureData: Float32Array[]): number[][] {
   // Optimization: Only calculate coefficients for [x][y] where y < x. [x][x] is
   // always 1, and [x][y] == [y][x], so we only need to calculate it once for
   // each x, y pair.
+  // TODO: Potential optimization by parallelizing this using shared memory.
   for (let colx = 0; colx < featureData.length; colx++) {
     const row = [];
     for (let coly = 0; coly < colx; coly++) {

--- a/src/colorizer/utils/correlation.ts
+++ b/src/colorizer/utils/correlation.ts
@@ -2,8 +2,11 @@
  * Calculates the Pearson correlation coefficient (a measurement of linear
  * correlation) between two arrays of numbers. See
  * https://en.wikipedia.org/wiki/Pearson_correlation_coefficient.
+ * @returns
+ * A number between -1 and 1 representing the correlation. Returns 0 if there
+ * are no finite values in the input arrays.
  */
-function pearson(x: Float32Array, y: Float32Array): number {
+export function pearson(x: Float32Array, y: Float32Array): number {
   // Adapted from: https://memory.psych.mun.ca/tech/js/correlation.shtml
   if (x.length !== y.length) {
     throw new Error(
@@ -27,6 +30,10 @@ function pearson(x: Float32Array, y: Float32Array): number {
     totalFiniteElements++;
   }
 
+  if (totalFiniteElements === 0) {
+    return 0;
+  }
+
   let sumx = 0;
   let sumy = 0;
   let sumxy = 0;
@@ -48,6 +55,13 @@ function pearson(x: Float32Array, y: Float32Array): number {
   const step2 = totalFiniteElements * sumx2 - sumx * sumx;
   const step3 = totalFiniteElements * sumy2 - sumy * sumy;
   const step4 = Math.sqrt(step2 * step3);
+
+  // Both numerator and denominator are 0, which occurs if one
+  // (or both) arrays have no variance. In this case, the correlation is 0.
+  if (Math.abs(step1) < 1e-6 && Math.abs(step4) < 1e-6) {
+    return 0;
+  }
+
   const answer = step1 / step4;
   return answer;
 }

--- a/src/colorizer/utils/correlation.ts
+++ b/src/colorizer/utils/correlation.ts
@@ -80,7 +80,7 @@ export function computeCorrelations(featureData: Float32Array[]): number[][] {
   // fill in remainder of diagonal with transposed values
   for (let i = 0; i < out.length; i++) {
     for (let j = i + 1; j < out.length; j++) {
-      out[j][i] = out[i][j];
+      out[i][j] = out[j][i];
     }
     out[i][i] = 1;
   }

--- a/src/colorizer/utils/correlation.ts
+++ b/src/colorizer/utils/correlation.ts
@@ -1,0 +1,84 @@
+/**
+ * Calculates the Pearson correlation coefficient (a measurement of linear
+ * correlation) between two arrays of numbers. See
+ * https://en.wikipedia.org/wiki/Pearson_correlation_coefficient.
+ */
+function pearson(x: Float32Array, y: Float32Array): number {
+  // Adapted from: https://memory.psych.mun.ca/tech/js/correlation.shtml
+  if (x.length !== y.length) {
+    throw new Error(
+      "correlations.ts/pearson: Data arrays must have the same length when calculating correlation coefficient."
+    );
+  }
+
+  const arrayLength = x.length;
+  const xy = new Float32Array(arrayLength);
+  const x2 = new Float32Array(arrayLength);
+  const y2 = new Float32Array(arrayLength);
+
+  let totalFiniteElements = 0;
+  for (let i = 0; i < arrayLength; i++) {
+    if (!Number.isFinite(x[i]) || !Number.isFinite(y[i])) {
+      continue;
+    }
+    xy[i] = x[i] * y[i];
+    x2[i] = x[i] * x[i];
+    y2[i] = y[i] * y[i];
+    totalFiniteElements++;
+  }
+
+  let sumx = 0;
+  let sumy = 0;
+  let sumxy = 0;
+  let sumx2 = 0;
+  let sumy2 = 0;
+
+  for (let i = 0; i < arrayLength; i++) {
+    if (!Number.isFinite(x[i]) || !Number.isFinite(y[i])) {
+      continue;
+    }
+    sumx += x[i];
+    sumy += y[i];
+    sumxy += xy[i];
+    sumx2 += x2[i];
+    sumy2 += y2[i];
+  }
+
+  const step1 = totalFiniteElements * sumxy - sumx * sumy;
+  const step2 = totalFiniteElements * sumx2 - sumx * sumx;
+  const step3 = totalFiniteElements * sumy2 - sumy * sumy;
+  const step4 = Math.sqrt(step2 * step3);
+  const answer = step1 / step4;
+  return answer;
+}
+
+/**
+ * Computes a matrix of Pearson correlation coefficients between the provided
+ * arrays of feature data.
+ * @param featureData An array of Float32Arrays of feature data.
+ * @returns a 2D matrix of correlation values between each pair of features. For
+ * any indices `i` and `j`, the value at `[i][j]` (or `[j][i]`) is the
+ * correlation coefficient between the `i`th and `j`th features.
+ */
+export function computeCorrelations(featureData: Float32Array[]): number[][] {
+  const out: number[][] = [];
+  for (let colx = 0; colx < featureData.length; colx++) {
+    const row = [];
+    for (let coly = 0; coly < colx; coly++) {
+      // get list of values for colx and coly
+      const xvals = featureData[colx];
+      const yvals = featureData[coly];
+      const val = pearson(xvals, yvals);
+      row.push(val);
+    }
+    out.push(row);
+  }
+  for (let i = 0; i < out.length; i++) {
+    // fill in remainder of diagonal with transposed values
+    for (let j = 1; j < out.length; j++) {
+      out[i][j] = out[j][i];
+    }
+    out[i][i] = 1;
+  }
+  return out;
+}

--- a/src/colorizer/utils/correlation.ts
+++ b/src/colorizer/utils/correlation.ts
@@ -62,6 +62,9 @@ function pearson(x: Float32Array, y: Float32Array): number {
  */
 export function computeCorrelations(featureData: Float32Array[]): number[][] {
   const out: number[][] = [];
+  // Optimization: Only calculate coefficients for [x][y] where y < x. [x][x] is
+  // always 1, and [x][y] == [y][x], so we only need to calculate it once for
+  // each x, y pair.
   for (let colx = 0; colx < featureData.length; colx++) {
     const row = [];
     for (let coly = 0; coly < colx; coly++) {
@@ -73,10 +76,11 @@ export function computeCorrelations(featureData: Float32Array[]): number[][] {
     }
     out.push(row);
   }
+
+  // fill in remainder of diagonal with transposed values
   for (let i = 0; i < out.length; i++) {
-    // fill in remainder of diagonal with transposed values
-    for (let j = 1; j < out.length; j++) {
-      out[i][j] = out[j][i];
+    for (let j = i + 1; j < out.length; j++) {
+      out[j][i] = out[i][j];
     }
     out[i][i] = 1;
   }

--- a/src/colorizer/workers/SharedWorkerPool.ts
+++ b/src/colorizer/workers/SharedWorkerPool.ts
@@ -41,6 +41,17 @@ export default class SharedWorkerPool {
     return await this.workerPool.exec("loadUrlData", [url, type]);
   }
 
+  async getCorrelations(d: Dataset, featureKeys?: string[]): Promise<number[][]> {
+    const featureData: Float32Array[] = [];
+    featureKeys = featureKeys ?? d.featureKeys;
+    for (const key of featureKeys) {
+      if (d.hasFeatureKey(key)) {
+        featureData.push(d.getFeatureData(key)!.data);
+      }
+    }
+    return await this.workerPool.exec("getCorrelations", [featureData]);
+  }
+
   /**
    * Calculates and averages the motion deltas for objects in the dataset as a flat array of
    * vector coordinates.

--- a/src/colorizer/workers/SharedWorkerPool.ts
+++ b/src/colorizer/workers/SharedWorkerPool.ts
@@ -41,6 +41,15 @@ export default class SharedWorkerPool {
     return await this.workerPool.exec("loadUrlData", [url, type]);
   }
 
+  /**
+   * Computes a matrix of Pearson correlation coefficients between the provided feature keys.
+   * @param d The Dataset to retrieve feature data from.
+   * @param featureKeys An optional array of feature keys to compute correlations for.
+   * If not provided, correlations will be computed for all features in the dataset.
+   * @returns a 2D matrix of correlation values between each pair of features. For
+   * any indices `i` and `j`, the value at `[i][j]` (or `[j][i]`) is the
+   * correlation coefficient between the `i`th and `j`th features.
+   */
   async getCorrelations(d: Dataset, featureKeys?: string[]): Promise<number[][]> {
     const featureData: Float32Array[] = [];
     featureKeys = featureKeys ?? d.featureKeys;

--- a/src/colorizer/workers/worker.ts
+++ b/src/colorizer/workers/worker.ts
@@ -2,6 +2,7 @@ import workerpool from "workerpool";
 import Transfer from "workerpool/types/transfer";
 
 import { FeatureDataType, VectorConfig } from "../types";
+import { computeCorrelations } from "../utils/correlation";
 import { LoadedData, loadFromJsonUrl, loadFromParquetUrl } from "../utils/data_load_utils";
 import { calculateMotionDeltas, constructAllTracksFromData } from "../utils/math_utils";
 import { arrayToDataTextureInfo } from "../utils/texture_utils";
@@ -25,6 +26,10 @@ async function loadUrlData(url: string, type: FeatureDataType): Promise<Transfer
   return new workerpool.Transfer({ min, max, data, textureInfo }, [data.buffer, textureInfo.data.buffer]);
 }
 
+async function getCorrelations(features: Float32Array[]): Promise<number[][]> {
+  return computeCorrelations(features);
+}
+
 async function getMotionDeltas(
   trackIds: Uint32Array,
   times: Uint32Array,
@@ -39,4 +44,5 @@ async function getMotionDeltas(
 workerpool.worker({
   loadUrlData,
   getMotionDeltas,
+  getCorrelations,
 });

--- a/tests/correlation.test.ts
+++ b/tests/correlation.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import { computeCorrelations, pearson } from "../src/colorizer/utils/correlation";
+import { ANY_ERROR } from "./test_utils";
+
+describe("pearson", () => {
+  it("handles empty arrays", () => {
+    expect(pearson(new Float32Array(0), new Float32Array(0))).toBe(0);
+  });
+
+  it("throws an error if arrays are of different length", () => {
+    expect(() => {
+      pearson(new Float32Array([1, 4]), new Float32Array([1, 2, 3]));
+    }).toThrowError(ANY_ERROR);
+  });
+
+  it("determines positive correlations", () => {
+    const data1 = new Float32Array([1, 2, 3, 4, 5]);
+    const data2 = new Float32Array([1, 2, 3, 4, 5]);
+    expect(pearson(data1, data2)).toBeCloseTo(1);
+
+    const data3 = new Float32Array([6, 14, 15, 76, 80]);
+    expect(pearson(data1, data3)).toBeCloseTo(0.909);
+    expect(pearson(data3, data1)).toBeCloseTo(0.909);
+  });
+
+  it("determines negative correlations", () => {
+    const data1 = new Float32Array([1, 2, 3, 4, 5]);
+    const data2 = new Float32Array([5, 4, 3, 2, 1]);
+    expect(pearson(data1, data2)).toBeCloseTo(-1);
+
+    const data3 = new Float32Array([100, 99, 60, 20, -4]);
+    expect(pearson(data1, data3)).toBeCloseTo(-0.9735);
+    expect(pearson(data3, data1)).toBeCloseTo(-0.9735);
+  });
+
+  it("handles arrays of length 1", () => {
+    const data1 = new Float32Array([1]);
+    const data2 = new Float32Array([5]);
+    expect(pearson(data1, data2)).toBeCloseTo(0);
+  });
+
+  it("returns zero if one or both arrays has zero variance", () => {
+    const data1 = new Float32Array([5, 5, 5, 5, 5]);
+    const data2 = new Float32Array([1, 2, 3, 4, 5]);
+    expect(pearson(data1, data2)).toBeCloseTo(0);
+
+    const data3 = new Float32Array([1, 1, 1, 1, 1]);
+    expect(pearson(data1, data3)).toBeCloseTo(0);
+  });
+
+  it("skips nan values", () => {
+    const data1 = new Float32Array([1, NaN, 3, NaN, 5]);
+    const data2 = new Float32Array([1, -1000, 3, 10000, 5]);
+    expect(pearson(data1, data2)).toBeCloseTo(1);
+  });
+});
+
+describe("computeCorrelations", () => {
+  it("handles empty arrays", () => {
+    expect(computeCorrelations([])).toEqual([]);
+  });
+
+  it("handles single array", () => {
+    expect(computeCorrelations([new Float32Array([1, 2, 3, 4, 5])])).toEqual([[1]]);
+  });
+
+  it("returns matrix of pearson calculations", () => {
+    const data1 = new Float32Array([1, 2, 3, 4, 5]);
+    const data2 = new Float32Array([3, 4, 3, 3, 4]);
+    const data3 = new Float32Array([5, 3, 3, 4, 1]);
+
+    // pearson(data1, data2) =  0.2887
+    // pearson(data1, data3) = -0.7462
+    // pearson(data2, data3) = -0.7385
+    const received = computeCorrelations([data1, data2, data3]);
+    const expected = [
+      [1, 0.2887, -0.7462],
+      [0.2887, 1, -0.7385],
+      [-0.7462, -0.7385, 1],
+    ];
+
+    expect(received.length).toBe(expected.length);
+    console.log(received);
+    for (let i = 0; i < received.length; i++) {
+      for (let j = 0; j < received[i].length; j++) {
+        expect(received[i][j]).toBeCloseTo(expected[i][j]);
+      }
+    }
+  });
+
+  it("is symmetric along diagonal", () => {
+    // Generate a random set of features and test that the correlation matrix is
+    // symmetric.
+    const numFeatures = 20;
+    const featuresLength = 100;
+
+    const features: Float32Array[] = [];
+    for (let i = 0; i < numFeatures; i++) {
+      features.push(new Float32Array(featuresLength).map(() => Math.random()));
+    }
+    const received = computeCorrelations(features);
+    for (let i = 0; i < received.length; i++) {
+      for (let j = 0; j < received[i].length; j++) {
+        expect(received[i][j]).toBe(received[j][i]);
+        if (i === j) {
+          expect(received[i][j]).toBe(1);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
Problem
=======
Part 1 of 2 for #447. 

This change adds a new worker task for calculating correlations between features in a dataset, based on work started by @toloudis. In part 2, this will be wired up to a new correlation plot tab.

*Estimated review size: small, 10-15 minutes*

Solution
========
- Adds a new `utils/correlations.ts` file containing logic for calculating the Pearson correlation coefficient from arrays of data.
- Adds a new handler to `SharedWorkerPool.ts` for asynchronously calculating the correlation coefficient matrix for features in a dataset.

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

