### PR TITLE
feature: Annotation list view UX improvements

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -996,6 +996,7 @@ function Viewer(): ReactElement {
             }}
             dataset={dataset}
             selectedTrack={selectedTrack}
+            time={currentFrame}
           />
         </div>
       ),

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -995,6 +995,7 @@ function Viewer(): ReactElement {
               setFrameAndRender(frame);
             }}
             dataset={dataset}
+            selectedTrack={selectedTrack}
           />
         </div>
       ),

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -20,6 +20,7 @@ import { ExportIconSVG } from "../assets";
 import { getDefaultViewerConfig } from "../colorizer/constants";
 import { ViewerConfig } from "../colorizer/types";
 import { AnalyticsEvent, triggerAnalyticsEvent } from "../colorizer/utils/analytics";
+import { StyledRadioGroup } from "../styles/components";
 import { FlexColumn, FlexColumnAlignCenter, FlexRow } from "../styles/utils";
 
 import CanvasRecorder, { RecordingOptions } from "../colorizer/recorders/CanvasRecorder";
@@ -86,7 +87,7 @@ const CustomRadio = styled(Radio)`
   }
 `;
 
-const ExportModeRadioGroup = styled(Radio.Group)`
+const ExportModeRadioGroup = styled(StyledRadioGroup)`
   & {
     // Use standard 40px of padding, unless the view is too narrow and it needs to shrink
     padding: 0 calc(min(40px, 5vw));
@@ -107,7 +108,7 @@ const MaxWidthRadioGroup = styled(Radio.Group)`
   }
 `;
 
-const VideoQualityRadioGroup = styled(Radio.Group)`
+const VideoQualityRadioGroup = styled(StyledRadioGroup)`
   & {
     display: flex;
     flex-direction: row;

--- a/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
+++ b/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, useContext, useEffect, useMemo, useRef } from "rea
 import styled from "styled-components";
 
 import { TagIconSVG } from "../../../assets";
-import { Dataset } from "../../../colorizer";
+import { Dataset, Track } from "../../../colorizer";
 import { FlexColumn, FlexColumnAlignCenter, FlexRowAlignCenter } from "../../../styles/utils";
 
 import { AppThemeContext } from "../../AppStyle";
@@ -14,6 +14,7 @@ type AnnotationDisplayListProps = {
   ids: number[];
   onClickObjectRow: (record: TableDataType) => void;
   onClickDeleteObject: (record: TableDataType) => void;
+  selectedTrack: Track | null;
 };
 
 const StyledCollapse = styled(Collapse)`
@@ -104,7 +105,9 @@ export default function AnnotationDisplayList(props: AnnotationDisplayListProps)
             <Collapse.Panel
               header={
                 <p>
-                  Track {trackId}{" "}
+                  <span style={{ fontWeight: props.selectedTrack?.trackId === trackId ? "600" : "400" }}>
+                    Track {trackId}{" "}
+                  </span>
                   <span style={{ color: theme.color.text.hint }}>
                     ({ids.length}/{trackLength})
                   </span>

--- a/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
+++ b/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
@@ -157,7 +157,7 @@ export default function AnnotationDisplayList(props: AnnotationDisplayListProps)
           Auto-scroll to track
         </Checkbox>
       </FlexRowAlignCenter>
-      <div style={{ position: "relative", border: "1px solid var(--color-borders)" }}>
+      <div style={{ position: "relative" }}>
         <div
           style={{ maxHeight: "400px", height: "100%", overflowY: "scroll" }}
           ref={scrollRef}

--- a/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
+++ b/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
@@ -16,6 +16,7 @@ type AnnotationDisplayListProps = {
   onClickObjectRow: (record: TableDataType) => void;
   onClickDeleteObject: (record: TableDataType) => void;
   selectedTrack: Track | null;
+  selectedId?: number;
 };
 
 const StyledCollapse = styled(Collapse)`
@@ -127,6 +128,7 @@ export default function AnnotationDisplayList(props: AnnotationDisplayListProps)
             >
               <AnnotationDisplayTable
                 ids={ids}
+                selectedId={props.selectedId}
                 dataset={props.dataset}
                 onClickObjectRow={props.onClickObjectRow}
                 onClickDeleteObject={props.onClickDeleteObject}

--- a/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
+++ b/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 
 import { TagIconSVG } from "../../../assets";
 import { Dataset, Track } from "../../../colorizer";
+import { ScrollShadowContainer, useScrollShadow } from "../../../colorizer/utils/react_utils";
 import { FlexColumn, FlexColumnAlignCenter, FlexRowAlignCenter } from "../../../styles/utils";
 
 import { AppThemeContext } from "../../AppStyle";
@@ -41,6 +42,7 @@ const StyledCollapse = styled(Collapse)`
 
 export default function AnnotationDisplayList(props: AnnotationDisplayListProps): ReactElement {
   const theme = useContext(AppThemeContext);
+  const { scrollShadowStyle, onScrollHandler, scrollRef } = useScrollShadow();
 
   const trackToLength = useRef<Record<string, number>>({});
 
@@ -131,9 +133,18 @@ export default function AnnotationDisplayList(props: AnnotationDisplayListProps)
   }
 
   return (
-    <FlexColumn style={{ width: "100%" }}>
+    <FlexColumn style={{ width: "100%", height: "100%" }}>
       <p style={{ fontSize: theme.font.size.label }}>{trackIdsSorted.length} track(s) selected</p>
-      {listContents}
+      <div style={{ position: "relative" }}>
+        <div
+          style={{ maxHeight: "400px", height: "100%", overflowY: "scroll" }}
+          ref={scrollRef}
+          onScroll={onScrollHandler}
+        >
+          {listContents}
+        </div>
+        <ScrollShadowContainer style={scrollShadowStyle} />
+      </div>
     </FlexColumn>
   );
 }

--- a/src/components/Tabs/Annotation/AnnotationDisplayTable.tsx
+++ b/src/components/Tabs/Annotation/AnnotationDisplayTable.tsx
@@ -10,6 +10,8 @@ import { FlexColumnAlignCenter, VisuallyHidden } from "../../../styles/utils";
 import { AppThemeContext } from "../../AppStyle";
 import IconButton from "../../IconButton";
 
+const SELECTED_ROW_CLASSNAME = "selected-row";
+
 export type TableDataType = {
   key: string;
   id: number;
@@ -26,11 +28,18 @@ const StyledAntTable = styled(Table)`
     padding: 4px 8px;
   }
 
-  &&& :not(.ant-table-header) > .rc-virtual-list .ant-table-cell:not(:has(.ant-btn)) {
-    /* Correction for a bug in virtual lists where text elements were not
-     * centered vertically */
-    display: flex;
-    align-items: center;
+  &&& :not(.ant-table-header) > .rc-virtual-list {
+    & .ant-table-row.${SELECTED_ROW_CLASSNAME} {
+      font-weight: bold;
+      background-color: var(--color-background-alt);
+    }
+
+    & .ant-table-cell:not(:has(.ant-btn)) {
+      /* Correction for a bug in virtual lists where text elements were not
+      * centered vertically */
+      display: flex;
+      align-items: center;
+    }
   }
 `;
 
@@ -41,11 +50,13 @@ type AnnotationTableProps = {
   ids: number[];
   height?: number | string;
   hideTrackColumn?: boolean;
+  selectedId?: number;
 };
 
 const defaultProps = {
   height: "100%",
   hideTrackColumn: false,
+  selectedId: -1,
 };
 
 /**
@@ -117,6 +128,7 @@ const AnnotationDisplayTable = memo(function AnnotationDisplayTable(inputProps: 
 
   return (
     <StyledAntTable
+      rowClassName={(record) => (record.id === props.selectedId ? SELECTED_ROW_CLASSNAME : "")}
       dataSource={tableData}
       columns={tableColumns}
       size="small"

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -31,6 +31,7 @@ type AnnotationTabProps = {
   setTrackAndFrame: (track: number, frame: number) => void;
   selectedTrack: Track | null;
   dataset: Dataset | null;
+  time: number;
 };
 
 export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
@@ -53,6 +54,9 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
 
   const labels = annotationData.getLabels();
   const selectedLabel: LabelData | undefined = labels[currentLabelIdx ?? -1];
+  const selectedId = useMemo(() => {
+    return props.selectedTrack?.getIdAtTime(props.time) ?? -1;
+  }, [props.time, props.selectedTrack]);
 
   const onSelectLabelIdx = (idx: string): void => {
     startTransition(() => {
@@ -192,6 +196,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
             dataset={props.dataset}
             ids={tableIds}
             height={395}
+            selectedId={selectedId}
           />
         </div>
         {/*
@@ -213,6 +218,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
             dataset={props.dataset}
             ids={tableIds}
             selectedTrack={props.selectedTrack}
+            selectedId={selectedId}
           ></AnnotationDisplayList>
         </div>
       </LoadingSpinner>

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -216,7 +216,9 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
           ></AnnotationDisplayList>
         </div>
       </LoadingSpinner>
-      {tableIds.length > 0 && <p style={{ color: theme.color.text.hint }}>Click a row to jump to that object.</p>}
+      {tableIds.length > 0 && (
+        <p style={{ color: theme.color.text.hint, margin: 0 }}>Click a row to jump to that object.</p>
+      )}
     </FlexColumnAlignCenter>
   );
 }

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -5,6 +5,7 @@ import { Color } from "three";
 
 import { Dataset } from "../../../colorizer";
 import { AnnotationState } from "../../../colorizer/utils/react_utils";
+import { StyledRadioGroup } from "../../../styles/components";
 import { FlexColumnAlignCenter, FlexRow, VisuallyHidden } from "../../../styles/utils";
 import { download } from "../../../utils/file_io";
 import { SelectItem } from "../../Dropdowns/types";
@@ -153,7 +154,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
         {/* View mode selection */}
         <label>
           <VisuallyHidden>View mode</VisuallyHidden>
-          <Radio.Group
+          <StyledRadioGroup
             style={{ display: "flex", flexDirection: "row" }}
             value={viewType}
             onChange={(e) => startTransition(() => setViewType(e.target.value))}
@@ -170,7 +171,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
                 <VisuallyHidden>List view {viewType === AnnotationViewType.LIST ? "(selected)" : ""}</VisuallyHidden>
               </Radio.Button>
             </Tooltip>
-          </Radio.Group>
+          </StyledRadioGroup>
         </label>
       </FlexRow>
 

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -3,7 +3,7 @@ import { Radio, Tooltip } from "antd";
 import React, { ReactElement, useCallback, useContext, useMemo, useState, useTransition } from "react";
 import { Color } from "three";
 
-import { Dataset } from "../../../colorizer";
+import { Dataset, Track } from "../../../colorizer";
 import { AnnotationState } from "../../../colorizer/utils/react_utils";
 import { StyledRadioGroup } from "../../../styles/components";
 import { FlexColumnAlignCenter, FlexRow, VisuallyHidden } from "../../../styles/utils";
@@ -29,6 +29,7 @@ const enum AnnotationViewType {
 type AnnotationTabProps = {
   annotationState: AnnotationState;
   setTrackAndFrame: (track: number, frame: number) => void;
+  selectedTrack: Track | null;
   dataset: Dataset | null;
 };
 
@@ -211,6 +212,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
             onClickDeleteObject={onClickDeleteObject}
             dataset={props.dataset}
             ids={tableIds}
+            selectedTrack={props.selectedTrack}
           ></AnnotationDisplayList>
         </div>
       </LoadingSpinner>

--- a/src/components/Tabs/Annotation/LabelEditControls.tsx
+++ b/src/components/Tabs/Annotation/LabelEditControls.tsx
@@ -6,6 +6,7 @@ import { Color, ColorRepresentation } from "three";
 
 import { TagAddIconSVG } from "../../../assets";
 import { AnnotationSelectionMode } from "../../../colorizer";
+import { StyledRadioGroup } from "../../../styles/components";
 import { FlexColumn, FlexRow } from "../../../styles/utils";
 
 import { LabelData } from "../../../colorizer/AnnotationData";
@@ -163,7 +164,7 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
 
       <label style={{ display: "flex", flexDirection: "row", gap: "6px", marginLeft: "8px" }}>
         <span style={{ fontSize: theme.font.size.label }}>Apply to </span>
-        <Radio.Group
+        <StyledRadioGroup
           style={{ display: "flex", flexDirection: "row" }}
           value={props.selectionMode}
           onChange={(e) => props.setSelectionMode(e.target.value)}
@@ -174,7 +175,7 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
           <Tooltip trigger={["hover", "focus"]} title="Apply to entire track" placement="top">
             <Radio.Button value={AnnotationSelectionMode.TRACK}>Track</Radio.Button>
           </Tooltip>
-        </Radio.Group>
+        </StyledRadioGroup>
       </label>
     </FlexRow>
   );

--- a/src/styles/components.tsx
+++ b/src/styles/components.tsx
@@ -1,0 +1,21 @@
+import { Radio } from "antd";
+import styled from "styled-components";
+
+/**
+ * Radio group with custom styling to keep button
+ * hover and active states consistent with other buttons.
+ */
+export const StyledRadioGroup = styled(Radio.Group)`
+  & .ant-radio-button-wrapper {
+    &:not(:disabled):hover {
+      color: var(--color-text-button);
+      fill: var(--color-text-button);
+      background-color: var(--color-button-hover);
+      border-color: var(--color-button);
+    }
+
+    &:not(:disabled):active {
+      border-color: var(--color-button-active);
+    }
+  }
+`;


### PR DESCRIPTION
Problem
=======
Closes #533, "Annotation - UX improvements to list view".

This adds a number of QoL changes to the list view, described below.

*Estimated review size: small, 10 minutes*

Solution
========
- Added an option to automatically scroll to the currently-selected track in the track list view.
- Bolded the currently selected track in the track list view.
- Bolded the currently selected object in the annotation table view.
- Changed radio buttons to behave like other UI buttons when hovered or clicked with the new `StyledRadioGroup` component.
- Changed the annotation list view to be a scrollable area with fixed height, and added scroll shadows.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link.

Screenshots (optional):
-----------------------

![image](https://github.com/user-attachments/assets/1e696e63-4d97-49b9-8966-f60d1ed322d6)
