### PR TITLE
refactor: Moved annotation table to a separate component

### DIFF
--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -75,7 +75,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
 
   const tableIds = useMemo(() => {
     return currentLabelIdx !== null ? annotationData.getLabeledIds(currentLabelIdx) : [];
-  }, [annotationData]);
+  }, [annotationData, currentLabelIdx]);
 
   return (
     <FlexColumnAlignCenter $gap={10}>

--- a/src/components/Tabs/Annotation/AnnotationTable.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTable.tsx
@@ -1,0 +1,118 @@
+import { CloseOutlined } from "@ant-design/icons";
+import { Table, TableProps } from "antd";
+import React, { ReactElement, useMemo } from "react";
+import styled from "styled-components";
+
+import { TagIconSVG } from "../../../assets";
+import { Dataset } from "../../../colorizer";
+import { FlexColumnAlignCenter, VisuallyHidden } from "../../../styles/utils";
+
+import IconButton from "../../IconButton";
+
+export type TableDataType = {
+  key: string;
+  id: number;
+  track: number;
+  time: number;
+};
+
+const StyledAntTable = styled(Table)`
+  .ant-table-row {
+    cursor: pointer;
+  }
+
+  &&&& .ant-table-cell {
+    padding: 4px 8px;
+  }
+`;
+
+type AnnotationTableProps = {
+  onClickObjectRow: (record: TableDataType) => void;
+  onClickDeleteObject: (record: TableDataType) => void;
+  dataset: Dataset | null;
+  ids: number[];
+};
+
+export default function AnnotationTable(props: AnnotationTableProps): ReactElement {
+  const tableColumns: TableProps<TableDataType>["columns"] = [
+    {
+      title: "Object ID",
+      dataIndex: "id",
+      key: "id",
+      sorter: (a, b) => a.id - b.id,
+    },
+    {
+      title: "Track ID",
+      dataIndex: "track",
+      key: "track",
+      sorter: (a, b) => a.track - b.track,
+    },
+    {
+      title: "Time",
+      dataIndex: "time",
+      key: "time",
+      sorter: (a, b) => a.time - b.time,
+    },
+    // Column that contains a remove button for the ID.
+    {
+      title: "",
+      key: "action",
+      render: (_, record) => (
+        <IconButton
+          type="text"
+          onClick={(event) => {
+            // Rows have their own behavior on click (jumping to a timestamp),
+            // so we need to stop event propagation so that the row click event
+            // doesn't fire.
+            event.stopPropagation();
+            props.onClickDeleteObject(record);
+          }}
+        >
+          <CloseOutlined />
+          <VisuallyHidden>
+            Remove ID {record.id} (track {record.track})
+          </VisuallyHidden>
+        </IconButton>
+      ),
+    },
+  ];
+
+  const tableData: TableDataType[] = useMemo(() => {
+    const dataset = props.dataset;
+    if (dataset) {
+      return props.ids.map((id) => {
+        const track = dataset.getTrackId(id);
+        const time = dataset.getTime(id);
+        return { key: id.toString(), id, track, time };
+      });
+    }
+    return [];
+  }, [props.ids, props.dataset]);
+
+  return (
+    <StyledAntTable
+      dataSource={tableData}
+      columns={tableColumns}
+      size="small"
+      pagination={false}
+      // TODO: Rows aren't actually buttons, which means that they are not
+      // keyboard accessible. Either find a way to make them tab indexable
+      // or add a button that is equivalent to click?
+      onRow={(record) => {
+        return {
+          onClick: () => {
+            props.onClickObjectRow(record);
+          },
+        };
+      }}
+      locale={{
+        emptyText: (
+          <FlexColumnAlignCenter style={{ margin: "16px 0 10px 0" }}>
+            <TagIconSVG style={{ width: "24px", height: "24px", marginBottom: 0 }} />
+            <p>No annotated IDs</p>
+          </FlexColumnAlignCenter>
+        ),
+      }}
+    ></StyledAntTable>
+  );
+}


### PR DESCRIPTION
Problem
=======
Refactor to support #516, "Annotation - add track list view."

This change moves the table view in the Annotation tab into its own component, which will be reused in a few places. This has been split out from the list view PR for ease of review!

*Estimated review size: small, 5-10 minutes*

Solution
========
- Moved annotation table-related logic into a new `AnnotationTable.tsx` component.


Preview here if you want to validate: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview-internal/pr-529
