### PR TITLE
refactor: Added color indicator to selection dropdown for annotation labels

### DIFF
--- a/src/components/Dropdowns/ColorRampDropdown.tsx
+++ b/src/components/Dropdowns/ColorRampDropdown.tsx
@@ -13,10 +13,11 @@ import {
   PaletteData,
 } from "../../colorizer";
 import { FlexRowAlignCenter } from "../../styles/utils";
+import { SelectItem } from "./types";
 
 import { AppThemeContext } from "../AppStyle";
 import IconButton from "../IconButton";
-import SelectionDropdown, { SelectItem } from "./SelectionDropdown";
+import SelectionDropdown from "./SelectionDropdown";
 
 const SELECTED_RAMP_ITEM_KEY = "__selected_ramp__";
 const CUSTOM_PALETTE_ITEM_KEY = "__custom__";

--- a/src/components/Dropdowns/SelectionDropdown.tsx
+++ b/src/components/Dropdowns/SelectionDropdown.tsx
@@ -190,6 +190,7 @@ export default function SelectionDropdown(inputProps: SelectionDropdownProps): R
       <StyledSelect
         aria-labelledby={id}
         classNamePrefix="react-select"
+        isMulti={false}
         placeholder=""
         type={props.buttonType ?? "outlined"}
         value={selectedOption}
@@ -200,8 +201,8 @@ export default function SelectionDropdown(inputProps: SelectionDropdownProps): R
         isClearable={false}
         isSearchable={props.isSearchable}
         onChange={(value) => {
-          if (value && (value as SelectItem).value) {
-            props.onChange((value as SelectItem).value);
+          if (value && value.value) {
+            props.onChange(value.value);
           }
           startTransition(() => {
             setSearchInput("");

--- a/src/components/Dropdowns/SelectionDropdown.tsx
+++ b/src/components/Dropdowns/SelectionDropdown.tsx
@@ -1,10 +1,11 @@
 import { ButtonProps, Tooltip } from "antd";
 import Fuse from "fuse.js";
-import React, { ReactElement, ReactNode, useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import React, { ReactElement, useCallback, useEffect, useMemo, useState, useTransition } from "react";
 import { components, ControlProps, OptionProps } from "react-select";
 
 import { useDebounce } from "../../colorizer/utils/react_utils";
 import { FlexRowAlignCenter } from "../../styles/utils";
+import { SelectItem } from "./types";
 
 import StyledSelect from "./StyledSelect";
 
@@ -12,18 +13,6 @@ import StyledSelect from "./StyledSelect";
 // but before the prop value updates. -> this is especially noticeable when slow datasets.
 // Is there a way we can do this using async promises, maybe? If the promise rejects,
 // discard the changed value?
-
-export type SelectItem = {
-  value: string;
-  label: string;
-  /** Optional tooltip for an option. If set, a tooltip will be shown when
-   * the option is hovered or focused in the dropdown. */
-  tooltip?: string | ReactNode;
-  /** Optional image source instead of a text label. If used, the label will be
-   * shown only as alt text for the image.
-   */
-  image?: string;
-};
 
 type SelectionDropdownProps = {
   /** Text label to include with the dropdown. If null or undefined, hides the label. */
@@ -62,7 +51,7 @@ const defaultProps: Partial<SelectionDropdownProps> = {
 };
 
 // Override options in the menu list to include tooltips and, optionally, image content.
-const Option = (props: OptionProps): ReactElement => {
+const Option = (props: OptionProps<SelectItem>): ReactElement => {
   // Debounce the tooltip so it only shows after a short delay when focusing/hovering over it.
   const isFocused = useDebounce(props.isFocused, 100) && props.isFocused;
   const title = (props as OptionProps<SelectItem>).data.tooltip;
@@ -164,7 +153,7 @@ export default function SelectionDropdown(inputProps: SelectionDropdownProps): R
   // Fixes a bug where the tooltip would show when hovering anywhere over the dropdown, including
   // other options.
   const Control = useCallback(
-    (controlProps: ControlProps): ReactElement => {
+    (controlProps: ControlProps<SelectItem>): ReactElement => {
       const selectedOption = controlProps.getValue()[0] as SelectItem | undefined;
 
       return (

--- a/src/components/Dropdowns/StyledSelect.tsx
+++ b/src/components/Dropdowns/StyledSelect.tsx
@@ -1,20 +1,22 @@
 import { ButtonProps } from "antd";
 import React, { ReactElement, useMemo } from "react";
-import Select, { components, DropdownIndicatorProps, StylesConfig } from "react-select";
+import Select, { components, DropdownIndicatorProps, GroupBase, StylesConfig } from "react-select";
 import { StateManagerProps } from "react-select/dist/declarations/src/useStateManager";
 import styled, { css } from "styled-components";
 import { Color } from "three";
 
 import { DropdownSVG } from "../../assets";
+import { SelectItem } from "./types";
 
 import { AppTheme, AppThemeContext } from "../AppStyle";
 
-type OptionWithColor = unknown & { color?: Color };
-
-type AntStyledSelectProps = StateManagerProps & {
+type AntStyledSelectProps<
+  IsMulti extends boolean = false,
+  Group extends GroupBase<SelectItem> = GroupBase<SelectItem>
+> = StateManagerProps<SelectItem, IsMulti, Group> & {
   type?: ButtonProps["type"] | "outlined";
   width?: string;
-  styles?: StylesConfig;
+  styles?: StylesConfig<SelectItem, IsMulti, Group>;
 };
 
 /**
@@ -138,7 +140,7 @@ const SelectContainer = styled.div<{ $type: ButtonProps["type"] | "outlined" }>`
   }
 `;
 
-const getCustomStyles = (theme: AppTheme, width: string): StylesConfig => ({
+const getCustomStyles = (theme: AppTheme, width: string): StylesConfig<SelectItem, false, GroupBase<SelectItem>> => ({
   control: (base, { isFocused }) => ({
     ...base,
     height: theme.controls.height,
@@ -216,17 +218,17 @@ const getCustomStyles = (theme: AppTheme, width: string): StylesConfig => ({
           : theme.color.dropdown.backgroundHover
         : undefined,
     },
-    ...addOptionalColorIndicator((data as OptionWithColor)?.color),
+    ...addOptionalColorIndicator(data?.color),
   }),
   singleValue: (styles, { data }) => ({
     ...styles,
-    ...addOptionalColorIndicator((data as OptionWithColor)?.color),
+    ...addOptionalColorIndicator(data?.color),
   }),
 });
 
 // Replace existing dropdown with custom dropdown arrow
 // TODO: Show loading indicator here?
-const DropdownIndicator = (props: DropdownIndicatorProps): ReactElement => {
+const DropdownIndicator = (props: DropdownIndicatorProps<SelectItem>): ReactElement => {
   return (
     <components.DropdownIndicator {...props}>
       <DropdownSVG style={{ width: "12px", height: "12px" }} viewBox="0 0 12 12" />
@@ -244,7 +246,10 @@ const DropdownIndicator = (props: DropdownIndicatorProps): ReactElement => {
  * Note that providing a `styles` prop may cause conflicts with existing style overrides
  * in this component.
  */
-export default function AntStyledSelect(props: AntStyledSelectProps): ReactElement {
+export default function AntStyledSelect<
+  IsMulti extends boolean = false,
+  Group extends GroupBase<SelectItem> = GroupBase<SelectItem>
+>(props: AntStyledSelectProps<IsMulti, Group>): ReactElement {
   const theme = React.useContext(AppThemeContext);
   const customStyles = useMemo(() => getCustomStyles(theme, props.width ?? "15vw"), [theme]);
 
@@ -254,7 +259,7 @@ export default function AntStyledSelect(props: AntStyledSelectProps): ReactEleme
         {...props}
         menuPlacement={props.menuPlacement || "auto"}
         components={{ DropdownIndicator, ...props.components }}
-        styles={{ ...customStyles, ...props.styles }}
+        styles={{ ...(customStyles as unknown as StylesConfig<SelectItem, IsMulti, Group>), ...props.styles }}
       />
     </SelectContainer>
   );

--- a/src/components/Dropdowns/StyledSelect.tsx
+++ b/src/components/Dropdowns/StyledSelect.tsx
@@ -3,14 +3,38 @@ import React, { ReactElement, useMemo } from "react";
 import Select, { components, DropdownIndicatorProps, StylesConfig } from "react-select";
 import { StateManagerProps } from "react-select/dist/declarations/src/useStateManager";
 import styled, { css } from "styled-components";
+import { Color } from "three";
 
 import { DropdownSVG } from "../../assets";
 
 import { AppTheme, AppThemeContext } from "../AppStyle";
 
+type OptionWithColor = unknown & { color?: Color };
+
 type AntStyledSelectProps = StateManagerProps & {
   type?: ButtonProps["type"] | "outlined";
   width?: string;
+  styles?: StylesConfig;
+};
+
+const addOptionalColorIndicator = (color: Color | undefined) => {
+  if (color) {
+    return {
+      alignItems: "center",
+      display: "flex",
+
+      ":before": {
+        backgroundColor: "#" + color.getHexString(),
+        borderRadius: 10,
+        content: '" "',
+        display: "block",
+        marginRight: 8,
+        height: 10,
+        width: 10,
+      },
+    };
+  }
+  return {};
 };
 
 // Styling is done via both styled-components and react-select's `styles` prop.
@@ -165,7 +189,7 @@ const getCustomStyles = (theme: AppTheme, width: string): StylesConfig => ({
     flexDirection: "column",
     gap: 4,
   }),
-  option: (styles, { isFocused, isSelected, isDisabled }) => ({
+  option: (styles, { data, isFocused, isSelected, isDisabled }) => ({
     ...styles,
     // Style to match Ant dropdowns
     borderRadius: 4,
@@ -188,6 +212,11 @@ const getCustomStyles = (theme: AppTheme, width: string): StylesConfig => ({
           : theme.color.dropdown.backgroundHover
         : undefined,
     },
+    ...addOptionalColorIndicator((data as OptionWithColor)?.color),
+  }),
+  singleValue: (styles, { data }) => ({
+    ...styles,
+    ...addOptionalColorIndicator((data as OptionWithColor)?.color),
   }),
 });
 

--- a/src/components/Dropdowns/StyledSelect.tsx
+++ b/src/components/Dropdowns/StyledSelect.tsx
@@ -17,12 +17,16 @@ type AntStyledSelectProps = StateManagerProps & {
   styles?: StylesConfig;
 };
 
-const addOptionalColorIndicator = (color: Color | undefined) => {
+/**
+ * If `color` is defined, adds style config properties  that add a colored
+ * pseudo-element indicator to the left of an option text in the dropdown.
+ */
+const addOptionalColorIndicator = (color: Color | undefined): Partial<StylesConfig["option"]> => {
   if (color) {
     return {
       alignItems: "center",
       display: "flex",
-
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       ":before": {
         backgroundColor: "#" + color.getHexString(),
         borderRadius: 10,

--- a/src/components/Dropdowns/types.ts
+++ b/src/components/Dropdowns/types.ts
@@ -1,0 +1,25 @@
+import { ReactNode } from "react";
+import { Color } from "three";
+
+/**
+ * A single option in a dropdown. Includes optional display properties.
+ */
+export type SelectItem = {
+  /** Display value of the option. */
+  label: string;
+  /** The key or value the option. This will be returned when the option is
+   * selected.
+   */
+  value: string;
+  /** Optional color for the option. If set, a small color indicator will be
+   * shown next to the label in the dropdown.
+   */
+  color?: Color;
+  /** Optional tooltip for an option. If set, a tooltip will be shown when
+   * the option is hovered or focused in the dropdown. */
+  tooltip?: string | ReactNode;
+  /** Optional image source instead of a text label. If used, the label will be
+   * used as alt text for the image.
+   */
+  image?: string;
+};

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -1,9 +1,8 @@
 import { CloseOutlined } from "@ant-design/icons";
-import { Color as AntdColor } from "@rc-component/color-picker";
-import { Button, ColorPicker, Table, TableProps } from "antd";
+import { Button, Table, TableProps } from "antd";
 import React, { ReactElement, useContext, useMemo } from "react";
 import styled from "styled-components";
-import { Color, ColorRepresentation } from "three";
+import { Color } from "three";
 
 import { TagIconSVG } from "../../../assets";
 import { Dataset } from "../../../colorizer";
@@ -61,12 +60,6 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
 
   const onSelectLabelIdx = (idx: string): void => {
     props.annotationState.setCurrentLabelIdx(parseInt(idx, 10));
-  };
-
-  const onColorPickerChange = (_value: any, hex: string): void => {
-    if (currentLabelIdx !== null) {
-      setLabelColor(currentLabelIdx, new Color(hex as ColorRepresentation));
-    }
   };
 
   const onCreateNewLabel = (): void => {
@@ -145,6 +138,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
     return {
       value: index.toString(),
       label: label.ids.size ? `${label.name} (${label.ids.size})` : label.name,
+      color: label.color,
     };
   });
 
@@ -175,16 +169,6 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
           disabled={currentLabelIdx === null}
           showSelectedItemTooltip={false}
         ></SelectionDropdown>
-        <div>
-          {/* TODO: Remove color picker once color dots can be added to the dropdowns. */}
-          <ColorPicker
-            size="small"
-            value={new AntdColor(selectedLabel?.color.getHexString() || "#ffffff")}
-            onChange={onColorPickerChange}
-            disabledAlpha={true}
-            disabled={!isAnnotationModeEnabled}
-          />
-        </div>
 
         {/*
          * Hide edit-related buttons until edit mode is enabled.

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -9,10 +9,11 @@ import { Dataset } from "../../../colorizer";
 import { AnnotationState } from "../../../colorizer/utils/react_utils";
 import { FlexColumnAlignCenter, FlexRow, VisuallyHidden } from "../../../styles/utils";
 import { download } from "../../../utils/file_io";
+import { SelectItem } from "../../Dropdowns/types";
 
 import { LabelData } from "../../../colorizer/AnnotationData";
 import { AppThemeContext } from "../../AppStyle";
-import SelectionDropdown, { SelectItem } from "../../Dropdowns/SelectionDropdown";
+import SelectionDropdown from "../../Dropdowns/SelectionDropdown";
 import IconButton from "../../IconButton";
 import AnnotationModeButton from "./AnnotationModeButton";
 import LabelEditControls from "./LabelEditControls";

--- a/src/components/Tabs/ScatterPlotTab.tsx
+++ b/src/components/Tabs/ScatterPlotTab.tsx
@@ -10,6 +10,7 @@ import { DrawMode, PlotRangeType, ScatterPlotConfig, ViewerConfig } from "../../
 import { useDebounce } from "../../colorizer/utils/react_utils";
 import { FlexRow, FlexRowAlignCenter } from "../../styles/utils";
 import { ShowAlertBannerCallback } from "../Banner/hooks";
+import { SelectItem } from "../Dropdowns/types";
 import {
   DataArray,
   drawCrosshair,
@@ -27,7 +28,7 @@ import {
 } from "./scatter_plot_data_utils";
 
 import { AppThemeContext } from "../AppStyle";
-import SelectionDropdown, { SelectItem } from "../Dropdowns/SelectionDropdown";
+import SelectionDropdown from "../Dropdowns/SelectionDropdown";
 import IconButton from "../IconButton";
 import LoadingSpinner from "../LoadingSpinner";
 


### PR DESCRIPTION
Problem
=======
Closes #523, "Annotation - show label color in dropdown".

This change adds a small colored dot to the dropdowns to replace the `ColorPicker` component that was previously being used to indicate label colors. This lets users see the color of all the labels in the dropdown menu when selecting them.

*Estimated review size: small, 5-10 minutes*

Solution
========
- Adds a styling configuration override in `StyledSelect`, where any data with the optional `color` property renders an extra colored pseudo-element.
- Refactors `SelectItem` into a separate `types` file and types `StyledSelect` with it.
- Adds label colors to the selection options in `AnnotationTab`.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link and create a few new labels. https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview-internal/pr-528/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&tab=annotation
2. The label colors should appear in the dropdown!

Screenshots (optional):
-----------------------
Before: 
![image](https://github.com/user-attachments/assets/a6cf7784-c798-4bb3-9507-09170077b069)


After:
![image](https://github.com/user-attachments/assets/ae25aeff-3324-42dc-bd43-e6dde3fd7afa)


