### PR TITLE
feat: Added interactive thumbnails to track list view

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -994,13 +994,12 @@ function Viewer(): ReactElement {
         <div className={styles.tabContent}>
           <AnnotationTab
             annotationState={annotationState}
-            setTrackAndFrame={(track, frame) => {
+            setFrame={async (frame) => {
               const isPlaying = timeControls.isPlaying();
               if (isPlaying) {
                 timeControls.pause();
               }
-              findTrack(track, false);
-              setFrameAndRender(frame);
+              await setFrameAndRender(frame);
               if (isPlaying) {
                 timeControls.play();
               }
@@ -1008,7 +1007,7 @@ function Viewer(): ReactElement {
             setTrack={(track) => findTrack(track, false)}
             dataset={dataset}
             selectedTrack={selectedTrack}
-            time={currentFrame}
+            frame={currentFrame}
           />
         </div>
       ),

--- a/src/colorizer/Track.ts
+++ b/src/colorizer/Track.ts
@@ -59,4 +59,16 @@ export default class Track {
   startTime(): number {
     return this.times[0];
   }
+
+  getMissingTimes(): number[] {
+    const missingTimes = [];
+    const startTime = this.startTime();
+    const timesSet = new Set(this.times);
+    for (let i = startTime; i < startTime + this.duration(); i++) {
+      if (!timesSet.has(i)) {
+        missingTimes.push(i);
+      }
+    }
+    return missingTimes;
+  }
 }

--- a/src/colorizer/utils/data_utils.ts
+++ b/src/colorizer/utils/data_utils.ts
@@ -169,3 +169,43 @@ export function formatAsBulletList(items: string[], maxDisplayCount: number = Nu
   }
   return itemDisplayText;
 }
+
+/**
+ * For a list of integers, returns a list of inclusive `[min, max]` value
+ * intervals where the integers are contiguous.
+ *
+ * @example
+ * ```
+ * const result = getIntervals([5, 6, 7, 9, 10, 14])
+ * // result = [[5, 7], [9, 10], [14, 14]]
+ * ```
+ */
+export function getIntervals(values: number[]): [number, number][] {
+  let min = values[0];
+  let max = values[0];
+  for (const value of values) {
+    min = Math.min(min, value);
+    max = Math.max(max, value);
+  }
+
+  const intervals: [number, number][] = [];
+  const valuesAsSet = new Set(values);
+  let lastIntervalStart = -1;
+
+  for (let i = min; i <= max; i++) {
+    if (valuesAsSet.has(i)) {
+      if (lastIntervalStart === -1) {
+        lastIntervalStart = i;
+      }
+    } else {
+      if (lastIntervalStart !== -1) {
+        intervals.push([lastIntervalStart, i - 1]);
+        lastIntervalStart = -1;
+      }
+    }
+  }
+  if (lastIntervalStart !== -1) {
+    intervals.push([lastIntervalStart, max]);
+  }
+  return intervals;
+}

--- a/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
+++ b/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useContext, useEffect, useMemo, useRef } from "react";
 import styled from "styled-components";
+import { Color } from "three";
 
 import { TagIconSVG } from "../../../assets";
 import { Dataset, Track } from "../../../colorizer";
@@ -9,15 +10,19 @@ import { FlexColumn, FlexColumnAlignCenter, FlexRowAlignCenter } from "../../../
 import { AppThemeContext } from "../../AppStyle";
 import DropdownItem from "../../Dropdowns/DropdownItem";
 import AnnotationDisplayTable, { TableDataType } from "./AnnotationDisplayTable";
+import AnnotationTrackThumbnail from "./AnnotationTrackThumbnail";
 
 type AnnotationDisplayListProps = {
   dataset: Dataset | null;
   ids: number[];
+  setFrame: (frame: number) => Promise<void>;
   onClickTrack: (trackId: number) => void;
   onClickObjectRow: (record: TableDataType) => void;
   onClickDeleteObject: (record: TableDataType) => void;
   selectedTrack: Track | null;
   selectedId?: number;
+  frame: number;
+  labelColor: Color;
 };
 
 const ListLayoutContainer = styled.div`
@@ -31,27 +36,25 @@ const ListLayoutContainer = styled.div`
 export default function AnnotationDisplayList(props: AnnotationDisplayListProps): ReactElement {
   const theme = useContext(AppThemeContext);
 
-  const trackToLength = useRef<Record<string, number>>({});
+  const cachedTracks = useRef<Map<string, Track | undefined>>(new Map());
   const selectedTrackId = props.selectedTrack?.trackId.toString();
 
   const { scrollShadowStyle, onScrollHandler, scrollRef } = useScrollShadow();
 
   useEffect(() => {
-    trackToLength.current = {};
+    cachedTracks.current.clear();
   }, [props.dataset]);
 
   // Building a track is an expensive operation (takes O(N) where N is the
-  // size of the dataset), so cache the length of tracks.
+  // size of the dataset), so cache the tracks.
   // TODO: This could be optimized by having the dataset perform this once
   // and save the results in a lookup table.
-  const getTrackLength = (trackId: number): number => {
-    if (trackToLength.current[trackId] !== undefined) {
-      return trackToLength.current[trackId];
-    } else {
+  const getTrack = (trackId: number): Track | undefined => {
+    if (!cachedTracks.current.has(trackId.toString())) {
       const track = props.dataset?.buildTrack(trackId);
-      trackToLength.current[trackId] = track?.ids.length ?? 0;
-      return track?.ids.length ?? 0;
+      cachedTracks.current.set(trackId.toString(), track);
     }
+    return cachedTracks.current.get(trackId.toString());
   };
 
   // Organize ids by track
@@ -97,8 +100,8 @@ export default function AnnotationDisplayList(props: AnnotationDisplayListProps)
     listContents = (
       <ul style={{ marginTop: 0 }}>
         {trackIds.map((trackId) => {
+          const track = getTrack(trackId);
           const ids = trackToIds.get(trackId.toString())!;
-          const trackLength = getTrackLength(trackId);
           const isSelectedTrack = props.selectedTrack?.trackId === trackId;
           return (
             <li key={trackId}>
@@ -109,12 +112,22 @@ export default function AnnotationDisplayList(props: AnnotationDisplayListProps)
                 }}
                 selected={isSelectedTrack}
               >
-                <p style={{ margin: 0 }}>
-                  {trackId}{" "}
-                  <span style={{ color: theme.color.text.hint }}>
-                    ({ids.length}/{trackLength})
-                  </span>
-                </p>
+                <FlexRowAlignCenter $gap={5}>
+                  <AnnotationTrackThumbnail
+                    widthPx={75}
+                    heightPx={14}
+                    ids={ids}
+                    track={track ?? null}
+                    dataset={props.dataset}
+                    color={props.labelColor}
+                  ></AnnotationTrackThumbnail>
+                  <p style={{ margin: 0 }}>
+                    {trackId}{" "}
+                    <span style={{ color: theme.color.text.hint }}>
+                      ({ids.length}/{track?.times.length})
+                    </span>
+                  </p>
+                </FlexRowAlignCenter>
               </DropdownItem>
             </li>
           );
@@ -123,7 +136,6 @@ export default function AnnotationDisplayList(props: AnnotationDisplayListProps)
     );
   }
 
-  const selectedTrackLength = getTrackLength(selectedTrackId ? parseInt(selectedTrackId, 10) : 0);
   const selectedTrackIds = trackToIds.get(selectedTrackId ?? "") ?? [];
 
   return (
@@ -160,24 +172,35 @@ export default function AnnotationDisplayList(props: AnnotationDisplayListProps)
             flexGrow: 2,
           }}
         >
-          <p style={{ fontSize: theme.font.size.label, marginTop: 0, marginBottom: "5px" }}>
-            {selectedTrackId ? (
-              <span>
-                Track {selectedTrackId}{" "}
-                <span style={{ color: theme.color.text.hint }}>
-                  ({selectedTrackIds.length}/{selectedTrackLength})
+          <FlexRowAlignCenter style={{ marginBottom: "5px" }} $gap={10}>
+            <AnnotationTrackThumbnail
+              frame={props.frame}
+              setFrame={props.setFrame}
+              ids={selectedTrackIds}
+              track={props.selectedTrack}
+              dataset={props.dataset}
+              color={props.labelColor}
+            ></AnnotationTrackThumbnail>
+
+            <p style={{ fontSize: theme.font.size.label, marginTop: 0 }}>
+              {selectedTrackId ? (
+                <span>
+                  Track {selectedTrackId}{" "}
+                  <span style={{ color: theme.color.text.hint }}>
+                    ({selectedTrackIds.length}/{props.selectedTrack?.times.length})
+                  </span>
                 </span>
-              </span>
-            ) : (
-              `No track selected`
-            )}
-          </p>
+              ) : (
+                `No track selected`
+              )}
+            </p>
+          </FlexRowAlignCenter>
           <AnnotationDisplayTable
             onClickObjectRow={props.onClickObjectRow}
             onClickDeleteObject={props.onClickDeleteObject}
             dataset={props.dataset}
             ids={selectedTrackId ? trackToIds.get(selectedTrackId) ?? [] : []}
-            height={412}
+            height={410}
             selectedId={props.selectedId}
             hideTrackColumn={true}
           ></AnnotationDisplayTable>

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -27,11 +27,11 @@ const enum AnnotationViewType {
 
 type AnnotationTabProps = {
   annotationState: AnnotationState;
-  setTrackAndFrame: (track: number, frame: number) => void;
+  setFrame: (frame: number) => Promise<void>;
   setTrack: (track: number) => void;
   selectedTrack: Track | null;
   dataset: Dataset | null;
-  time: number;
+  frame: number;
 };
 
 export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
@@ -49,13 +49,13 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
   } = props.annotationState;
 
   const [isPending, startTransition] = useTransition();
-  const [viewType, setViewType] = useState<AnnotationViewType>(AnnotationViewType.TABLE);
+  const [viewType, setViewType] = useState<AnnotationViewType>(AnnotationViewType.LIST);
 
   const labels = annotationData.getLabels();
   const selectedLabel: LabelData | undefined = labels[currentLabelIdx ?? -1];
   const selectedId = useMemo(() => {
-    return props.selectedTrack?.getIdAtTime(props.time) ?? -1;
-  }, [props.time, props.selectedTrack]);
+    return props.selectedTrack?.getIdAtTime(props.frame) ?? -1;
+  }, [props.frame, props.selectedTrack]);
 
   const onSelectLabelIdx = (idx: string): void => {
     startTransition(() => {
@@ -78,9 +78,10 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
 
   const onClickObjectRow = useCallback(
     (record: TableDataType): void => {
-      props.setTrackAndFrame(record.track, record.time);
+      props.setTrack(record.track);
+      props.setFrame(record.time);
     },
-    [props.setTrackAndFrame]
+    [props.setTrack, props.setFrame]
   );
 
   const onClickDeleteObject = useCallback(
@@ -215,10 +216,13 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
             onClickObjectRow={onClickObjectRow}
             onClickDeleteObject={onClickDeleteObject}
             onClickTrack={props.setTrack}
+            setFrame={props.setFrame}
             dataset={props.dataset}
             ids={tableIds}
             selectedTrack={props.selectedTrack}
             selectedId={selectedId}
+            frame={props.frame}
+            labelColor={selectedLabel?.color}
           ></AnnotationDisplayList>
         </div>
       </LoadingSpinner>

--- a/src/components/Tabs/Annotation/AnnotationTrackThumbnail.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTrackThumbnail.tsx
@@ -1,0 +1,178 @@
+import React, { ReactElement, useCallback, useContext, useEffect, useRef, useState } from "react";
+import styled from "styled-components";
+import { Color } from "three";
+
+import { Dataset, Track } from "../../../colorizer";
+import { getIntervals } from "../../../colorizer/utils/data_utils";
+
+import { AppTheme, AppThemeContext } from "../../AppStyle";
+
+type AnnotationTrackThumbnailProps = {
+  ids: number[];
+  track: Track | null;
+  dataset: Dataset | null;
+  color: Color;
+  heightPx?: number;
+  widthPx?: number;
+  setFrame?: (frame: number) => Promise<void>;
+  frame?: number;
+};
+
+const defaultProps = {
+  heightPx: 18,
+  widthPx: 150,
+};
+
+const ThumbnailContainer = styled.div<{ $widthPx: number; $heightPx: number; $theme: AppTheme }>`
+  position: relative;
+  border-radius: 4px;
+  border: 1px solid ${(props) => props.$theme.color.layout.borders};
+  overflow: hidden;
+  width: ${(props) => props.$widthPx}px;
+  height: ${(props) => props.$heightPx}px;
+  display: flex;
+
+  & > canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+`;
+
+export default function AnnotationTrackThumbnail(inputProps: AnnotationTrackThumbnailProps): ReactElement {
+  const props = { ...defaultProps, ...inputProps };
+  const { track, dataset, ids } = props;
+  const theme = useContext(AppThemeContext);
+
+  const [hoveredCanvasX, setHoveredCanvasX] = useState<number | null>(null);
+  const [awaitingFrame, setAwaitingFrame] = useState<number | null>(null);
+
+  // The thumbnail uses two layered canvases. The time canvas on top just draws
+  // lines for the current and hovered time, while the base canvas draws the
+  // labeled intervals.
+  const baseCanvasRef = useRef<HTMLCanvasElement>(null);
+  const timeCanvasRef = useRef<HTMLCanvasElement>(null);
+
+  const minTime = track ? track.times[0] : 0;
+  const maxTime = track ? track.times[track.times.length - 1] : 0;
+  const duration = maxTime - minTime + 1;
+  const indexToCanvasScale = props.widthPx / duration;
+
+  const xCoordToTime = useCallback(
+    (x: number): number => Math.floor(x / indexToCanvasScale + minTime),
+    [minTime, indexToCanvasScale]
+  );
+  const timeToXCoord = useCallback(
+    (time: number): number => (time - minTime) * indexToCanvasScale,
+    [minTime, indexToCanvasScale]
+  );
+
+  // Add event listeners
+  useEffect(() => {
+    const getXCoord = (event: MouseEvent): number => {
+      const canvas = timeCanvasRef.current;
+      if (!canvas) {
+        return 0;
+      }
+      const rect = canvas.getBoundingClientRect();
+      return event.clientX - rect.left;
+    };
+
+    const onMouseMove = (event: MouseEvent): void => setHoveredCanvasX(getXCoord(event));
+    const onMouseLeave = (): void => setHoveredCanvasX(null);
+    const onMouseClick = async (event: MouseEvent): Promise<void> => {
+      if (props.setFrame) {
+        const frame = xCoordToTime(getXCoord(event));
+        setAwaitingFrame(frame);
+        await props.setFrame(frame);
+        setAwaitingFrame(null);
+      }
+    };
+
+    timeCanvasRef.current?.addEventListener("mousemove", onMouseMove);
+    timeCanvasRef.current?.addEventListener("mouseleave", onMouseLeave);
+    timeCanvasRef.current?.addEventListener("click", onMouseClick);
+    return () => {
+      timeCanvasRef.current?.removeEventListener("mousemove", onMouseMove);
+      timeCanvasRef.current?.removeEventListener("mouseleave", onMouseLeave);
+      timeCanvasRef.current?.removeEventListener("click", onMouseClick);
+    };
+  }, [props.setFrame, xCoordToTime]);
+
+  // Update time canvas
+  useEffect(() => {
+    const canvas = timeCanvasRef.current;
+    const ctx = timeCanvasRef.current?.getContext("2d");
+    if (!canvas || !ctx) {
+      return;
+    }
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    if (!track || !dataset) {
+      return;
+    }
+
+    const drawDashedLine = (x: number, color: string): void => {
+      ctx.strokeStyle = color;
+      ctx.setLineDash([2, 2]);
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, props.heightPx);
+      ctx.stroke();
+      ctx.closePath();
+    };
+
+    // Draw hovered time on canvas.
+    if (props.frame && hoveredCanvasX !== null) {
+      const hoveredTime = xCoordToTime(hoveredCanvasX);
+      const x = timeToXCoord(hoveredTime + 0.5);
+      drawDashedLine(x, theme.color.text.hint);
+    }
+    // Draw the current time on the canvas. Replace with awaiting time if it is
+    // set for optimistic updates
+    if (props.frame !== undefined && props.frame >= minTime && props.frame <= maxTime) {
+      const frame = awaitingFrame !== null ? awaitingFrame : props.frame;
+      const x = timeToXCoord(frame + 0.5);
+      drawDashedLine(x, theme.color.text.primary);
+    }
+  }, [track, dataset, props.widthPx, props.heightPx, props.frame, hoveredCanvasX, awaitingFrame]);
+
+  // Update base canvas
+  useEffect(() => {
+    const canvas = baseCanvasRef.current;
+    const ctx = baseCanvasRef.current?.getContext("2d");
+    if (!canvas || !ctx) {
+      return;
+    }
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    if (track === null || dataset === null) {
+      return;
+    }
+    const selectedTimes = ids.map((id) => dataset.getTime(id));
+    const selectedIntervals = getIntervals(selectedTimes);
+    // Check for time intervals where there are no objects present for the track
+    const missingIntervals = getIntervals(track.getMissingTimes());
+
+    const drawInterval = (interval: [number, number], color: string): void => {
+      const minX = timeToXCoord(interval[0]);
+      const maxX = timeToXCoord(interval[1] + 1);
+      ctx.fillStyle = color;
+      ctx.fillRect(minX, 0, maxX - minX, props.heightPx);
+    };
+
+    // Draw missing time intervals on the canvas
+    for (const interval of missingIntervals) {
+      drawInterval(interval, theme.color.layout.borders);
+    }
+    // Draw selected intervals on the canvas
+    for (const interval of selectedIntervals) {
+      drawInterval(interval, "#" + props.color.getHexString());
+    }
+  }, [ids, track, props.frame, props.widthPx, props.heightPx]);
+
+  return (
+    <ThumbnailContainer $theme={theme} $heightPx={props.heightPx} $widthPx={props.widthPx}>
+      <canvas ref={baseCanvasRef} width={props.widthPx} height={props.heightPx}></canvas>
+      <canvas ref={timeCanvasRef} width={props.widthPx} height={props.heightPx}></canvas>
+    </ThumbnailContainer>
+  );
+}

--- a/src/components/Tabs/Annotation/AnnotationTrackThumbnail.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTrackThumbnail.tsx
@@ -145,6 +145,9 @@ export default function AnnotationTrackThumbnail(inputProps: AnnotationTrackThum
       return;
     }
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = theme.color.layout.background;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
     if (track === null || dataset === null) {
       return;
     }

--- a/src/components/Tabs/Annotation/AnnotationTrackThumbnail.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTrackThumbnail.tsx
@@ -23,7 +23,7 @@ const defaultProps = {
   widthPx: 150,
 };
 
-const ThumbnailContainer = styled.div<{ $widthPx: number; $heightPx: number; $theme: AppTheme }>`
+const ThumbnailContainer = styled.div<{ $widthPx: number; $heightPx: number; $interactive: boolean; $theme: AppTheme }>`
   position: relative;
   border-radius: 4px;
   border: 1px solid ${(props) => props.$theme.color.layout.borders};
@@ -31,6 +31,7 @@ const ThumbnailContainer = styled.div<{ $widthPx: number; $heightPx: number; $th
   width: ${(props) => props.$widthPx}px;
   height: ${(props) => props.$heightPx}px;
   display: flex;
+  cursor: ${(props) => (props.$interactive ? "pointer" : "auto")};
 
   & > canvas {
     position: absolute;
@@ -81,7 +82,7 @@ export default function AnnotationTrackThumbnail(inputProps: AnnotationTrackThum
     const onMouseMove = (event: MouseEvent): void => setHoveredCanvasX(getXCoord(event));
     const onMouseLeave = (): void => setHoveredCanvasX(null);
     const onMouseClick = async (event: MouseEvent): Promise<void> => {
-      if (props.setFrame) {
+      if (props.setFrame && props.track) {
         const frame = xCoordToTime(getXCoord(event));
         setAwaitingFrame(frame);
         await props.setFrame(frame);
@@ -97,7 +98,7 @@ export default function AnnotationTrackThumbnail(inputProps: AnnotationTrackThum
       timeCanvasRef.current?.removeEventListener("mouseleave", onMouseLeave);
       timeCanvasRef.current?.removeEventListener("click", onMouseClick);
     };
-  }, [props.setFrame, xCoordToTime]);
+  }, [props.setFrame, props.track, xCoordToTime]);
 
   // Update time canvas
   useEffect(() => {
@@ -170,7 +171,12 @@ export default function AnnotationTrackThumbnail(inputProps: AnnotationTrackThum
   }, [ids, track, props.frame, props.widthPx, props.heightPx]);
 
   return (
-    <ThumbnailContainer $theme={theme} $heightPx={props.heightPx} $widthPx={props.widthPx}>
+    <ThumbnailContainer
+      $theme={theme}
+      $heightPx={props.heightPx}
+      $widthPx={props.widthPx}
+      $interactive={props.track !== null}
+    >
       <canvas ref={baseCanvasRef} width={props.widthPx} height={props.heightPx}></canvas>
       <canvas ref={timeCanvasRef} width={props.widthPx} height={props.heightPx}></canvas>
     </ThumbnailContainer>

--- a/tests/data_utils.test.ts
+++ b/tests/data_utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { FeatureThreshold, ThresholdType } from "../src/colorizer/types";
-import { getKeyFromName, validateThresholds } from "../src/colorizer/utils/data_utils";
+import { getIntervals, getKeyFromName, validateThresholds } from "../src/colorizer/utils/data_utils";
 
 import { makeMockDataset } from "./Dataset.test";
 
@@ -100,6 +100,40 @@ describe("data_utils", () => {
           type: ThresholdType.CATEGORICAL,
           enabledCategories: [true, false, false],
         },
+      ]);
+    });
+  });
+
+  describe("getSubsetSubregions", () => {
+    it("returns interval over whole range", () => {
+      const values = [0, 1, 2, 3, 4, 5];
+      expect(getIntervals(values)).deep.equals([[0, 5]]);
+    });
+
+    it("returns interval missing start", () => {
+      const values = [2, 3, 4, 5];
+      expect(getIntervals(values)).deep.equals([[2, 5]]);
+    });
+
+    it("returns intervals missing end", () => {
+      const values = [0, 1, 2, 3];
+      expect(getIntervals(values)).deep.equals([[0, 3]]);
+    });
+
+    it("returns multiple intervals", () => {
+      const values = [1, 3, 4, 5];
+      expect(getIntervals(values)).deep.equals([
+        [1, 1],
+        [3, 5],
+      ]);
+    });
+
+    it("returns intervals as values and not indices", () => {
+      const values = [5, 6, 7, 9, 10, 14];
+      expect(getIntervals(values)).deep.equals([
+        [5, 7],
+        [9, 10],
+        [14, 14],
       ]);
     });
   });

--- a/tests/data_utils.test.ts
+++ b/tests/data_utils.test.ts
@@ -110,27 +110,20 @@ describe("data_utils", () => {
       expect(getIntervals(values)).deep.equals([[0, 5]]);
     });
 
-    it("returns interval missing start", () => {
+    it("returns interval missing zero", () => {
       const values = [2, 3, 4, 5];
       expect(getIntervals(values)).deep.equals([[2, 5]]);
     });
 
-    it("returns intervals missing end", () => {
-      const values = [0, 1, 2, 3];
-      expect(getIntervals(values)).deep.equals([[0, 3]]);
-    });
-
     it("returns multiple intervals", () => {
-      const values = [1, 3, 4, 5];
-      expect(getIntervals(values)).deep.equals([
+      const values1 = [1, 3, 4, 5];
+      expect(getIntervals(values1)).deep.equals([
         [1, 1],
         [3, 5],
       ]);
-    });
 
-    it("returns intervals as values and not indices", () => {
-      const values = [5, 6, 7, 9, 10, 14];
-      expect(getIntervals(values)).deep.equals([
+      const values2 = [5, 6, 7, 9, 10, 14];
+      expect(getIntervals(values2)).deep.equals([
         [5, 7],
         [9, 10],
         [14, 14],


### PR DESCRIPTION
Problem
=======
Closes #516 ("add track list view") and closes #534, "Annotation - Add range visual in list view".

This change adds an interactive thumbnail that shows what parts of a track are currently selected.

*Estimated review size: medium, 30-40 minutes*

Solution
========
- Adds a new `getIntervals` method in `data_utils`, which returns continuous ranges of integers in a list.
  - Also added related unit tests
- Added a `getMissingTimes` method in `Track` to return time gaps in the track.
- Added a new `AnnotationTrackThumbnail.tsx` component, which renders what sections of a track are selected using two canvas elements.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the PR preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview-internal/pr-542/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&tab=annotation
2. Start editing annotations. A thumbnail should appear next to each track number and in the track popout.

Screenshots (optional):
-----------------------

**PR talk-through (🔊):**

https://github.com/user-attachments/assets/425ec8b1-b6c3-4d18-ae64-036c7c7449da



![image](https://github.com/user-attachments/assets/cd588df8-dee9-4526-a2f5-3d06ec4b1e10)

