### PR TITLE
feature: Select time ranges in annotation (select range pt. 1)

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -22,7 +22,6 @@ import React, {
 import { Link, Location, useLocation, useSearchParams } from "react-router-dom";
 
 import {
-  AnnotationSelectionMode,
   Dataset,
   DEFAULT_CATEGORICAL_PALETTE_KEY,
   DEFAULT_COLOR_RAMP_KEY,
@@ -843,11 +842,10 @@ function Viewer(): ReactElement {
     (track: Track | null) => {
       setFindTrackInput(track?.trackId.toString() || "");
       setSelectedTrack(track);
-      if (track && annotationState.isAnnotationModeEnabled && annotationState.currentLabelIdx !== null) {
+      if (dataset && track) {
         const id = track.getIdAtTime(currentFrame);
-        const isLabeled = annotationState.data.isLabelOnId(annotationState.currentLabelIdx, id);
-        const ids = annotationState.selectionMode === AnnotationSelectionMode.TIME ? [id] : track.ids;
-        annotationState.setLabelOnIds(annotationState.currentLabelIdx, ids, !isLabeled);
+        // TODO: Check for shift key held
+        annotationState.handleAnnotationClick(dataset, id, false);
       }
     },
     [

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -366,7 +366,7 @@ function Viewer(): ReactElement {
         return;
       }
 
-      const newTrack = dataset!.buildTrack(trackId);
+      const newTrack = dataset!.getTrack(trackId);
 
       if (newTrack.ids.length < 1) {
         // Check track validity

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -42,7 +42,6 @@ import {
 } from "./colorizer";
 import { AnalyticsEvent, triggerAnalyticsEvent } from "./colorizer/utils/analytics";
 import { getColorMap, getInRangeLUT, thresholdMatchFinder, validateThresholds } from "./colorizer/utils/data_utils";
-import { useShortcutKey } from "./colorizer/utils/hooks";
 import {
   useAnnotations,
   useConstructor,
@@ -227,7 +226,6 @@ function Viewer(): ReactElement {
   const [findTrackInput, setFindTrackInput] = useState("");
   const [lastValidHoveredId, setLastValidHoveredId] = useState<number>(-1);
   const [showObjectHoverInfo, setShowObjectHoverInfo] = useState(false);
-  const isShiftPressed = useShortcutKey("Shift");
 
   // EVENT LISTENERS ////////////////////////////////////////////////////////
 
@@ -847,10 +845,10 @@ function Viewer(): ReactElement {
       if (dataset && track) {
         const id = track.getIdAtTime(currentFrame);
         // TODO: Check for shift key held
-        annotationState.handleAnnotationClick(dataset, id, isShiftPressed);
+        annotationState.handleAnnotationClick(dataset, id);
       }
     },
-    [annotationState.handleAnnotationClick, isShiftPressed, currentFrame]
+    [dataset, currentFrame, annotationState.handleAnnotationClick]
   );
 
   // RECORDING CONTROLS ////////////////////////////////////////////////////

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -844,7 +844,6 @@ function Viewer(): ReactElement {
       setSelectedTrack(track);
       if (dataset && track) {
         const id = track.getIdAtTime(currentFrame);
-        // TODO: Check for shift key held
         annotationState.handleAnnotationClick(dataset, id);
       }
     },

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -42,6 +42,7 @@ import {
 } from "./colorizer";
 import { AnalyticsEvent, triggerAnalyticsEvent } from "./colorizer/utils/analytics";
 import { getColorMap, getInRangeLUT, thresholdMatchFinder, validateThresholds } from "./colorizer/utils/data_utils";
+import { useShortcutKey } from "./colorizer/utils/hooks";
 import {
   useAnnotations,
   useConstructor,
@@ -226,6 +227,7 @@ function Viewer(): ReactElement {
   const [findTrackInput, setFindTrackInput] = useState("");
   const [lastValidHoveredId, setLastValidHoveredId] = useState<number>(-1);
   const [showObjectHoverInfo, setShowObjectHoverInfo] = useState(false);
+  const isShiftPressed = useShortcutKey("Shift");
 
   // EVENT LISTENERS ////////////////////////////////////////////////////////
 
@@ -845,15 +847,10 @@ function Viewer(): ReactElement {
       if (dataset && track) {
         const id = track.getIdAtTime(currentFrame);
         // TODO: Check for shift key held
-        annotationState.handleAnnotationClick(dataset, id, false);
+        annotationState.handleAnnotationClick(dataset, id, isShiftPressed);
       }
     },
-    [
-      annotationState.isAnnotationModeEnabled,
-      annotationState.selectionMode,
-      annotationState.currentLabelIdx,
-      currentFrame,
-    ]
+    [annotationState.handleAnnotationClick, isShiftPressed, currentFrame]
   );
 
   // RECORDING CONTROLS ////////////////////////////////////////////////////

--- a/src/colorizer/AnnotationData.ts
+++ b/src/colorizer/AnnotationData.ts
@@ -124,6 +124,7 @@ export interface IAnnotationDataSetters {
   deleteLabel(labelIdx: number): void;
 
   setLabelOnIds(labelIdx: number, ids: number[], value: boolean): void;
+  clear(): void;
 }
 
 export type IAnnotationData = IAnnotationDataGetters & IAnnotationDataSetters;
@@ -313,5 +314,11 @@ export class AnnotationData implements IAnnotationData {
     // prefixed with `#`.
 
     return csvString;
+  }
+
+  clear(): void {
+    this.labelData = [];
+    this.numLabelsCreated = 0;
+    this.timeToLabelIdMap = null;
   }
 }

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -519,6 +519,7 @@ export default class Dataset {
     if (this.cleanupArrayLoaderOnDispose) {
       this.arrayLoader.dispose();
     }
+    this.cachedTracks.clear();
   }
 
   /** get frame index of a given cell id */
@@ -551,7 +552,7 @@ export default class Dataset {
     }, []) as number[];
   }
 
-  public buildTrack(trackId: number): Track {
+  public getTrack(trackId: number): Track {
     const cachedTrack = this.cachedTracks.get(trackId);
     if (cachedTrack) {
       return cachedTrack;

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -203,6 +203,7 @@ export type ScatterPlotConfig = {
 
 export enum AnnotationSelectionMode {
   TIME,
+  RANGE,
   TRACK,
 }
 

--- a/src/colorizer/utils/hooks/index.ts
+++ b/src/colorizer/utils/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useShortcutKey } from "./useShortcutKey";

--- a/src/colorizer/utils/hooks/useShortcutKey.ts
+++ b/src/colorizer/utils/hooks/useShortcutKey.ts
@@ -1,0 +1,28 @@
+// TODO: Replace with a shortcut key library like https://www.npmjs.com/package/hotkeys-js
+import { useEffect, useState } from "react";
+
+export function useShortcutKey(key: string): boolean {
+  const [isPressed, setIsPressed] = useState(false);
+
+  useEffect(() => {
+    const onKeyDown = ({ key: pressedKey }: KeyboardEvent): void => {
+      if (pressedKey === key) {
+        setIsPressed(true);
+      }
+    };
+    const onKeyUp = ({ key: pressedKey }: KeyboardEvent): void => {
+      if (pressedKey === key) {
+        setIsPressed(false);
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    return (): void => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
+  return isPressed;
+}

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -475,14 +475,15 @@ export const useAnnotations = (): AnnotationState => {
         if (idRange !== null) {
           setLastEditedRange(idRange);
           annotationData.setLabelOnIds(currentLabelIdx, idRange, !isLabeled);
+          setLastClickedId(null);
           break;
         }
-        // If no range is selected, select at a single time.
+        // If no range is selected, continue to default to select at a single time.
       case AnnotationSelectionMode.TIME:
       default:
         annotationData.setLabelOnIds(currentLabelIdx, [id], !isLabeled);
+        setLastClickedId(id);
     }
-    setLastClickedId(id);
     setDataUpdateCounter((value) => value + 1);
   };
 

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -426,7 +426,7 @@ export const useAnnotations = (): AnnotationState => {
     if (dataset.getTrackId(id1) !== dataset.getTrackId(id2)) {
       throw new Error(`useAnnotations:getIdsInRange: IDs ${id1} and ${id2} are not in the same track.`);
     }
-    const track = dataset.buildTrack(dataset.getTrackId(id1));
+    const track = dataset.getTrack(dataset.getTrackId(id1));
     const idx0 = track.ids.indexOf(id1);
     const idx1 = track.ids.indexOf(id2);
     const startIdx = Math.min(idx0, idx1);
@@ -464,7 +464,7 @@ export const useAnnotations = (): AnnotationState => {
       setLastClickedId(id);
       return;
     }
-    const track = dataset.buildTrack(dataset.getTrackId(id));
+    const track = dataset.getTrack(dataset.getTrackId(id));
     const isLabeled = annotationData.isLabelOnId(currentLabelIdx, id);
 
     const idRange = getSelectRangeFromId(dataset, id);

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -1,4 +1,4 @@
-import React, { EventHandler, useEffect, useMemo, useRef, useState } from "react";
+import React, { EventHandler, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import styled from "styled-components";
 import { useLocalStorage } from "usehooks-ts";
 
@@ -434,7 +434,7 @@ export const useAnnotations = (): AnnotationState => {
 
   // Return a list of IDs that would be selected if the ID was clicked with
   // range selection mode turned on.
-  const getSelectRangeFromId = (dataset: Dataset, id: number): number[] | null => {
+  const getSelectRangeFromId = useCallback((dataset: Dataset, id: number): number[] | null => {
     // If this ID is one of the endpoints of the last range clicked,
     // return the same range.
     if (lastEditedRange !== null) {
@@ -455,9 +455,9 @@ export const useAnnotations = (): AnnotationState => {
     }
     // IDs are not in the same track.
     return null;
-  };
+  }, [lastEditedRange, lastClickedId]);
 
-  const handleAnnotationClick = (dataset: Dataset, id: number): void => {
+  const handleAnnotationClick = useCallback((dataset: Dataset, id: number): void => {
     if (!isAnnotationEnabled || currentLabelIdx === null) {
       setLastClickedId(id);
       return;
@@ -485,7 +485,7 @@ export const useAnnotations = (): AnnotationState => {
         setLastClickedId(id);
     }
     setDataUpdateCounter((value) => value + 1);
-  };
+  }, [selectionMode, currentLabelIdx, getSelectRangeFromId]);
 
   const clear = (): void => {
     annotationData.clear();

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -3,11 +3,11 @@ import styled from "styled-components";
 import { useLocalStorage } from "usehooks-ts";
 
 import { AnnotationSelectionMode, VectorConfig } from "../types";
+import { useShortcutKey } from "./hooks";
 
 import { AnnotationData, IAnnotationDataGetters, IAnnotationDataSetters } from "../AnnotationData";
 import Dataset from "../Dataset";
 import SharedWorkerPool from "../workers/SharedWorkerPool";
-import { useShortcutKey } from "./hooks";
 
 // TODO: Move this to a folder outside of `colorizer`.
 // TODO: Split this up into multiple files.
@@ -309,7 +309,7 @@ export const useMotionDeltas = (
   return motionDeltas;
 };
 
-export type AnnotationState =  {
+export type AnnotationState = {
   // Viewer state that lives outside the annotation data itself
   currentLabelIdx: number | null;
   setCurrentLabelIdx: (labelIdx: number) => void;
@@ -328,14 +328,13 @@ export type AnnotationState =  {
    * changes.
    */
   data: IAnnotationDataGetters;
-} & IAnnotationDataSetters & {
-};
+} & IAnnotationDataSetters & {};
 
 export const useAnnotations = (): AnnotationState => {
   const annotationData = useConstructor(() => new AnnotationData());
 
   const [currentLabelIdx, setCurrentLabelIdx] = useState<number | null>(null);
-  const [isAnnotationEnabled, _setIsAnnotationEnabled] = useState<boolean>(false);  
+  const [isAnnotationEnabled, _setIsAnnotationEnabled] = useState<boolean>(false);
   const [selectionMode, setSelectionMode] = useState<AnnotationSelectionMode>(AnnotationSelectionMode.TIME);
   const [visible, _setVisibility] = useState<boolean>(false);
   const isRangeSelectHotkeyPressed = useShortcutKey("Shift");
@@ -391,13 +390,12 @@ export const useAnnotations = (): AnnotationState => {
     return annotationData.deleteLabel(labelIdx);
   };
 
-  
   const getSelectRangeFromId = (dataset: Dataset, id: number): number[] | null => {
     const firstIdInRange = lastEditedRange ? lastEditedRange[0] : -1;
     const lastIdInRange = lastEditedRange ? lastEditedRange[lastEditedRange.length - 1] : -1;
 
     if (lastEditedRange !== null && (id === firstIdInRange || id === lastIdInRange)) {
-      // If this ID is one of the endpoints of the last range clicked, 
+      // If this ID is one of the endpoints of the last range clicked,
       // return the same range.
       return lastEditedRange;
     } else if (dataset && lastClickedId !== null) {
@@ -410,7 +408,7 @@ export const useAnnotations = (): AnnotationState => {
       }
     }
     return null;
-  }  
+  };
 
   const getIdsInRange = (dataset: Dataset, id1: number, id2: number): number[] => {
     const track = dataset.buildTrack(dataset.getTrackId(id1));
@@ -419,7 +417,7 @@ export const useAnnotations = (): AnnotationState => {
     const startIdx = Math.min(idx0, idx1);
     const endIdx = Math.max(idx0, idx1);
     return track.ids.slice(startIdx, endIdx + 1);
-  }
+  };
 
   const handleAnnotationClick = (dataset: Dataset, id: number): void => {
     if (!isAnnotationEnabled || currentLabelIdx === null) {
@@ -445,7 +443,7 @@ export const useAnnotations = (): AnnotationState => {
     }
     setLastClickedId(id);
     setDataUpdateCounter((value) => value + 1);
-  }
+  };
 
   const clear = (): void => {
     annotationData.clear();
@@ -453,18 +451,20 @@ export const useAnnotations = (): AnnotationState => {
     setLastEditedRange(null);
     setLastClickedId(null);
     setIsAnnotationEnabled(false);
-  }
+  };
 
-  const data = useMemo((): IAnnotationDataGetters => ({
+  const data = useMemo(
+    (): IAnnotationDataGetters => ({
       // Data getters
       getLabels: annotationData.getLabels,
       getLabelsAppliedToId: annotationData.getLabelsAppliedToId,
       getLabeledIds: annotationData.getLabeledIds,
       getTimeToLabelIdMap: annotationData.getTimeToLabelIdMap,
       isLabelOnId: annotationData.isLabelOnId,
-      toCsv: annotationData.toCsv
-    })
-  , [dataUpdateCounter]);
+      toCsv: annotationData.toCsv,
+    }),
+    [dataUpdateCounter]
+  );
 
   return {
     // UI state

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -319,8 +319,6 @@ export type AnnotationState = {
   setVisibility: (visible: boolean) => void;
   selectionMode: AnnotationSelectionMode;
   setSelectionMode: (mode: AnnotationSelectionMode) => void;
-  /** Whether the range selection hotkey is currently pressed. (Shift by default.) */
-  isSelectRangeHotkeyPressed: boolean;
   /**
    * For a given ID, returns the range of IDs that would be selected if the ID
    * is clicked with range selection mode turned on.
@@ -345,12 +343,33 @@ export const useAnnotations = (): AnnotationState => {
 
   const [currentLabelIdx, setCurrentLabelIdx] = useState<number | null>(null);
   const [isAnnotationEnabled, _setIsAnnotationEnabled] = useState<boolean>(false);
-  const [selectionMode, setSelectionMode] = useState<AnnotationSelectionMode>(AnnotationSelectionMode.TIME);
   const [visible, _setVisibility] = useState<boolean>(false);
+  
+  const [baseSelectionMode, setBaseSelectionMode] = useState<AnnotationSelectionMode>(AnnotationSelectionMode.TIME);
+  
   const isSelectRangeHotkeyPressed = useShortcutKey("Shift");
-
   const [lastClickedId, setLastClickedId] = useState<number | null>(null);
   const [lastEditedRange, setLastEditedRange] = useState<number[] | null>(null);
+  
+  // When in time mode, allow hotkeys to temporarily change to range mode.
+  let selectionMode = baseSelectionMode;
+  if (baseSelectionMode === AnnotationSelectionMode.TIME && isSelectRangeHotkeyPressed) {
+    selectionMode = AnnotationSelectionMode.RANGE;
+  }
+  
+  const setSelectionMode = (newMode: AnnotationSelectionMode): void => {
+    if (newMode === baseSelectionMode) {
+      return;
+    }
+    if (newMode === AnnotationSelectionMode.RANGE) {
+      // Clear the range-related data when switching, since otherwise
+      // it can be confusing to have a previously interacted-with object
+      // become part of a selected range.
+      setLastClickedId(null);
+      setLastEditedRange(null);
+    }
+    setBaseSelectionMode(newMode);
+  }
 
   // Annotation mode can only be enabled if there is at least one label, so create
   // one if necessary.
@@ -446,18 +465,22 @@ export const useAnnotations = (): AnnotationState => {
     const track = dataset.buildTrack(dataset.getTrackId(id));
     const isLabeled = annotationData.isLabelOnId(currentLabelIdx, id);
 
-    if (selectionMode === AnnotationSelectionMode.TRACK) {
-      // Toggle entire track
-      annotationData.setLabelOnIds(currentLabelIdx, track.ids, !isLabeled);
-    } else {
-      // Time-based selection
-      const idRange = getSelectRangeFromId(dataset, id);
-      if (isSelectRangeHotkeyPressed && idRange !== null) {
-        setLastEditedRange(idRange);
-        annotationData.setLabelOnIds(currentLabelIdx, idRange, !isLabeled);
-      } else {
+    switch (selectionMode) {
+      case AnnotationSelectionMode.TRACK:
+        // Toggle entire track
+        annotationData.setLabelOnIds(currentLabelIdx, track.ids, !isLabeled);
+        break;
+      case AnnotationSelectionMode.RANGE:
+        const idRange = getSelectRangeFromId(dataset, id);
+        if (idRange !== null) {
+          setLastEditedRange(idRange);
+          annotationData.setLabelOnIds(currentLabelIdx, idRange, !isLabeled);
+          break;
+        }
+        // If no range is selected, select at a single time.
+      case AnnotationSelectionMode.TIME:
+      default:
         annotationData.setLabelOnIds(currentLabelIdx, [id], !isLabeled);
-      }
     }
     setLastClickedId(id);
     setDataUpdateCounter((value) => value + 1);
@@ -496,7 +519,6 @@ export const useAnnotations = (): AnnotationState => {
     setSelectionMode,
     data,
     handleAnnotationClick,
-    isSelectRangeHotkeyPressed,
     getSelectRangeFromId,
     // Wrap state mutators
     createNewLabel: wrapFunctionInUpdate(annotationData.createNewLabel),

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -369,7 +369,7 @@ export const useAnnotations = (): AnnotationState => {
       setLastEditedRange(null);
     }
     setBaseSelectionMode(newMode);
-  }
+  };
 
   // Annotation mode can only be enabled if there is at least one label, so create
   // one if necessary.
@@ -465,20 +465,21 @@ export const useAnnotations = (): AnnotationState => {
     const track = dataset.buildTrack(dataset.getTrackId(id));
     const isLabeled = annotationData.isLabelOnId(currentLabelIdx, id);
 
+    const idRange = getSelectRangeFromId(dataset, id);
     switch (selectionMode) {
       case AnnotationSelectionMode.TRACK:
         // Toggle entire track
         annotationData.setLabelOnIds(currentLabelIdx, track.ids, !isLabeled);
         break;
       case AnnotationSelectionMode.RANGE:
-        const idRange = getSelectRangeFromId(dataset, id);
         if (idRange !== null) {
           setLastEditedRange(idRange);
           annotationData.setLabelOnIds(currentLabelIdx, idRange, !isLabeled);
           setLastClickedId(null);
-          break;
+        } else {
+          setLastClickedId(id);
         }
-        // If no range is selected, continue to default to select at a single time.
+        break;
       case AnnotationSelectionMode.TIME:
       default:
         annotationData.setLabelOnIds(currentLabelIdx, [id], !isLabeled);

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -409,7 +409,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
         props.onTrackClicked(null);
       } else {
         const trackId = props.dataset.getTrackId(id);
-        const newTrack = props.dataset.buildTrack(trackId);
+        const newTrack = props.dataset.getTrack(trackId);
         props.onTrackClicked(newTrack);
       }
     },

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -543,10 +543,10 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       if (isMouseDragging.current) {
         canv.domElement.style.cursor = "move";
       } else if (props.annotationState.isAnnotationModeEnabled) {
-        if (props.annotationState.selectionMode === AnnotationSelectionMode.TIME) {
-          canv.domElement.style.cursor = "crosshair";
-        } else {
+        if (props.annotationState.selectionMode === AnnotationSelectionMode.TRACK) {
           canv.domElement.style.cursor = "cell";
+        } else {
+          canv.domElement.style.cursor = "crosshair";
         }
       } else {
         canv.domElement.style.cursor = "auto";

--- a/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
+++ b/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext, useEffect, useMemo, useRef } from "react";
+import React, { ReactElement, useContext, useMemo } from "react";
 import styled from "styled-components";
 import { Color } from "three";
 
@@ -36,26 +36,9 @@ const ListLayoutContainer = styled.div`
 export default function AnnotationDisplayList(props: AnnotationDisplayListProps): ReactElement {
   const theme = useContext(AppThemeContext);
 
-  const cachedTracks = useRef<Map<string, Track | undefined>>(new Map());
   const selectedTrackId = props.selectedTrack?.trackId.toString();
 
   const { scrollShadowStyle, onScrollHandler, scrollRef } = useScrollShadow();
-
-  useEffect(() => {
-    cachedTracks.current.clear();
-  }, [props.dataset]);
-
-  // Building a track is an expensive operation (takes O(N) where N is the
-  // size of the dataset), so cache the tracks.
-  // TODO: This could be optimized by having the dataset perform this once
-  // and save the results in a lookup table.
-  const getTrack = (trackId: number): Track | undefined => {
-    if (!cachedTracks.current.has(trackId.toString())) {
-      const track = props.dataset?.buildTrack(trackId);
-      cachedTracks.current.set(trackId.toString(), track);
-    }
-    return cachedTracks.current.get(trackId.toString());
-  };
 
   // Organize ids by track
   const trackToIds: Map<string, number[]> = useMemo(() => {
@@ -100,7 +83,7 @@ export default function AnnotationDisplayList(props: AnnotationDisplayListProps)
     listContents = (
       <ul style={{ marginTop: 0 }}>
         {trackIds.map((trackId) => {
-          const track = getTrack(trackId);
+          const track = props.dataset?.buildTrack(trackId);
           const ids = trackToIds.get(trackId.toString())!;
           const isSelectedTrack = props.selectedTrack?.trackId === trackId;
           return (
@@ -124,7 +107,7 @@ export default function AnnotationDisplayList(props: AnnotationDisplayListProps)
                   <p style={{ margin: 0 }}>
                     {trackId}{" "}
                     <span style={{ color: theme.color.text.hint }}>
-                      ({ids.length}/{track?.times.length})
+                      ({ids.length}/{track?.times.length ?? 0})
                     </span>
                   </p>
                 </FlexRowAlignCenter>

--- a/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
+++ b/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
@@ -83,7 +83,7 @@ export default function AnnotationDisplayList(props: AnnotationDisplayListProps)
     listContents = (
       <ul style={{ marginTop: 0 }}>
         {trackIds.map((trackId) => {
-          const track = props.dataset?.buildTrack(trackId);
+          const track = props.dataset?.getTrack(trackId);
           const ids = trackToIds.get(trackId.toString())!;
           const isSelectedTrack = props.selectedTrack?.trackId === trackId;
           return (

--- a/src/components/Tabs/Annotation/LabelEditControls.tsx
+++ b/src/components/Tabs/Annotation/LabelEditControls.tsx
@@ -172,6 +172,14 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
           <Tooltip trigger={["hover", "focus"]} title="Apply only at the current time" placement="top">
             <Radio.Button value={AnnotationSelectionMode.TIME}>Time</Radio.Button>
           </Tooltip>
+          <Tooltip
+            trigger={["hover", "focus"]}
+            title="Select range between two timepoints in a track"
+            autoAdjustOverflow={false}
+            placement="top"
+          >
+            <Radio.Button value={AnnotationSelectionMode.RANGE}>Range</Radio.Button>
+          </Tooltip>
           <Tooltip trigger={["hover", "focus"]} title="Apply to entire track" placement="top">
             <Radio.Button value={AnnotationSelectionMode.TRACK}>Track</Radio.Button>
           </Tooltip>

--- a/src/components/Tooltips/CanvasHoverTooltip.tsx
+++ b/src/components/Tooltips/CanvasHoverTooltip.tsx
@@ -35,6 +35,7 @@ const ObjectInfoCard = styled.div`
   overflow-wrap: break-word;
 
   transition: opacity 300ms ease-in-out;
+  width: fit-content;
 `;
 
 /**
@@ -165,6 +166,23 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
           </Tag>
         </FlexRow>
       );
+    } else if (props.annotationState.isRangeSelectHotkeyPressed && dataset) {
+      const hoveredRange = props.annotationState.getSelectRangeFromId(dataset, lastHoveredId);
+      if (hoveredRange !== null && hoveredRange.length > 1) {
+        // Get min and max track IDs
+        const id0 = hoveredRange[0];
+        const id1 = hoveredRange[hoveredRange.length - 1];
+        const t0 = dataset.getTime(id0);
+        const t1 = dataset.getTime(id1);
+        annotationLabel = (
+          <FlexRow>
+            {annotationLabel}
+            <Tag bordered={true} color="gold" style={{ width: "fit-content" }}>
+              ✦ Applying to {hoveredRange.length} objects from time {t0} to {t1}
+            </Tag>
+          </FlexRow>
+        );
+      }
     }
   }
 

--- a/src/components/Tooltips/CanvasHoverTooltip.tsx
+++ b/src/components/Tooltips/CanvasHoverTooltip.tsx
@@ -166,7 +166,7 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
           </Tag>
         </FlexRow>
       );
-    } else if (props.annotationState.isSelectRangeHotkeyPressed && dataset) {
+    } else if (props.annotationState.selectionMode === AnnotationSelectionMode.RANGE && dataset) {
       const hoveredRange = props.annotationState.getSelectRangeFromId(dataset, lastHoveredId);
       if (hoveredRange !== null && hoveredRange.length > 1) {
         // Get min and max track IDs

--- a/src/components/Tooltips/CanvasHoverTooltip.tsx
+++ b/src/components/Tooltips/CanvasHoverTooltip.tsx
@@ -157,12 +157,14 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
       </Tag>
     );
 
+    const isHoveredIdLabeled = props.annotationState.data.isLabelOnId(currentLabelIdx, lastHoveredId);
     if (props.annotationState.selectionMode === AnnotationSelectionMode.TRACK) {
+      const verb = isHoveredIdLabeled ? "unlabel" : "label";
       annotationLabel = (
         <FlexRow>
           {annotationLabel}
           <Tag bordered={true} color="gold" style={{ width: "fit-content" }}>
-            ✦ Applying to track
+            ✦ Click to {verb} entire track
           </Tag>
         </FlexRow>
       );
@@ -174,11 +176,12 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
         const id1 = hoveredRange[hoveredRange.length - 1];
         const t0 = dataset.getTime(id0);
         const t1 = dataset.getTime(id1);
+        const verb = isHoveredIdLabeled ? "unlabel" : "label";
         annotationLabel = (
           <FlexRow>
             {annotationLabel}
             <Tag bordered={true} color="gold" style={{ width: "fit-content" }}>
-              ✦ Applying to {hoveredRange.length} objects from time {t0} to {t1}
+              ✦ Click to {verb} {hoveredRange.length} objects from time {t0} to {t1}
             </Tag>
           </FlexRow>
         );

--- a/src/components/Tooltips/CanvasHoverTooltip.tsx
+++ b/src/components/Tooltips/CanvasHoverTooltip.tsx
@@ -166,7 +166,7 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
           </Tag>
         </FlexRow>
       );
-    } else if (props.annotationState.isRangeSelectHotkeyPressed && dataset) {
+    } else if (props.annotationState.isSelectRangeHotkeyPressed && dataset) {
       const hoveredRange = props.annotationState.getSelectRangeFromId(dataset, lastHoveredId);
       if (hoveredRange !== null && hoveredRange.length > 1) {
         // Get min and max track IDs

--- a/src/components/Tooltips/HoverTooltip.tsx
+++ b/src/components/Tooltips/HoverTooltip.tsx
@@ -21,7 +21,7 @@ const defaultProps: Partial<HoverTooltipProps> = {
 const TooltipDiv = styled.div`
   position: fixed;
   transition: opacity 300ms ease-in-out;
-  z-index: 1;
+  z-index: 200;
 `;
 
 /**


### PR DESCRIPTION
Problem
=======
Part 1 of 3 for #514, "Annotation - select range of track with shortcut keys." (Also closes #531, "optimize track building in Dataset".)

Adds a range annotation mode to select a range of objects within the same track. Click a track, go to a different timepoint, and click again to label (or unlabel) all of the objects in between.

I'll be following up on this PR with a change that visualizes the affected range.

*Estimated review size: medium, 20-25 minutes*

Solution
========
- Moved annotation click handling behavior out of `Viewer.tsx` and into a new callback, `handleAnnotationClick`.
- Added a new React hook, `useShortcutKey`, which tracks whether a given key is pressed down.
- Added a new range selection mode where, when annotation editing is enabled, clicking one an object in a track and then clicking another object at a different timepoint will annotate the segments of the track in between those two points.
  - Clicking again on the same object will toggle the range.
  - Range selection mode can be temporarily enabled from the time selection mode by holding shift. (This will be documented in a tooltip in select range pt. 3)
- Added a tag in the hover tooltip that appears when range selection mode is used and a range of cells will be edited.

Misc:
- Implemented a `clear()` method in `AnnotationData` to support future work in #559
- `Dataset` now caches built tracks for performance, as described in #531.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open PR preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview-internal/pr-561/
2. Load a dataset and activate annotation edit mode. Change selection mode to range.
3. Click on a cell, then jump forward in time.
4. Hover over the same track. You should see a popup message saying what frames objects will be selected on.
5. Click. The whole range between the previously clicked time point and the current one should be selected.
6. Keep shift held down and click the same cell again to toggle the whole range.

Screenshots (optional):
-----------------------

**Video talk-through (🔊):**

https://github.com/user-attachments/assets/31c7f0b9-b1f1-4fec-87f2-878b08bea8ee


