### PR TITLE
fix: Fixed flickering issue by memoizing dropdown items

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -51,6 +51,7 @@ import {
   useRecentCollections,
 } from "./colorizer/utils/react_utils";
 import * as urlUtils from "./colorizer/utils/url_utils";
+import { SelectItem } from "./components/Dropdowns/types";
 import { SCATTERPLOT_TIME_FEATURE } from "./components/Tabs/scatter_plot_data_utils";
 import { DEFAULT_PLAYBACK_FPS, INTERNAL_BUILD } from "./constants";
 import { FlexRow, FlexRowAlignCenter } from "./styles/utils";
@@ -887,7 +888,8 @@ function Viewer(): ReactElement {
     });
   };
 
-  const getFeatureDropdownData = useCallback((): { value: string; label: string }[] => {
+  const datasetDropdownData = useMemo(() => collection?.getDatasetKeys() || [], [collection]);
+  const featureDropdownData = useMemo((): SelectItem[] => {
     if (!dataset) {
       return [];
     }
@@ -1079,7 +1081,7 @@ function Viewer(): ReactElement {
             label="Dataset"
             selected={datasetKey}
             buttonType="primary"
-            items={collection?.getDatasetKeys() || []}
+            items={datasetDropdownData}
             onChange={handleDatasetChange}
           />
           <FlexRow $gap={6}>
@@ -1101,7 +1103,7 @@ function Viewer(): ReactElement {
               //   dataset?.getFeatureNameWithUnits(featureKey)
               // )
               selected={featureKey}
-              items={getFeatureDropdownData()}
+              items={featureDropdownData}
               onChange={(value) => {
                 if (value !== featureKey && dataset) {
                   replaceFeature(dataset, value);

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -333,7 +333,9 @@ export const useAnnotations = (): AnnotationState => {
   const [isAnnotationEnabled, _setIsAnnotationEnabled] = useState<boolean>(false);  
   const [selectionMode, setSelectionMode] = useState<AnnotationSelectionMode>(AnnotationSelectionMode.TIME);
   const [visible, _setVisibility] = useState<boolean>(false);
-
+  /** Increments every time a state update is required. */
+  const [dataUpdateCounter, setDataUpdateCounter] = useState(0);
+  
   // Annotation mode can only be enabled if there is at least one label, so create
   // one if necessary.
   const setIsAnnotationEnabled = (enabled: boolean): void => {
@@ -342,6 +344,7 @@ export const useAnnotations = (): AnnotationState => {
       if (annotationData.getLabels().length === 0) {
         const newLabelIdx = annotationData.createNewLabel();
         setCurrentLabelIdx(newLabelIdx);
+        setDataUpdateCounter((value) => value + 1);
       }
     }
     _setIsAnnotationEnabled(enabled);
@@ -353,8 +356,6 @@ export const useAnnotations = (): AnnotationState => {
       setIsAnnotationEnabled(false);
     }
   };
-  /** Increments every time a state update is required. */
-  const [dataUpdateCounter, setDataUpdateCounter] = useState(0);
 
   const wrapFunctionInUpdate = <F extends (...args: any[]) => void>(fn: F): F => {
     return <F>function (...args: any[]) {

--- a/src/components/Dropdowns/SelectionDropdown.tsx
+++ b/src/components/Dropdowns/SelectionDropdown.tsx
@@ -96,11 +96,14 @@ function formatAsSelectItems(items: string[] | SelectItem[]): SelectItem[] {
  * Options can be searched by typing in the dropdown input.
  *
  * Uses react-select internally but mimics the style of Ant Design for consistency.
+ *
+ * NOTE: Items must be memoized or else flickering may occur when the page is rapidly
+ * re-rendered (e.g. during playback).
  */
 export default function SelectionDropdown(inputProps: SelectionDropdownProps): ReactElement {
   const props = { ...defaultProps, ...inputProps };
 
-  const options = formatAsSelectItems(props.items);
+  const options = useMemo(() => formatAsSelectItems(props.items), [props.items]);
 
   // TODO: Show loading spinner?
   const [_isPending, startTransition] = useTransition();

--- a/src/components/PlaybackSpeedControl.tsx
+++ b/src/components/PlaybackSpeedControl.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useMemo } from "react";
 
 import { DEFAULT_PLAYBACK_FPS } from "../constants";
 
@@ -13,6 +13,7 @@ type PlaybackSpeedControlProps = {
   max?: number;
   step?: number;
 };
+
 const defaultProps: Partial<PlaybackSpeedControlProps> = {
   baselineFps: DEFAULT_PLAYBACK_FPS,
   disabled: false,
@@ -30,10 +31,13 @@ export default function PlaybackSpeedControl(inputProps: PlaybackSpeedControlPro
   };
 
   // Generate values for the dropdown
-  const dropdownItems = [];
-  for (let i = props.min; i < props.max; i += props.step) {
-    dropdownItems.push({ value: i.toFixed(2), label: i.toFixed(2) + "x" });
-  }
+  const dropdownItems = useMemo(() => {
+    const dropdownItems = [];
+    for (let i = props.min; i < props.max; i += props.step) {
+      dropdownItems.push({ value: i.toFixed(2), label: i.toFixed(2) + "x" });
+    }
+    return dropdownItems;
+  }, [props.min, props.max, props.step]);
 
   // Convert from raw fps to slider values
   const sliderValue = props.fps / props.baselineFps;

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -88,13 +88,15 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
   );
 
   // Options for the selection dropdown
-  const selectLabelOptions: SelectItem[] = labels.map((label, index) => {
-    return {
-      value: index.toString(),
-      label: label.ids.size ? `${label.name} (${label.ids.size})` : label.name,
-      color: label.color,
-    };
-  });
+  const selectLabelOptions: SelectItem[] = useMemo(() => {
+    return labels.map((label, index) => {
+      return {
+        value: index.toString(),
+        label: label.ids.size ? `${label.name} (${label.ids.size})` : label.name,
+        color: label.color,
+      };
+    });
+  }, [annotationData]);
 
   const tableIds = useMemo(() => {
     return currentLabelIdx !== null ? annotationData.getLabeledIds(currentLabelIdx) : [];

--- a/src/components/Tabs/ScatterPlotTab.tsx
+++ b/src/components/Tabs/ScatterPlotTab.tsx
@@ -48,6 +48,8 @@ const PLOTLY_CLICK_TIMEOUT_MS = 10;
 
 const DEFAULT_RANGE_TYPE = PlotRangeType.ALL_TIME;
 
+const PLOT_RANGE_SELECT_ITEMS = Object.values(PlotRangeType);
+
 type ScatterPlotTabProps = {
   dataset: Dataset | null;
   currentFrame: number;
@@ -843,13 +845,16 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
   // Component Rendering
   //////////////////////////////////
 
-  const makeControlBar = (): ReactElement => {
+  const menuItems = useMemo((): SelectItem[] => {
     const featureKeys = dataset ? dataset.featureKeys : [];
     const menuItems: SelectItem[] = featureKeys.map((key: string) => {
       return { value: key, label: dataset?.getFeatureNameWithUnits(key) ?? key };
     });
     menuItems.push(SCATTERPLOT_TIME_FEATURE);
+    return menuItems;
+  }, [dataset]);
 
+  const makeControlBar = (menuItems: SelectItem[]): ReactElement => {
     return (
       <FlexRowAlignCenter $gap={6} style={{ flexWrap: "wrap" }}>
         <SelectionDropdown
@@ -882,7 +887,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
           <SelectionDropdown
             label={"Show objects from"}
             selected={rangeType}
-            items={Object.values(PlotRangeType)}
+            items={PLOT_RANGE_SELECT_ITEMS}
             width={"120px"}
             onChange={(value: string) => props.updateScatterPlotConfig({ rangeType: value as PlotRangeType })}
           ></SelectionDropdown>
@@ -919,7 +924,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
 
   return (
     <>
-      {makeControlBar()}
+      {makeControlBar(menuItems)}
       <div style={{ position: "relative" }}>
         <LoadingSpinner loading={isPending || isRendering || isDebouncePending} style={{ marginTop: "10px" }}>
           {makePlotButtons()}

--- a/src/components/Tabs/Settings/VectorFieldSettings.tsx
+++ b/src/components/Tabs/Settings/VectorFieldSettings.tsx
@@ -1,6 +1,6 @@
 import { Color as AntdColor } from "@rc-component/color-picker";
 import { Card, Checkbox, ColorPicker, Radio } from "antd";
-import React, { ReactElement } from "react";
+import React, { ReactElement, useMemo } from "react";
 import { Color, ColorRepresentation } from "three";
 
 import { VECTOR_KEY_MOTION_DELTA } from "../../../colorizer/constants";
@@ -28,7 +28,7 @@ export default function VectorFieldSettings(props: VectorFieldSettingsProps): Re
   };
 
   // TODO: Add additional vectors here when support for user vector data is added.
-  const vectorOptions = [VECTOR_OPTION_MOTION];
+  const vectorOptions = useMemo(() => [VECTOR_OPTION_MOTION], []);
 
   return (
     <>

--- a/src/components/Tabs/SettingsTab.tsx
+++ b/src/components/Tabs/SettingsTab.tsx
@@ -1,6 +1,6 @@
 import { Color as AntdColor } from "@rc-component/color-picker";
 import { Checkbox, ColorPicker } from "antd";
-import React, { ReactElement } from "react";
+import React, { ReactElement, useMemo } from "react";
 import { Color, ColorRepresentation } from "three";
 
 import { Dataset } from "../../colorizer";
@@ -36,11 +36,15 @@ type SettingsTabProps = {
 };
 
 export default function SettingsTab(props: SettingsTabProps): ReactElement {
-  const backdropOptions = props.dataset
-    ? Array.from(props.dataset.getBackdropData().entries()).map(([key, data]) => {
-        return { value: key, label: data.name };
-      })
-    : [];
+  const backdropOptions = useMemo(
+    () =>
+      props.dataset
+        ? Array.from(props.dataset.getBackdropData().entries()).map(([key, data]) => {
+            return { value: key, label: data.name };
+          })
+        : [],
+    [props.dataset]
+  );
 
   const isBackdropDisabled = backdropOptions.length === 0 || props.selectedBackdropKey === null;
   const isBackdropOptionsDisabled = isBackdropDisabled || !props.config.backdropVisible;


### PR DESCRIPTION
Problem
=======
Closes #540, "dropdown hover flickers during playback."

*Estimated review size: small, 5-10 minutes*

Solution
========
- Fixed a bug where the AnnotationData prop wouldn't update when annotation is enabled and a new label is created.
- Changed all dropdown items to be memoized to prevent a flickering bug caused by excessive re-rendering.

## Type of change

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing

Screenshots (optional):
-----------------------
Show-n-tell images/animations here
