### PR TITLE
feature: Select whole tracks in annotation mode

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -831,11 +831,8 @@ function Viewer(): ReactElement {
       if (track && annotationState.isAnnotationModeEnabled && annotationState.currentLabelIdx !== null) {
         const id = track.getIdAtTime(currentFrame);
         const isLabeled = annotationState.data.isLabelOnId(annotationState.currentLabelIdx, id);
-        if (annotationState.selectionMode === AnnotationSelectionMode.TIME) {
-          annotationState.setLabelOnId(annotationState.currentLabelIdx, track.getIdAtTime(currentFrame), !isLabeled);
-        } else {
-          annotationState.setLabelOnIds(annotationState.currentLabelIdx, track.ids, !isLabeled);
-        }
+        const ids = annotationState.selectionMode === AnnotationSelectionMode.TIME ? [id] : track.ids;
+        annotationState.setLabelOnIds(annotationState.currentLabelIdx, ids, !isLabeled);
       }
     },
     [

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -22,6 +22,7 @@ import React, {
 import { Link, Location, useLocation, useSearchParams } from "react-router-dom";
 
 import {
+  AnnotationSelectionMode,
   Dataset,
   DEFAULT_CATEGORICAL_PALETTE_KEY,
   DEFAULT_COLOR_RAMP_KEY,
@@ -830,10 +831,19 @@ function Viewer(): ReactElement {
       if (track && annotationState.isAnnotationModeEnabled && annotationState.currentLabelIdx !== null) {
         const id = track.getIdAtTime(currentFrame);
         const isLabeled = annotationState.data.isLabelOnId(annotationState.currentLabelIdx, id);
-        annotationState.setLabelOnId(annotationState.currentLabelIdx, track.getIdAtTime(currentFrame), !isLabeled);
+        if (annotationState.selectionMode === AnnotationSelectionMode.TIME) {
+          annotationState.setLabelOnId(annotationState.currentLabelIdx, track.getIdAtTime(currentFrame), !isLabeled);
+        } else {
+          annotationState.setLabelOnIds(annotationState.currentLabelIdx, track.ids, !isLabeled);
+        }
       }
     },
-    [annotationState.isAnnotationModeEnabled, annotationState.currentLabelIdx, currentFrame]
+    [
+      annotationState.isAnnotationModeEnabled,
+      annotationState.selectionMode,
+      annotationState.currentLabelIdx,
+      currentFrame,
+    ]
   );
 
   // RECORDING CONTROLS ////////////////////////////////////////////////////

--- a/src/colorizer/AnnotationData.ts
+++ b/src/colorizer/AnnotationData.ts
@@ -123,7 +123,6 @@ export interface IAnnotationDataSetters {
   setLabelColor(labelIdx: number, color: Color): void;
   deleteLabel(labelIdx: number): void;
 
-  setLabelOnId(labelIdx: number, id: number, value: boolean): void;
   setLabelOnIds(labelIdx: number, ids: number[], value: boolean): void;
 }
 
@@ -268,7 +267,7 @@ export class AnnotationData implements IAnnotationData {
     this.timeToLabelIdMap = null;
   }
 
-  setLabelOnId(labelIdx: number, id: number, value: boolean): void {
+  private setLabelOnId(labelIdx: number, id: number, value: boolean): void {
     this.validateIndex(labelIdx);
     if (value) {
       this.labelData[labelIdx].ids.add(id);

--- a/src/colorizer/AnnotationData.ts
+++ b/src/colorizer/AnnotationData.ts
@@ -124,6 +124,7 @@ export interface IAnnotationDataSetters {
   deleteLabel(labelIdx: number): void;
 
   setLabelOnId(labelIdx: number, id: number, value: boolean): void;
+  setLabelOnIds(labelIdx: number, ids: number[], value: boolean): void;
 }
 
 export type IAnnotationData = IAnnotationDataGetters & IAnnotationDataSetters;
@@ -153,6 +154,7 @@ export class AnnotationData implements IAnnotationData {
     this.deleteLabel = this.deleteLabel.bind(this);
     this.isLabelOnId = this.isLabelOnId.bind(this);
     this.setLabelOnId = this.setLabelOnId.bind(this);
+    this.setLabelOnIds = this.setLabelOnIds.bind(this);
     this.toCsv = this.toCsv.bind(this);
   }
 
@@ -272,6 +274,14 @@ export class AnnotationData implements IAnnotationData {
       this.labelData[labelIdx].ids.add(id);
     } else {
       this.labelData[labelIdx].ids.delete(id);
+    }
+    this.timeToLabelIdMap = null;
+  }
+
+  setLabelOnIds(labelIdx: number, ids: number[], value: boolean): void {
+    this.validateIndex(labelIdx);
+    for (const id of ids) {
+      this.setLabelOnId(labelIdx, id, value);
     }
     this.timeToLabelIdMap = null;
   }

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -200,6 +200,11 @@ export type ScatterPlotConfig = {
   rangeType: PlotRangeType;
 };
 
+export enum AnnotationSelectionMode {
+  TIME,
+  TRACK,
+}
+
 /**
  * Callback used to report warnings to the user. The message is the title
  * of the warning, and the description is the body of the warning. If an array

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -2,7 +2,7 @@ import React, { EventHandler, useEffect, useMemo, useRef, useState } from "react
 import styled from "styled-components";
 import { useLocalStorage } from "usehooks-ts";
 
-import { VectorConfig } from "../types";
+import { AnnotationSelectionMode, VectorConfig } from "../types";
 
 import { AnnotationData, IAnnotationDataGetters, IAnnotationDataSetters } from "../AnnotationData";
 import Dataset from "../Dataset";
@@ -316,6 +316,8 @@ export type AnnotationState =  {
   setIsAnnotationModeEnabled: (enabled: boolean) => void;
   visible: boolean;
   setVisibility: (visible: boolean) => void;
+  selectionMode: AnnotationSelectionMode;
+  setSelectionMode: (mode: AnnotationSelectionMode) => void;
   /**
    * Contains annotation data getters. Use this object directly as a dependency
    * in `useMemo` or `useCallback` to trigger updates when the underlying data
@@ -329,6 +331,7 @@ export const useAnnotations = (): AnnotationState => {
 
   const [currentLabelIdx, setCurrentLabelIdx] = useState<number | null>(null);
   const [isAnnotationEnabled, _setIsAnnotationEnabled] = useState<boolean>(false);  
+  const [selectionMode, setSelectionMode] = useState<AnnotationSelectionMode>(AnnotationSelectionMode.TIME);
   const [visible, _setVisibility] = useState<boolean>(false);
 
   // Annotation mode can only be enabled if there is at least one label, so create
@@ -398,6 +401,8 @@ export const useAnnotations = (): AnnotationState => {
     setIsAnnotationModeEnabled: setIsAnnotationEnabled,
     visible,
     setVisibility,
+    selectionMode,
+    setSelectionMode,
     data,
     // Wrap state mutators
     createNewLabel: wrapFunctionInUpdate(annotationData.createNewLabel),
@@ -405,5 +410,6 @@ export const useAnnotations = (): AnnotationState => {
     setLabelColor: wrapFunctionInUpdate(annotationData.setLabelColor),
     deleteLabel: wrapFunctionInUpdate(onDeleteLabel),
     setLabelOnId: wrapFunctionInUpdate(annotationData.setLabelOnId),
+    setLabelOnIds: wrapFunctionInUpdate(annotationData.setLabelOnIds),
   };
 };

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -409,7 +409,6 @@ export const useAnnotations = (): AnnotationState => {
     setLabelName: wrapFunctionInUpdate(annotationData.setLabelName),
     setLabelColor: wrapFunctionInUpdate(annotationData.setLabelColor),
     deleteLabel: wrapFunctionInUpdate(onDeleteLabel),
-    setLabelOnId: wrapFunctionInUpdate(annotationData.setLabelOnId),
     setLabelOnIds: wrapFunctionInUpdate(annotationData.setLabelOnIds),
   };
 };

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -7,7 +7,7 @@ import { clamp } from "three/src/math/MathUtils";
 
 import { ImagesIconSVG, ImagesSlashIconSVG, NoImageSVG, TagIconSVG, TagSlashIconSVG } from "../assets";
 import { ColorRamp, Dataset, Track } from "../colorizer";
-import { LoadTroubleshooting, TabType, ViewerConfig } from "../colorizer/types";
+import { AnnotationSelectionMode, LoadTroubleshooting, TabType, ViewerConfig } from "../colorizer/types";
 import * as mathUtils from "../colorizer/utils/math_utils";
 import { AnnotationState } from "../colorizer/utils/react_utils";
 import { INTERNAL_BUILD } from "../constants";
@@ -536,12 +536,16 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       if (isMouseDragging.current) {
         canv.domElement.style.cursor = "move";
       } else if (props.annotationState.isAnnotationModeEnabled) {
-        canv.domElement.style.cursor = "crosshair";
+        if (props.annotationState.selectionMode === AnnotationSelectionMode.TIME) {
+          canv.domElement.style.cursor = "crosshair";
+        } else {
+          canv.domElement.style.cursor = "cell";
+        }
       } else {
         canv.domElement.style.cursor = "auto";
       }
     },
-    [handlePan, props.annotationState.isAnnotationModeEnabled]
+    [handlePan, props.annotationState.isAnnotationModeEnabled, props.annotationState.selectionMode]
   );
 
   const onMouseUp = useCallback((_event: MouseEvent): void => {

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -1,7 +1,6 @@
 import { MenuOutlined, TableOutlined } from "@ant-design/icons";
-import { Button, Radio, Tooltip } from "antd";
+import { Radio, Tooltip } from "antd";
 import React, { ReactElement, useCallback, useContext, useMemo, useState, useTransition } from "react";
-import styled from "styled-components";
 import { Color } from "three";
 
 import { Dataset } from "../../../colorizer";
@@ -12,6 +11,7 @@ import { SelectItem } from "../../Dropdowns/types";
 
 import { LabelData } from "../../../colorizer/AnnotationData";
 import { AppThemeContext } from "../../AppStyle";
+import TextButton from "../../Buttons/TextButton";
 import SelectionDropdown from "../../Dropdowns/SelectionDropdown";
 import LoadingSpinner from "../../LoadingSpinner";
 import AnnotationDisplayList from "./AnnotationDisplayList";
@@ -19,14 +19,11 @@ import AnnotationTable, { TableDataType } from "./AnnotationDisplayTable";
 import AnnotationModeButton from "./AnnotationModeButton";
 import LabelEditControls from "./LabelEditControls";
 
+const LABEL_DROPDOWN_LABEL_ID = "label-dropdown-label";
 const enum AnnotationViewType {
   TABLE,
   LIST,
 }
-
-const ViewModeRadioButton = styled(Radio.Button)`
-  padding: 0px 8px 0px 8px;
-`;
 
 type AnnotationTabProps = {
   annotationState: AnnotationState;
@@ -111,27 +108,28 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
           onClick={() => setIsAnnotationModeEnabled(!isAnnotationModeEnabled)}
         />
 
-        <Button
+        <TextButton
           onClick={() => {
             const csvData = props.annotationState.data.toCsv(props.dataset!);
             download("annotations.csv", "data:text/csv;charset=utf-8," + encodeURIComponent(csvData));
             console.log(csvData);
           }}
         >
-          Export as CSV
-        </Button>
+          Export CSV
+        </TextButton>
       </FlexRow>
 
       {/* Label selection and edit/create/delete buttons */}
-      <FlexRow style={{ justifyContent: "space-between", width: "100%" }}>
-        <FlexRow $gap={10}>
+      <FlexRow $gap={6} style={{ width: "100%" }}>
+        <FlexRow $gap={6}>
+          <VisuallyHidden id={LABEL_DROPDOWN_LABEL_ID}>Current label</VisuallyHidden>
           <SelectionDropdown
             selected={(currentLabelIdx ?? -1).toString()}
             items={selectLabelOptions}
             onChange={onSelectLabelIdx}
             disabled={currentLabelIdx === null}
             showSelectedItemTooltip={false}
-            label="Label"
+            htmlLabelId={LABEL_DROPDOWN_LABEL_ID}
           ></SelectionDropdown>
 
           {/*
@@ -153,25 +151,24 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
         </FlexRow>
 
         {/* View mode selection */}
-        <label style={{ display: "flex", flexDirection: "row", gap: "6px" }}>
-          <span style={{ fontSize: theme.font.size.label }}>View </span>
+        <label>
+          <VisuallyHidden>View mode</VisuallyHidden>
           <Radio.Group
-            // buttonStyle="solid"
             style={{ display: "flex", flexDirection: "row" }}
             value={viewType}
             onChange={(e) => startTransition(() => setViewType(e.target.value))}
           >
             <Tooltip trigger={["hover", "focus"]} title="Table view" placement="top">
-              <ViewModeRadioButton value={AnnotationViewType.TABLE}>
+              <Radio.Button value={AnnotationViewType.TABLE} style={{ padding: "0 8px" }}>
                 <TableOutlined />
                 <VisuallyHidden>Table view {viewType === AnnotationViewType.TABLE ? "(selected)" : ""}</VisuallyHidden>
-              </ViewModeRadioButton>
+              </Radio.Button>
             </Tooltip>
             <Tooltip trigger={["hover", "focus"]} title="List view" placement="top">
-              <ViewModeRadioButton value={AnnotationViewType.LIST}>
+              <Radio.Button value={AnnotationViewType.LIST} style={{ padding: "0 8px" }}>
                 <MenuOutlined />
                 <VisuallyHidden>List view {viewType === AnnotationViewType.LIST ? "(selected)" : ""}</VisuallyHidden>
-              </ViewModeRadioButton>
+              </Radio.Button>
             </Tooltip>
           </Radio.Group>
         </label>

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -1,11 +1,11 @@
 import { MenuOutlined, TableOutlined } from "@ant-design/icons";
 import { Button, Radio, Tooltip } from "antd";
-import React, { ReactElement, useCallback, useContext, useMemo, useTransition } from "react";
+import React, { ReactElement, useCallback, useContext, useMemo, useState, useTransition } from "react";
 import { Color } from "three";
 
-import { Dataset } from "../../../colorizer";
+import { AnnotationSelectionMode, Dataset } from "../../../colorizer";
 import { AnnotationState } from "../../../colorizer/utils/react_utils";
-import { FlexColumnAlignCenter, FlexRow, VisuallyHidden } from "../../../styles/utils";
+import { FlexColumnAlignCenter, FlexRow, FlexRowAlignCenter, VisuallyHidden } from "../../../styles/utils";
 import { download } from "../../../utils/file_io";
 import { SelectItem } from "../../Dropdowns/types";
 
@@ -45,7 +45,8 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
   } = props.annotationState;
 
   const [isPending, startTransition] = useTransition();
-  const [viewType, setViewType] = React.useState<AnnotationViewType>(AnnotationViewType.TABLE);
+  const [viewType, setViewType] = useState<AnnotationViewType>(AnnotationViewType.TABLE);
+
   const labels = annotationData.getLabels();
   const selectedLabel: LabelData | undefined = labels[currentLabelIdx ?? -1];
 
@@ -139,30 +140,46 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
       </FlexRow>
 
       {/* Label selection and edit/create/delete buttons */}
-      <FlexRow $gap={10} style={{ width: "100%" }}>
-        <SelectionDropdown
-          selected={(currentLabelIdx ?? -1).toString()}
-          items={selectLabelOptions}
-          onChange={onSelectLabelIdx}
-          disabled={currentLabelIdx === null}
-          showSelectedItemTooltip={false}
-          label="Label"
-        ></SelectionDropdown>
+      <FlexRow style={{ justifyContent: "space-between", width: "100%" }}>
+        <FlexRow $gap={10}>
+          <SelectionDropdown
+            selected={(currentLabelIdx ?? -1).toString()}
+            items={selectLabelOptions}
+            onChange={onSelectLabelIdx}
+            disabled={currentLabelIdx === null}
+            showSelectedItemTooltip={false}
+            label="Label"
+          ></SelectionDropdown>
 
-        {/*
-         * Hide edit-related buttons until edit mode is enabled.
-         * Note that currentLabelIdx will never be null when edit mode is enabled.
-         */}
-        {isAnnotationModeEnabled && currentLabelIdx !== null && (
-          <LabelEditControls
-            onCreateNewLabel={onCreateNewLabel}
-            onDeleteLabel={onDeleteLabel}
-            setLabelColor={(color: Color) => setLabelColor(currentLabelIdx, color)}
-            setLabelName={(name: string) => setLabelName(currentLabelIdx, name)}
-            selectedLabel={selectedLabel}
-            selectedLabelIdx={currentLabelIdx}
-          />
-        )}
+          {/*
+           * Hide edit-related buttons until edit mode is enabled.
+           * Note that currentLabelIdx will never be null when edit mode is enabled.
+           */}
+          {isAnnotationModeEnabled && currentLabelIdx !== null && (
+            <LabelEditControls
+              onCreateNewLabel={onCreateNewLabel}
+              onDeleteLabel={onDeleteLabel}
+              setLabelColor={(color: Color) => setLabelColor(currentLabelIdx, color)}
+              setLabelName={(name: string) => setLabelName(currentLabelIdx, name)}
+              selectedLabel={selectedLabel}
+              selectedLabelIdx={currentLabelIdx}
+            />
+          )}
+        </FlexRow>
+
+        {/* Mode selection */}
+        <FlexRowAlignCenter $gap={6}>
+          <span style={{ fontSize: theme.font.size.label }}>Select by </span>
+          <Radio.Group
+            // buttonStyle="solid"
+            style={{ display: "flex", flexDirection: "row" }}
+            value={props.annotationState.selectionMode}
+            onChange={(e) => props.annotationState.setSelectionMode(e.target.value)}
+          >
+            <Radio.Button value={AnnotationSelectionMode.TIME}>Time</Radio.Button>
+            <Radio.Button value={AnnotationSelectionMode.TRACK}>Track</Radio.Button>
+          </Radio.Group>
+        </FlexRowAlignCenter>
       </FlexRow>
 
       {/* Table or list view */}

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -43,7 +43,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
     deleteLabel,
     setLabelName,
     setLabelColor,
-    setLabelOnId,
+    setLabelOnIds,
   } = props.annotationState;
 
   const [isPending, startTransition] = useTransition();
@@ -81,10 +81,10 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
   const onClickDeleteObject = useCallback(
     (record: TableDataType): void => {
       if (currentLabelIdx !== null) {
-        setLabelOnId(currentLabelIdx, record.id, false);
+        setLabelOnIds(currentLabelIdx, [record.id], false);
       }
     },
-    [currentLabelIdx, setLabelOnId]
+    [currentLabelIdx, setLabelOnIds]
   );
 
   // Options for the selection dropdown

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -1,11 +1,12 @@
 import { MenuOutlined, TableOutlined } from "@ant-design/icons";
 import { Button, Radio, Tooltip } from "antd";
 import React, { ReactElement, useCallback, useContext, useMemo, useState, useTransition } from "react";
+import styled from "styled-components";
 import { Color } from "three";
 
-import { AnnotationSelectionMode, Dataset } from "../../../colorizer";
+import { Dataset } from "../../../colorizer";
 import { AnnotationState } from "../../../colorizer/utils/react_utils";
-import { FlexColumnAlignCenter, FlexRow, FlexRowAlignCenter, VisuallyHidden } from "../../../styles/utils";
+import { FlexColumnAlignCenter, FlexRow, VisuallyHidden } from "../../../styles/utils";
 import { download } from "../../../utils/file_io";
 import { SelectItem } from "../../Dropdowns/types";
 
@@ -22,6 +23,10 @@ const enum AnnotationViewType {
   TABLE,
   LIST,
 }
+
+const ViewModeRadioButton = styled(Radio.Button)`
+  padding: 0px 8px 0px 8px;
+`;
 
 type AnnotationTabProps = {
   annotationState: AnnotationState;
@@ -106,37 +111,15 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
           onClick={() => setIsAnnotationModeEnabled(!isAnnotationModeEnabled)}
         />
 
-        <FlexRow $gap={8}>
-          <Button
-            onClick={() => {
-              const csvData = props.annotationState.data.toCsv(props.dataset!);
-              download("annotations.csv", "data:text/csv;charset=utf-8," + encodeURIComponent(csvData));
-              console.log(csvData);
-            }}
-          >
-            Export as CSV
-          </Button>
-
-          <Radio.Group
-            buttonStyle="solid"
-            style={{ display: "flex", flexDirection: "row" }}
-            value={viewType}
-            onChange={(e) => startTransition(() => setViewType(e.target.value))}
-          >
-            <Tooltip trigger={["hover", "focus"]} title="Table view" placement="top">
-              <Radio.Button value={AnnotationViewType.TABLE}>
-                <TableOutlined />
-                <VisuallyHidden>Table view {viewType === AnnotationViewType.TABLE ? "(selected)" : ""}</VisuallyHidden>
-              </Radio.Button>
-            </Tooltip>
-            <Tooltip trigger={["hover", "focus"]} title="List view" placement="top">
-              <Radio.Button value={AnnotationViewType.LIST}>
-                <MenuOutlined />
-                <VisuallyHidden>List view {viewType === AnnotationViewType.LIST ? "(selected)" : ""}</VisuallyHidden>
-              </Radio.Button>
-            </Tooltip>
-          </Radio.Group>
-        </FlexRow>
+        <Button
+          onClick={() => {
+            const csvData = props.annotationState.data.toCsv(props.dataset!);
+            download("annotations.csv", "data:text/csv;charset=utf-8," + encodeURIComponent(csvData));
+            console.log(csvData);
+          }}
+        >
+          Export as CSV
+        </Button>
       </FlexRow>
 
       {/* Label selection and edit/create/delete buttons */}
@@ -163,23 +146,35 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
               setLabelName={(name: string) => setLabelName(currentLabelIdx, name)}
               selectedLabel={selectedLabel}
               selectedLabelIdx={currentLabelIdx}
+              selectionMode={props.annotationState.selectionMode}
+              setSelectionMode={props.annotationState.setSelectionMode}
             />
           )}
         </FlexRow>
 
-        {/* Mode selection */}
-        <FlexRowAlignCenter $gap={6}>
-          <span style={{ fontSize: theme.font.size.label }}>Select by </span>
+        {/* View mode selection */}
+        <label style={{ display: "flex", flexDirection: "row", gap: "6px" }}>
+          <span style={{ fontSize: theme.font.size.label }}>View </span>
           <Radio.Group
             // buttonStyle="solid"
             style={{ display: "flex", flexDirection: "row" }}
-            value={props.annotationState.selectionMode}
-            onChange={(e) => props.annotationState.setSelectionMode(e.target.value)}
+            value={viewType}
+            onChange={(e) => startTransition(() => setViewType(e.target.value))}
           >
-            <Radio.Button value={AnnotationSelectionMode.TIME}>Time</Radio.Button>
-            <Radio.Button value={AnnotationSelectionMode.TRACK}>Track</Radio.Button>
+            <Tooltip trigger={["hover", "focus"]} title="Table view" placement="top">
+              <ViewModeRadioButton value={AnnotationViewType.TABLE}>
+                <TableOutlined />
+                <VisuallyHidden>Table view {viewType === AnnotationViewType.TABLE ? "(selected)" : ""}</VisuallyHidden>
+              </ViewModeRadioButton>
+            </Tooltip>
+            <Tooltip trigger={["hover", "focus"]} title="List view" placement="top">
+              <ViewModeRadioButton value={AnnotationViewType.LIST}>
+                <MenuOutlined />
+                <VisuallyHidden>List view {viewType === AnnotationViewType.LIST ? "(selected)" : ""}</VisuallyHidden>
+              </ViewModeRadioButton>
+            </Tooltip>
           </Radio.Group>
-        </FlexRowAlignCenter>
+        </label>
       </FlexRow>
 
       {/* Table or list view */}

--- a/src/components/Tabs/Annotation/LabelEditControls.tsx
+++ b/src/components/Tabs/Annotation/LabelEditControls.tsx
@@ -1,10 +1,11 @@
 import { DeleteOutlined, EditOutlined } from "@ant-design/icons";
 import { Color as AntdColor } from "@rc-component/color-picker";
-import { Button, ColorPicker, Input, InputRef, Popconfirm, Popover, Tooltip } from "antd";
+import { Button, ColorPicker, Input, InputRef, Popconfirm, Popover, Radio, Tooltip } from "antd";
 import React, { ReactElement, useContext, useEffect, useRef, useState } from "react";
 import { Color, ColorRepresentation } from "three";
 
 import { TagAddIconSVG } from "../../../assets";
+import { AnnotationSelectionMode } from "../../../colorizer";
 import { FlexColumn, FlexRow } from "../../../styles/utils";
 
 import { LabelData } from "../../../colorizer/AnnotationData";
@@ -18,6 +19,8 @@ type LabelEditControlsProps = {
   setLabelName: (name: string) => void;
   selectedLabel: LabelData;
   selectedLabelIdx: number;
+  selectionMode: AnnotationSelectionMode;
+  setSelectionMode: (mode: AnnotationSelectionMode) => void;
 };
 
 export default function LabelEditControls(props: LabelEditControlsProps): ReactElement {
@@ -157,6 +160,23 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
           </IconButton>
         </Tooltip>
       </Popconfirm>
+
+      <label style={{ display: "flex", flexDirection: "row", gap: "6px", marginLeft: "4px" }}>
+        <span style={{ fontSize: theme.font.size.label }}>Select by </span>
+        <Radio.Group
+          // buttonStyle="solid"
+          style={{ display: "flex", flexDirection: "row" }}
+          value={props.selectionMode}
+          onChange={(e) => props.setSelectionMode(e.target.value)}
+        >
+          <Tooltip trigger={["hover", "focus"]} title="Select only at the current time" placement="top">
+            <Radio.Button value={AnnotationSelectionMode.TIME}>Time</Radio.Button>
+          </Tooltip>
+          <Tooltip trigger={["hover", "focus"]} title="Select entire track" placement="top">
+            <Radio.Button value={AnnotationSelectionMode.TRACK}>Track</Radio.Button>
+          </Tooltip>
+        </Radio.Group>
+      </label>
     </FlexRow>
   );
 }

--- a/src/components/Tabs/Annotation/LabelEditControls.tsx
+++ b/src/components/Tabs/Annotation/LabelEditControls.tsx
@@ -121,7 +121,7 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
   );
 
   return (
-    <FlexRow $gap={10}>
+    <FlexRow $gap={6}>
       <Tooltip title="Create new label" placement="top">
         <IconButton onClick={onClickCreateNewLabel} type="outlined">
           <TagAddIconSVG />
@@ -161,18 +161,17 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
         </Tooltip>
       </Popconfirm>
 
-      <label style={{ display: "flex", flexDirection: "row", gap: "6px", marginLeft: "4px" }}>
-        <span style={{ fontSize: theme.font.size.label }}>Select by </span>
+      <label style={{ display: "flex", flexDirection: "row", gap: "6px", marginLeft: "8px" }}>
+        <span style={{ fontSize: theme.font.size.label }}>Apply to </span>
         <Radio.Group
-          // buttonStyle="solid"
           style={{ display: "flex", flexDirection: "row" }}
           value={props.selectionMode}
           onChange={(e) => props.setSelectionMode(e.target.value)}
         >
-          <Tooltip trigger={["hover", "focus"]} title="Select only at the current time" placement="top">
+          <Tooltip trigger={["hover", "focus"]} title="Apply only at the current time" placement="top">
             <Radio.Button value={AnnotationSelectionMode.TIME}>Time</Radio.Button>
           </Tooltip>
-          <Tooltip trigger={["hover", "focus"]} title="Select entire track" placement="top">
+          <Tooltip trigger={["hover", "focus"]} title="Apply to entire track" placement="top">
             <Radio.Button value={AnnotationSelectionMode.TRACK}>Track</Radio.Button>
           </Tooltip>
         </Radio.Group>

--- a/src/components/Tooltips/CanvasHoverTooltip.tsx
+++ b/src/components/Tooltips/CanvasHoverTooltip.tsx
@@ -2,7 +2,13 @@ import { Tag } from "antd";
 import React, { PropsWithChildren, ReactElement, useCallback } from "react";
 import styled from "styled-components";
 
-import { Dataset, VECTOR_KEY_MOTION_DELTA, VectorTooltipMode, ViewerConfig } from "../../colorizer";
+import {
+  AnnotationSelectionMode,
+  Dataset,
+  VECTOR_KEY_MOTION_DELTA,
+  VectorTooltipMode,
+  ViewerConfig,
+} from "../../colorizer";
 import { numberToStringDecimal } from "../../colorizer/utils/math_utils";
 import { AnnotationState } from "../../colorizer/utils/react_utils";
 import { FlexColumn } from "../../styles/utils";
@@ -149,6 +155,17 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
         {currentLabelData.name}
       </Tag>
     );
+
+    if (props.annotationState.selectionMode === AnnotationSelectionMode.TRACK) {
+      annotationLabel = (
+        <FlexColumn $gap={4}>
+          {annotationLabel}
+          <Tag bordered={true} color="gold" style={{ width: "fit-content" }}>
+            ✦ Selecting tracks
+          </Tag>
+        </FlexColumn>
+      );
+    }
   }
 
   const tooltipContent = (

--- a/src/components/Tooltips/CanvasHoverTooltip.tsx
+++ b/src/components/Tooltips/CanvasHoverTooltip.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../colorizer";
 import { numberToStringDecimal } from "../../colorizer/utils/math_utils";
 import { AnnotationState } from "../../colorizer/utils/react_utils";
-import { FlexColumn } from "../../styles/utils";
+import { FlexColumn, FlexRow } from "../../styles/utils";
 
 import HoverTooltip from "./HoverTooltip";
 
@@ -158,12 +158,12 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
 
     if (props.annotationState.selectionMode === AnnotationSelectionMode.TRACK) {
       annotationLabel = (
-        <FlexColumn $gap={4}>
+        <FlexRow>
           {annotationLabel}
           <Tag bordered={true} color="gold" style={{ width: "fit-content" }}>
-            ✦ Selecting tracks
+            ✦ Applying to track
           </Tag>
-        </FlexColumn>
+        </FlexRow>
       );
     }
   }

--- a/tests/colorizer/AnnotationData.test.ts
+++ b/tests/colorizer/AnnotationData.test.ts
@@ -74,37 +74,35 @@ describe("AnnotationData", () => {
     const annotationData = new AnnotationData();
     annotationData.createNewLabel();
     annotationData.createNewLabel();
-    annotationData.setLabelOnId(0, 0, true);
-    annotationData.setLabelOnId(0, 35, true);
-    annotationData.setLabelOnId(0, 458, true);
-    annotationData.setLabelOnId(1, 35, true);
+    annotationData.setLabelOnIds(0, [0, 35, 458], true);
+    annotationData.setLabelOnIds(1, [35], true);
 
     expect(annotationData.getLabelsAppliedToId(0)).to.deep.equal([0]);
     expect(annotationData.getLabelsAppliedToId(35)).to.deep.equal([0, 1]);
     expect(annotationData.getLabelsAppliedToId(458)).to.deep.equal([0]);
 
-    annotationData.setLabelOnId(0, 35, false);
+    annotationData.setLabelOnIds(0, [35], false);
     expect(annotationData.getLabelsAppliedToId(0)).to.deep.equal([0]);
     expect(annotationData.getLabelsAppliedToId(35)).to.deep.equal([1]);
     expect(annotationData.getLabelsAppliedToId(458)).to.deep.equal([0]);
   });
 
-  it("ignores duplicate calls to setLabelOnId", () => {
+  it("ignores duplicate calls to setLabelOnIds", () => {
     const annotationData = new AnnotationData();
     annotationData.createNewLabel();
     annotationData.createNewLabel();
-    annotationData.setLabelOnId(0, 0, true);
-    annotationData.setLabelOnId(0, 0, true);
-    annotationData.setLabelOnId(0, 1, true);
+    annotationData.setLabelOnIds(0, [0], true);
+    annotationData.setLabelOnIds(0, [0], true);
+    annotationData.setLabelOnIds(0, [1], true);
 
     expect(annotationData.getLabelsAppliedToId(0)).to.deep.equal([0]);
     expect(annotationData.isLabelOnId(0, 0)).toBe(true);
     expect(annotationData.getLabelsAppliedToId(1)).to.deep.equal([0]);
     expect(annotationData.isLabelOnId(0, 1)).toBe(true);
 
-    annotationData.setLabelOnId(0, 0, false);
-    annotationData.setLabelOnId(0, 0, false);
-    annotationData.setLabelOnId(0, 1, false);
+    annotationData.setLabelOnIds(0, [0], false);
+    annotationData.setLabelOnIds(0, [0], false);
+    annotationData.setLabelOnIds(0, [1], false);
 
     expect(annotationData.getLabelsAppliedToId(0)).to.deep.equal([]);
     expect(annotationData.isLabelOnId(0, 0)).toBe(false);
@@ -118,15 +116,10 @@ describe("AnnotationData", () => {
     };
     const annotationData = new AnnotationData();
     annotationData.createNewLabel();
-    annotationData.setLabelOnId(0, 0, true);
-    annotationData.setLabelOnId(0, 1, true);
-    annotationData.setLabelOnId(0, 2, true);
-    annotationData.setLabelOnId(0, 3, true);
-    annotationData.setLabelOnId(0, 4, true);
-    annotationData.setLabelOnId(0, 5, true);
+    annotationData.setLabelOnIds(0, [0, 1, 2, 3, 4, 5], true);
 
     annotationData.createNewLabel();
-    annotationData.setLabelOnId(1, 2, true);
+    annotationData.setLabelOnIds(1, [2], true);
 
     /* eslint-disable @typescript-eslint/naming-convention */
     // ESLint doesn't like "0" and "1" being property keys.
@@ -154,9 +147,9 @@ describe("AnnotationData", () => {
       annotationData.createNewLabel("Label 2");
       annotationData.createNewLabel("Label 3");
 
-      annotationData.setLabelOnId(0, 0, true);
-      annotationData.setLabelOnId(1, 1, true);
-      annotationData.setLabelOnId(2, 2, true);
+      annotationData.setLabelOnIds(0, [0], true);
+      annotationData.setLabelOnIds(1, [1], true);
+      annotationData.setLabelOnIds(2, [2], true);
 
       const csv = annotationData.toCsv(mockDataset);
       expect(csv).to.equal(
@@ -171,10 +164,10 @@ describe("AnnotationData", () => {
       annotationData.createNewLabel('a","fake label');
       annotationData.createNewLabel('","');
 
-      annotationData.setLabelOnId(0, 0, true);
-      annotationData.setLabelOnId(1, 1, true);
-      annotationData.setLabelOnId(2, 2, true);
-      annotationData.setLabelOnId(3, 3, true);
+      annotationData.setLabelOnIds(0, [0], true);
+      annotationData.setLabelOnIds(1, [1], true);
+      annotationData.setLabelOnIds(2, [2], true);
+      annotationData.setLabelOnIds(3, [3], true);
 
       const csv = annotationData.toCsv(mockDataset);
 


### PR DESCRIPTION
Problem
=======
Closes #508, "Annotation - select whole tracks".

Adds the ability to select or deselect a whole track at once when annotating!

*Estimated review size: small, 10-20 minutes*

Solution
========
- Adds a method to change label status on many object IDs at once in `AnnotationData`.
- Adds additional state to the annotation state hook to track the current selection mode (track vs. time).
- Changes the Viewer to select/deselect all IDs in a track based on the current selection mode.
- Changes cursor to a `cell` style when selecting by tracks and adds an additional tooltip.
- Changed layout of annotation tab based on feedback from Lyndsay.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview-internal/pr-532/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&tab=annotation
2. Open the annotation tab and enter annotation edit mode.
3. Switch the "Apply to" toggle to "Track", and the view to "list view". The cursor should change when hovering over the viewport.
4. Click any object. The entire track should be labeled at once.

Screenshots (optional):
-----------------------

**Video talk-through (🔊):**

https://github.com/user-attachments/assets/dff364c2-0f81-4b49-a824-5d9226efc2ee


Regular time selection:
![image](https://github.com/user-attachments/assets/9bc13a2c-e614-4172-ae50-90556b9a2839)

Selection by tracks:
![image](https://github.com/user-attachments/assets/20668ece-66b8-4de8-881d-ea53235cca16)



Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
2. other important file

Thanks for contributing!
