### PR TITLE
refactor: Initial shared viewer state (pt. 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "styled-components": "^6.0.8",
         "three": "^0.151.3",
         "usehooks-ts": "^2.9.1",
-        "workerpool": "^9.1.3"
+        "workerpool": "^9.1.3",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.3",
@@ -14102,6 +14103,34 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "styled-components": "^6.0.8",
     "three": "^0.151.3",
     "usehooks-ts": "^2.9.1",
-    "workerpool": "^9.1.3"
+    "workerpool": "^9.1.3",
+    "zustand": "^5.0.3"
   }
 }

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -997,14 +997,7 @@ function Viewer(): ReactElement {
       key: TabType.SETTINGS,
       children: (
         <div className={styles.tabContent}>
-          <SettingsTab
-            config={config}
-            updateConfig={updateConfig}
-            dataset={dataset}
-            // TODO: This could be part of a dataset-specific settings object
-            selectedBackdropKey={selectedBackdropKey}
-            setSelectedBackdropKey={setSelectedBackdropKey}
-          />
+          <SettingsTab config={config} updateConfig={updateConfig} dataset={dataset} />
         </div>
       ),
     },
@@ -1184,12 +1177,8 @@ function Viewer(): ReactElement {
                   loading={isDatasetLoading}
                   loadingProgress={datasetLoadProgress}
                   canv={canv}
-                  collection={collection || null}
                   vectorData={motionDeltas}
-                  dataset={dataset}
-                  datasetKey={datasetKey}
                   featureKey={featureKey}
-                  selectedBackdropKey={selectedBackdropKey}
                   colorRamp={getColorMap(colorRampData, colorRampKey, colorRampReversed)}
                   colorRampMin={colorRampMin}
                   colorRampMax={colorRampMax}

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -128,18 +128,6 @@ function Viewer(): ReactElement {
   const [currentFrame, setCurrentFrame] = useState<number>(0);
   const annotationState = useAnnotations();
 
-  useEffect(() => {
-    // Switch to default backdrop if the dataset has one and none is currently selected.
-    // If the dataset has no backdrops, hide the backdrop.
-    if (dataset && (selectedBackdropKey === null || !dataset.hasBackdrop(selectedBackdropKey))) {
-      const defaultBackdropKey = dataset.getDefaultBackdropKey();
-      setSelectedBackdropKey(defaultBackdropKey);
-      if (!defaultBackdropKey) {
-        updateConfig({ backdropVisible: false });
-      }
-    }
-  }, [dataset, selectedBackdropKey]);
-
   // TODO: Save these settings in local storage
   // Use reducer here in case multiple updates happen simultaneously
   const [config, updateConfig] = useReducer(
@@ -547,15 +535,6 @@ function Viewer(): ReactElement {
 
       setFindTrackInput("");
 
-      // Switch to the new dataset's default backdrop if the current one is not in the
-      // new dataset. `selectedBackdropKey` is null only if the current dataset has no backdrops.
-      if (
-        selectedBackdropKey === null ||
-        (selectedBackdropKey !== null && !newDataset.hasBackdrop(selectedBackdropKey))
-      ) {
-        setSelectedBackdropKey(newDataset.getDefaultBackdropKey());
-      }
-
       setSelectedTrack(null);
       setDatasetOpen(true);
       setFeatureThresholds(validateThresholds(newDataset, featureThresholds));
@@ -700,6 +679,8 @@ function Viewer(): ReactElement {
     if (!isInitialDatasetLoaded) {
       return;
     }
+    // TODO: Move initial parsing out of `Viewer.tsx` once state store is
+    // fully implemented.
     const setupInitialParameters = async (): Promise<void> => {
       if (initialUrlParams.thresholds) {
         if (dataset) {

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -108,11 +108,14 @@ function Viewer(): ReactElement {
     return canvas;
   });
 
+  // TODO: Merge these into a single state slice call?
   const collection = useViewerStateStore((state) => state.collection);
   const setCollection = useViewerStateStore((state) => state.setCollection);
   const dataset = useViewerStateStore((state) => state.dataset);
   const datasetKey = useViewerStateStore((state) => state.datasetKey);
   const setDataset = useViewerStateStore((state) => state.setDataset);
+  // TODO: Remove these when URL parameter initialization and updating is moved
+  // into a helper method/out of the component
   /** Backdrop key is null if the dataset has no backdrops, or during initialization. */
   const selectedBackdropKey = useViewerStateStore((state) => state.backdropKey);
   const setSelectedBackdropKey = useViewerStateStore((state) => state.setBackdropKey);
@@ -997,7 +1000,7 @@ function Viewer(): ReactElement {
       key: TabType.SETTINGS,
       children: (
         <div className={styles.tabContent}>
-          <SettingsTab config={config} updateConfig={updateConfig} dataset={dataset} />
+          <SettingsTab config={config} updateConfig={updateConfig} />
         </div>
       ),
     },

--- a/src/colorizer/state/ViewerState.ts
+++ b/src/colorizer/state/ViewerState.ts
@@ -1,0 +1,46 @@
+import { create } from "zustand";
+
+import { BackdropSlice, createBackdropSlice } from "./slices/backdrop_slice";
+import { CollectionSlice, createCollectionSlice } from "./slices/collection_slice";
+import { ColorRampSlice, createColorRampSlice } from "./slices/color_ramp_slice";
+import { createDatasetSlice, DatasetSlice } from "./slices/dataset_slice";
+
+// type ViewerStoreState = ColorRampSliceState & {
+//   collection: Collection | null;
+//   dataset: Dataset | null;
+//   datasetKey: string;
+//   selectedTrack: Track | null;
+//   currentFrame: number;
+//   featureKey: string;
+
+//   backdropKey: string | null;
+//   annotationState: AnnotationState;
+
+//   featureThresholds: FeatureThreshold[];
+//   inRangeLut: Uint8Array;
+// };
+
+// type ViewerStoreActions = ColorRampSliceActions & {
+//   setCollection: (collection: Collection) => void;
+//   setDataset: (dataset: Dataset) => void;
+//   setDatasetKey: (datasetKey: string) => void;
+//   setSelectedTrack: (track: Track) => void;
+//   setCurrentFrame: (frame: number) => void;
+//   setFeatureKey: (featureKey: string) => void;
+
+//   setBackdropKey: (key: string | null) => void;
+//   setAnnotationState: (state: AnnotationState) => void;
+//   setInRangeLut: (lut: Uint8Array) => void;
+//   setFeatureThresholds: (thresholds: FeatureThreshold[]) => void;
+
+//   loadFromUrlParams: (urlParams: Partial<UrlParams>) => void;
+// };
+
+export const useViewerStateStore = create<CollectionSlice & DatasetSlice & BackdropSlice & ColorRampSlice>()(
+  (...a) => ({
+    ...createCollectionSlice(...a),
+    ...createDatasetSlice(...a),
+    ...createBackdropSlice(...a),
+    ...createColorRampSlice(...a),
+  })
+);

--- a/src/colorizer/state/ViewerState.ts
+++ b/src/colorizer/state/ViewerState.ts
@@ -5,6 +5,7 @@ import { BackdropSlice, createBackdropSlice } from "./slices/backdrop_slice";
 import { CollectionSlice, createCollectionSlice } from "./slices/collection_slice";
 import { ColorRampSlice, createColorRampSlice } from "./slices/color_ramp_slice";
 import { createDatasetSlice, DatasetSlice } from "./slices/dataset_slice";
+import { zustandHmrFix } from "./utils/store_utils";
 
 export type ViewerState = CollectionSlice & DatasetSlice & BackdropSlice & ColorRampSlice;
 
@@ -17,3 +18,5 @@ export const viewerStateStoreCreator: StateCreator<ViewerState> = (...a) => ({
 
 // TODO: Add documentation on usage here
 export const useViewerStateStore = create<ViewerState>()(viewerStateStoreCreator);
+
+zustandHmrFix("ViewerStateStore", useViewerStateStore);

--- a/src/colorizer/state/ViewerState.ts
+++ b/src/colorizer/state/ViewerState.ts
@@ -5,7 +5,6 @@ import { BackdropSlice, createBackdropSlice } from "./slices/backdrop_slice";
 import { CollectionSlice, createCollectionSlice } from "./slices/collection_slice";
 import { ColorRampSlice, createColorRampSlice } from "./slices/color_ramp_slice";
 import { createDatasetSlice, DatasetSlice } from "./slices/dataset_slice";
-import { zustandHmrFix } from "./utils/store_utils";
 
 export type ViewerState = CollectionSlice & DatasetSlice & BackdropSlice & ColorRampSlice;
 
@@ -19,4 +18,26 @@ export const viewerStateStoreCreator: StateCreator<ViewerState> = (...a) => ({
 // TODO: Add documentation on usage here
 export const useViewerStateStore = create<ViewerState>()(viewerStateStoreCreator);
 
-zustandHmrFix("ViewerStateStore", useViewerStateStore);
+// Adds compatibility with hot module reloading.
+// Adapted from https://github.com/pmndrs/zustand/discussions/827#discussioncomment-9843290
+declare global {
+  interface Window {
+    __store: ViewerState;
+  }
+}
+
+if (import.meta.hot) {
+  useViewerStateStore.subscribe((state) => {
+    if (typeof window !== "undefined") {
+      window.__store = state;
+    }
+  });
+  import.meta.hot!.accept((newModule) => {
+    if (!newModule) return;
+    const newStore = newModule.useViewerStateStore;
+    if (!newStore) return;
+    if (window.__store) {
+      newStore.setState(window.__store, true);
+    }
+  });
+}

--- a/src/colorizer/state/ViewerState.ts
+++ b/src/colorizer/state/ViewerState.ts
@@ -1,46 +1,19 @@
 import { create } from "zustand";
+import { StateCreator } from "zustand";
 
 import { BackdropSlice, createBackdropSlice } from "./slices/backdrop_slice";
 import { CollectionSlice, createCollectionSlice } from "./slices/collection_slice";
 import { ColorRampSlice, createColorRampSlice } from "./slices/color_ramp_slice";
 import { createDatasetSlice, DatasetSlice } from "./slices/dataset_slice";
 
-// type ViewerStoreState = ColorRampSliceState & {
-//   collection: Collection | null;
-//   dataset: Dataset | null;
-//   datasetKey: string;
-//   selectedTrack: Track | null;
-//   currentFrame: number;
-//   featureKey: string;
+export type ViewerState = CollectionSlice & DatasetSlice & BackdropSlice & ColorRampSlice;
 
-//   backdropKey: string | null;
-//   annotationState: AnnotationState;
+export const viewerStateStoreCreator: StateCreator<ViewerState> = (...a) => ({
+  ...createCollectionSlice(...a),
+  ...createDatasetSlice(...a),
+  ...createBackdropSlice(...a),
+  ...createColorRampSlice(...a),
+});
 
-//   featureThresholds: FeatureThreshold[];
-//   inRangeLut: Uint8Array;
-// };
-
-// type ViewerStoreActions = ColorRampSliceActions & {
-//   setCollection: (collection: Collection) => void;
-//   setDataset: (dataset: Dataset) => void;
-//   setDatasetKey: (datasetKey: string) => void;
-//   setSelectedTrack: (track: Track) => void;
-//   setCurrentFrame: (frame: number) => void;
-//   setFeatureKey: (featureKey: string) => void;
-
-//   setBackdropKey: (key: string | null) => void;
-//   setAnnotationState: (state: AnnotationState) => void;
-//   setInRangeLut: (lut: Uint8Array) => void;
-//   setFeatureThresholds: (thresholds: FeatureThreshold[]) => void;
-
-//   loadFromUrlParams: (urlParams: Partial<UrlParams>) => void;
-// };
-
-export const useViewerStateStore = create<CollectionSlice & DatasetSlice & BackdropSlice & ColorRampSlice>()(
-  (...a) => ({
-    ...createCollectionSlice(...a),
-    ...createDatasetSlice(...a),
-    ...createBackdropSlice(...a),
-    ...createColorRampSlice(...a),
-  })
-);
+// TODO: Add documentation on usage here
+export const useViewerStateStore = create<ViewerState>()(viewerStateStoreCreator);

--- a/src/colorizer/state/slices/backdrop_slice.ts
+++ b/src/colorizer/state/slices/backdrop_slice.ts
@@ -1,0 +1,40 @@
+import { clamp } from "three/src/math/MathUtils";
+import { StateCreator } from "zustand";
+
+import { DatasetSlice } from "./dataset_slice";
+
+type BackdropSliceState = {
+  backdropKey: string | null;
+  backdropVisible: boolean;
+  /** Brightness, as a percentage in the `[0, 200]` range. 100 by default. */
+  backdropBrightness: number;
+  /** Saturation, as a percentage in the `[0, 100]` range. */
+  backdropSaturation: number;
+  /** Object opacity when backdrop is visible, as a percentage in the `[0, 100]`
+   * range. 50 by default. */
+  objectOpacity: number;
+};
+
+type BackdropSliceActions = {
+  setBackdropKey: (key: string | null) => void;
+  setBackdropVisible: (visible: boolean) => void;
+  setBackdropBrightness: (brightness: number) => void;
+  setBackdropSaturation: (saturation: number) => void;
+};
+
+export type BackdropSlice = BackdropSliceState & BackdropSliceActions;
+
+export const createBackdropSlice: StateCreator<BackdropSlice & DatasetSlice, [], [], BackdropSlice> = (set, get) => ({
+  backdropKey: null,
+  backdropVisible: false,
+  backdropBrightness: 100,
+  backdropSaturation: 100,
+  objectOpacity: 50,
+
+  // Only allow keys that are in the dataset.
+  setBackdropKey: (key: string | null) => set({ backdropKey: key && get().dataset?.hasBackdrop(key) ? key : null }),
+  setBackdropVisible: (visible: boolean) => set({ backdropVisible: visible }),
+  setBackdropBrightness: (brightness: number) => set({ backdropBrightness: clamp(brightness, 0, 200) }),
+  setBackdropSaturation: (saturation: number) => set({ backdropSaturation: clamp(saturation, 0, 100) }),
+  setObjectOpacity: (opacity: number) => set({ objectOpacity: clamp(opacity, 0, 100) }),
+});

--- a/src/colorizer/state/slices/backdrop_slice.ts
+++ b/src/colorizer/state/slices/backdrop_slice.ts
@@ -30,6 +30,7 @@ type BackdropSliceActions = {
   setBackdropVisible: (visible: boolean) => void;
   setBackdropBrightness: (brightness: number) => void;
   setBackdropSaturation: (saturation: number) => void;
+  setObjectOpacity: (opacity: number) => void;
 };
 
 export type BackdropSlice = BackdropSliceState & BackdropSliceActions;

--- a/src/colorizer/state/slices/backdrop_slice.ts
+++ b/src/colorizer/state/slices/backdrop_slice.ts
@@ -45,8 +45,10 @@ export const createBackdropSlice: StateCreator<BackdropSlice & DatasetSlice, [],
   setBackdropKey: (key: string | null) => {
     const dataset = get().dataset;
     // Ignore request if backdrop is non-null but is not in the dataset
-    if (key !== null && dataset && !dataset.hasBackdrop(key)) {
-      throw new Error(`Backdrop key '${key}' was not found in the dataset.`);
+    if (!dataset) {
+      return;
+    } else if (key !== null && !dataset.hasBackdrop(key)) {
+      return;
     }
     // Optionally toggle backdrop visibility if the key is null
     set({ backdropKey: key, backdropVisible: get().backdropVisible && key !== null });

--- a/src/colorizer/state/slices/backdrop_slice.ts
+++ b/src/colorizer/state/slices/backdrop_slice.ts
@@ -4,6 +4,8 @@ import { StateCreator } from "zustand";
 import { DatasetSlice } from "./dataset_slice";
 
 type BackdropSliceState = {
+  /** The key of the backdrop image set in the current dataset. `null` if there
+   * is no Dataset loaded or if the dataset does not have backdrops. */
   backdropKey: string | null;
   backdropVisible: boolean;
   /** Brightness, as a percentage in the `[0, 200]` range. 100 by default. */
@@ -16,7 +18,15 @@ type BackdropSliceState = {
 };
 
 type BackdropSliceActions = {
+  /**
+   * Sets the backdrop key. A string key value will be ignored if it does not
+   * exist in the current dataset.
+   */
   setBackdropKey: (key: string | null) => void;
+  /**
+   * Sets the visibility of the backdrop layer. The backdrop will be hidden if
+   * the current backdrop key is `null`.
+   */
   setBackdropVisible: (visible: boolean) => void;
   setBackdropBrightness: (brightness: number) => void;
   setBackdropSaturation: (saturation: number) => void;
@@ -31,9 +41,17 @@ export const createBackdropSlice: StateCreator<BackdropSlice & DatasetSlice, [],
   backdropSaturation: 100,
   objectOpacity: 50,
 
-  // Only allow keys that are in the dataset.
-  setBackdropKey: (key: string | null) => set({ backdropKey: key && get().dataset?.hasBackdrop(key) ? key : null }),
-  setBackdropVisible: (visible: boolean) => set({ backdropVisible: visible }),
+  setBackdropKey: (key: string | null) => {
+    const dataset = get().dataset;
+    // Ignore request if backdrop is non-null but is not in the dataset
+    if (key !== null && dataset && !dataset.hasBackdrop(key)) {
+      throw new Error(`Backdrop key '${key}' was not found in the dataset.`);
+    }
+    // Optionally toggle backdrop visibility if the key is null
+    set({ backdropKey: key, backdropVisible: get().backdropVisible && key !== null });
+  },
+  // Only enable when backdrop key is not null
+  setBackdropVisible: (visible: boolean) => set({ backdropVisible: visible && get().backdropKey !== null }),
   setBackdropBrightness: (brightness: number) => set({ backdropBrightness: clamp(brightness, 0, 200) }),
   setBackdropSaturation: (saturation: number) => set({ backdropSaturation: clamp(saturation, 0, 100) }),
   setObjectOpacity: (opacity: number) => set({ objectOpacity: clamp(opacity, 0, 100) }),

--- a/src/colorizer/state/slices/collection_slice.ts
+++ b/src/colorizer/state/slices/collection_slice.ts
@@ -1,0 +1,27 @@
+import { StateCreator } from "zustand";
+
+import { DatasetSlice } from "./dataset_slice";
+
+import Collection from "../../Collection";
+
+type CollectionSliceState = {
+  collection: Collection | null;
+};
+
+type CollectionSliceActions = {
+  setCollection: (collection: Collection) => void;
+  // TODO: Add action for loading and setting a dataset here
+};
+
+export type CollectionSlice = CollectionSliceState & CollectionSliceActions;
+
+export const createCollectionSlice: StateCreator<CollectionSlice & DatasetSlice, [], [], CollectionSlice> = (
+  set,
+  _get
+) => ({
+  collection: null,
+
+  setCollection: (collection: Collection) => {
+    set({ collection });
+  },
+});

--- a/src/colorizer/state/slices/color_ramp_slice.ts
+++ b/src/colorizer/state/slices/color_ramp_slice.ts
@@ -1,0 +1,94 @@
+import { Color } from "three";
+import { StateCreator } from "zustand";
+
+import { DEFAULT_CATEGORICAL_PALETTE_KEY, KNOWN_CATEGORICAL_PALETTES } from "../../colors/categorical_palettes";
+import { DEFAULT_COLOR_RAMP_KEY, KNOWN_COLOR_RAMPS } from "../../colors/color_ramps";
+import { arrayDeepEquals, getColorMap } from "../../utils/data_utils";
+
+import ColorRamp from "../../ColorRamp";
+
+export type ColorRampSliceState = {
+  colorRampKey: string;
+  isColorRampReversed: boolean;
+  colorRampMin: number;
+  colorRampMax: number;
+  categoricalPalette: Color[];
+
+  // Derived values
+  /** The key of the categorical palette, if it matches a known palette. `null`
+   * if the palette does not match. */
+  categoricalPaletteKey: string | null;
+  /** The current ColorRamp, based on the selected key and optionally reversed. */
+  colorRamp: ColorRamp;
+};
+
+export type ColorRampSliceActions = {
+  /** Changes the key of the current color ramp. Must be a known color ramp
+   * key from `KNOWN_COLOR_RAMPS`. Resets the reversed state when set.
+   */
+  setColorRampKey: (key: string) => void;
+  setColorRampReversed: (reversed: boolean) => void;
+  setColorRampMin: (min: number) => void;
+  setColorRampMax: (max: number) => void;
+  setCategoricalPalette: (palette: Color[]) => void;
+};
+
+export type ColorRampSlice = ColorRampSliceState & ColorRampSliceActions;
+
+const getPaletteKey = (palette: Color[]): string | null => {
+  for (const [key, paletteData] of KNOWN_CATEGORICAL_PALETTES) {
+    if (arrayDeepEquals(paletteData.colors, palette)) {
+      return key;
+    }
+  }
+  return null;
+};
+
+export const createColorRampSlice: StateCreator<ColorRampSlice> = (set) => ({
+  // State
+  colorRampKey: DEFAULT_COLOR_RAMP_KEY,
+  isColorRampReversed: false,
+  colorRampMin: 0,
+  colorRampMax: 1,
+  categoricalPalette: KNOWN_CATEGORICAL_PALETTES.get(DEFAULT_CATEGORICAL_PALETTE_KEY)!.colors,
+  // Derived values
+  categoricalPaletteKey: DEFAULT_CATEGORICAL_PALETTE_KEY,
+  colorRamp: KNOWN_COLOR_RAMPS.get(DEFAULT_COLOR_RAMP_KEY)!.colorRamp,
+  // Actions
+  setColorRampKey: (key: string) =>
+    set((state) => {
+      if (!KNOWN_COLOR_RAMPS.has(key)) {
+        throw new Error(`Unknown color ramp key: ${key}`);
+      }
+      if (key === state.colorRampKey) {
+        return {};
+      }
+      return {
+        colorRampKey: key,
+        isColorRampReversed: false,
+        colorRamp: getColorMap(KNOWN_COLOR_RAMPS, key, false),
+      };
+    }),
+  setColorRampReversed: (reversed: boolean) =>
+    set((state) => ({
+      isColorRampReversed: reversed,
+      colorRamp: getColorMap(KNOWN_COLOR_RAMPS, state.colorRampKey, reversed),
+    })),
+  // Enforce min/max
+  setColorRampMin: (min: number) =>
+    set((state) => ({
+      colorRampMin: Math.min(min, state.colorRampMax),
+      colorRampMax: Math.max(min, state.colorRampMax),
+    })),
+  setColorRampMax: (max: number) =>
+    set((state) => ({
+      colorRampMin: Math.min(max, state.colorRampMin),
+      colorRampMax: Math.max(max, state.colorRampMin),
+    })),
+  setCategoricalPalette: (palette: Color[]) =>
+    set((_state) => ({
+      // Check if the new palette matches a known palette key.
+      categoricalPaletteKey: getPaletteKey(palette),
+      categoricalPalette: palette,
+    })),
+});

--- a/src/colorizer/state/slices/dataset_slice.ts
+++ b/src/colorizer/state/slices/dataset_slice.ts
@@ -1,0 +1,35 @@
+import { StateCreator } from "zustand";
+
+import { BackdropSlice } from "./backdrop_slice";
+import { CollectionSlice } from "./collection_slice";
+
+import Dataset from "../../Dataset";
+
+type DatasetSliceState = {
+  datasetKey: string | null;
+  dataset: Dataset | null;
+};
+
+type DatasetSliceActions = {
+  setDataset: (key: string, dataset: Dataset) => void;
+  clearDataset: () => void;
+};
+
+export type DatasetSlice = DatasetSliceState & DatasetSliceActions;
+
+export const createDatasetSlice: StateCreator<CollectionSlice & DatasetSlice & BackdropSlice, [], [], DatasetSlice> = (
+  set,
+  get
+) => ({
+  datasetKey: null,
+  dataset: null,
+
+  setDataset: (key: string, dataset: Dataset) => {
+    // Validate dataset-dependent state values
+    let backdropKey = get().backdropKey;
+    backdropKey = backdropKey !== null && dataset.hasBackdrop(backdropKey) ? backdropKey : null;
+
+    set({ datasetKey: key, dataset, backdropKey });
+  },
+  clearDataset: () => set({ datasetKey: null, dataset: null, backdropKey: null }),
+});

--- a/src/colorizer/state/slices/dataset_slice.ts
+++ b/src/colorizer/state/slices/dataset_slice.ts
@@ -33,6 +33,7 @@ export const createDatasetSlice: StateCreator<CollectionSlice & DatasetSlice & B
       backdropKey = dataset.getDefaultBackdropKey();
     }
 
+    // TODO: Dispose of old dataset?
     set({ datasetKey: key, dataset, backdropKey });
   },
   clearDataset: () => set({ datasetKey: null, dataset: null, backdropKey: null }),

--- a/src/colorizer/state/slices/dataset_slice.ts
+++ b/src/colorizer/state/slices/dataset_slice.ts
@@ -25,9 +25,13 @@ export const createDatasetSlice: StateCreator<CollectionSlice & DatasetSlice & B
   dataset: null,
 
   setDataset: (key: string, dataset: Dataset) => {
-    // Validate dataset-dependent state values
+    ///// Validate dataset-dependent state values /////
+
+    // Switch to new dataset's default backdrop if the current one is not in the new dataset.
     let backdropKey = get().backdropKey;
-    backdropKey = backdropKey !== null && dataset.hasBackdrop(backdropKey) ? backdropKey : null;
+    if (backdropKey === null || !dataset.hasBackdrop(backdropKey)) {
+      backdropKey = dataset.getDefaultBackdropKey();
+    }
 
     set({ datasetKey: key, dataset, backdropKey });
   },

--- a/src/colorizer/state/utils/store_utils.ts
+++ b/src/colorizer/state/utils/store_utils.ts
@@ -1,0 +1,42 @@
+import { shallow } from "zustand/shallow";
+
+/**
+ * Creates a selector function that computes a value based on a set of dependencies.
+ * The selector will only recompute the value when the dependencies change.
+ * @param depsFn A function that returns the dependencies (as an array). Values are compared using
+ * shallow equality (`zustand/shallow`).
+ * @param computeFn A function that computes and returns the value based on the dependencies.
+ * @returns A selector function that returns a computed value, caching the result unless
+ * the dependencies change.
+ *
+ * @example
+ * ```
+ * const useStore = create((set, get) => ({
+ *   first: "John",
+ *   last: "Doe",
+ *   fullName: computed(
+ *     // Dependencies:
+ *     () => [get().first, get().last],
+ *     // Computation (only computed when first accessed and only recomputed if a dependency value changes):
+ *     (first, last) => `${first} ${last}`,
+ *   ),
+ * }));
+ * ```
+ *
+ * Adapted from https://github.com/pmndrs/zustand/issues/108#issuecomment-2197556875
+ */
+export function computed<const TDeps extends readonly unknown[] = unknown[], TResult = unknown>(
+  depsFn: () => TDeps,
+  computeFn: (...deps: TDeps) => TResult
+): () => TResult {
+  let prevDeps: TDeps;
+  let cachedResult: TResult;
+  return () => {
+    const deps = depsFn();
+    if (prevDeps === undefined || !shallow(prevDeps, deps)) {
+      prevDeps = deps;
+      cachedResult = computeFn(...deps);
+    }
+    return cachedResult;
+  };
+}

--- a/src/colorizer/state/utils/store_utils.ts
+++ b/src/colorizer/state/utils/store_utils.ts
@@ -1,3 +1,4 @@
+import { UseBoundStore } from "zustand";
 import { shallow } from "zustand/shallow";
 
 /**
@@ -40,3 +41,22 @@ export function computed<const TDeps extends readonly unknown[] = unknown[], TRe
     return cachedResult;
   };
 }
+
+export const zustandHmrFix = (name: string, useStore: UseBoundStore<any>) => {
+  if (import.meta.hot) {
+    const state = import.meta.hot!.data[name];
+    if (state) {
+      useStore.setState(import.meta.hot!.data[name]);
+    }
+    useStore.subscribe((state: any) => {
+      import.meta.hot!.data[name] = state;
+    });
+    import.meta.hot!.accept((newModule) => {
+      if (newModule) {
+        console.log("🔁  Accepting updated module: ", newModule);
+        console.log("Overriding state with", import.meta.hot!.data[name]);
+        useStore.setState(import.meta.hot!.data[name]);
+      }
+    });
+  }
+};

--- a/src/colorizer/state/utils/store_utils.ts
+++ b/src/colorizer/state/utils/store_utils.ts
@@ -1,4 +1,3 @@
-import { UseBoundStore } from "zustand";
 import { shallow } from "zustand/shallow";
 
 /**
@@ -41,22 +40,3 @@ export function computed<const TDeps extends readonly unknown[] = unknown[], TRe
     return cachedResult;
   };
 }
-
-export const zustandHmrFix = (name: string, useStore: UseBoundStore<any>) => {
-  if (import.meta.hot) {
-    const state = import.meta.hot!.data[name];
-    if (state) {
-      useStore.setState(import.meta.hot!.data[name]);
-    }
-    useStore.subscribe((state: any) => {
-      import.meta.hot!.data[name] = state;
-    });
-    import.meta.hot!.accept((newModule) => {
-      if (newModule) {
-        console.log("🔁  Accepting updated module: ", newModule);
-        console.log("Overriding state with", import.meta.hot!.data[name]);
-        useStore.setState(import.meta.hot!.data[name]);
-      }
-    });
-  }
-};

--- a/src/colorizer/utils/data_utils.ts
+++ b/src/colorizer/utils/data_utils.ts
@@ -209,3 +209,16 @@ export function getIntervals(values: number[]): [number, number][] {
   }
   return intervals;
 }
+
+/** Returns whether the two arrays are deeply equal, where arr1[i] === arr2[i] for all i. */
+export function arrayDeepEquals<T>(arr1: T[], arr2: T[]): boolean {
+  if (arr1.length !== arr2.length) {
+    return false;
+  }
+  for (let i = 0; i < arr2.length; i++) {
+    if (arr1[i] !== arr2[i]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -6,7 +6,7 @@ import { Color, ColorRepresentation, Vector2 } from "three";
 import { clamp } from "three/src/math/MathUtils";
 
 import { ImagesIconSVG, ImagesSlashIconSVG, NoImageSVG, TagIconSVG, TagSlashIconSVG } from "../assets";
-import { ColorRamp, Dataset, Track } from "../colorizer";
+import { ColorRamp, Track } from "../colorizer";
 import { AnnotationSelectionMode, LoadTroubleshooting, TabType, ViewerConfig } from "../colorizer/types";
 import * as mathUtils from "../colorizer/utils/math_utils";
 import { AnnotationState } from "../colorizer/utils/react_utils";
@@ -14,7 +14,7 @@ import { INTERNAL_BUILD } from "../constants";
 import { FlexColumn, FlexColumnAlignCenter, VisuallyHidden } from "../styles/utils";
 
 import CanvasUIOverlay from "../colorizer/CanvasWithOverlay";
-import Collection from "../colorizer/Collection";
+import { useViewerStateStore } from "../colorizer/state/ViewerState";
 import { AppThemeContext } from "./AppStyle";
 import { AlertBannerProps } from "./Banner";
 import { LinkStyleButton } from "./Buttons/LinkStyleButton";
@@ -114,16 +114,8 @@ const AnnotationModeContainer = styled(FlexColumnAlignCenter)`
 
 type CanvasWrapperProps = {
   canv: CanvasUIOverlay;
-  /** Dataset to look up track and ID information in.
-   * Changing this does NOT update the canvas dataset; do so
-   * directly by calling `canv.setDataset()`.
-   */
-  dataset: Dataset | null;
-  datasetKey: string | null;
 
   featureKey: string | null;
-  /** Pan and zoom will be reset on collection change. */
-  collection: Collection | null;
   config: ViewerConfig;
   updateConfig: (settings: Partial<ViewerConfig>) => void;
   vectorData: Float32Array | null;
@@ -131,8 +123,6 @@ type CanvasWrapperProps = {
   loading: boolean;
   loadingProgress: number | null;
   isRecording: boolean;
-
-  selectedBackdropKey: string | null;
 
   colorRamp: ColorRamp;
   colorRampMin: number;
@@ -175,6 +165,11 @@ const defaultProps: Partial<CanvasWrapperProps> = {
  */
 export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElement {
   const props = { ...defaultProps, ...inputProps } as Required<CanvasWrapperProps>;
+
+  const dataset = useViewerStateStore((state) => state.dataset);
+  const datasetKey = useViewerStateStore((state) => state.datasetKey);
+  const collection = useViewerStateStore((state) => state.collection);
+  const selectedBackdropKey = useViewerStateStore((state) => state.backdropKey);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -269,8 +264,8 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
 
   // Update backdrops
   useMemo(() => {
-    if (props.selectedBackdropKey !== null && props.config.backdropVisible) {
-      canv.setBackdropKey(props.selectedBackdropKey);
+    if (selectedBackdropKey !== null && props.config.backdropVisible) {
+      canv.setBackdropKey(selectedBackdropKey);
       canv.setBackdropBrightness(props.config.backdropBrightness);
       canv.setBackdropSaturation(props.config.backdropSaturation);
       canv.setObjectOpacity(props.config.objectOpacity);
@@ -279,7 +274,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       canv.setObjectOpacity(100);
     }
   }, [
-    props.selectedBackdropKey,
+    selectedBackdropKey,
     props.config.backdropVisible,
     props.config.backdropBrightness,
     props.config.backdropSaturation,
@@ -289,7 +284,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   // Update categorical colors
   useMemo(() => {
     canv.setCategoricalColors(props.categoricalColors);
-  }, [props.categoricalColors, props.dataset, props.featureKey]);
+  }, [props.categoricalColors, dataset, props.featureKey]);
 
   // Update drawing modes for outliers + out of range values
   useMemo(() => {
@@ -322,12 +317,12 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   }, [props.config.showTimestamp]);
 
   useMemo(() => {
-    canv.setCollection(props.collection);
-  }, [props.collection]);
+    canv.setCollection(collection);
+  }, [collection]);
 
   useMemo(() => {
-    canv.setDatasetKey(props.datasetKey);
-  }, [props.datasetKey]);
+    canv.setDatasetKey(datasetKey);
+  }, [datasetKey]);
 
   useMemo(() => {
     canv.setIsExporting(props.isRecording);
@@ -349,12 +344,10 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
 
   useMemo(() => {
     const annotationLabels = props.annotationState.data.getLabels();
-    const timeToAnnotationLabelIds = props.dataset
-      ? props.annotationState.data.getTimeToLabelIdMap(props.dataset)
-      : new Map();
+    const timeToAnnotationLabelIds = dataset ? props.annotationState.data.getTimeToLabelIdMap(dataset) : new Map();
     canv.setAnnotationData(annotationLabels, timeToAnnotationLabelIds, props.annotationState.currentLabelIdx);
     canv.isAnnotationVisible = props.annotationState.visible;
-  }, [props.dataset, props.annotationState.data, props.annotationState.currentLabelIdx, props.annotationState.visible]);
+  }, [dataset, props.annotationState.data, props.annotationState.currentLabelIdx, props.annotationState.visible]);
 
   // CANVAS RESIZING /////////////////////////////////////////////////
 
@@ -398,22 +391,22 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
     canvasPanOffset.current = new Vector2(0, 0);
     canv.setZoom(1.0);
     canv.setPan(0, 0);
-  }, [props.collection]);
+  }, [collection]);
 
   /** Report clicked tracks via the passed callback. */
   const handleTrackSelection = useCallback(
     async (event: MouseEvent): Promise<void> => {
       const id = canv.getIdAtPixel(event.offsetX, event.offsetY);
       // Reset track input
-      if (id < 0 || props.dataset === null) {
+      if (id < 0 || dataset === null) {
         props.onTrackClicked(null);
       } else {
-        const trackId = props.dataset.getTrackId(id);
-        const newTrack = props.dataset.buildTrack(trackId);
+        const trackId = dataset.getTrackId(id);
+        const newTrack = dataset.buildTrack(trackId);
         props.onTrackClicked(newTrack);
       }
     },
-    [canv, props.dataset, props.onTrackClicked]
+    [canv, dataset, props.onTrackClicked]
   );
 
   /**
@@ -421,10 +414,10 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
    */
   const getFrameSizeInScreenPx = useCallback((): Vector2 => {
     const canvasSizePx = getCanvasSizePx();
-    const frameResolution = props.dataset ? props.dataset.frameResolution : canvasSizePx;
+    const frameResolution = dataset ? dataset.frameResolution : canvasSizePx;
     const canvasZoom = 1 / canvasZoomInverse.current;
     return mathUtils.getFrameSizeInScreenPx(canvasSizePx, frameResolution, canvasZoom);
-  }, [props.dataset?.frameResolution, getCanvasSizePx]);
+  }, [dataset?.frameResolution, getCanvasSizePx]);
 
   /** Change zoom by some delta factor. */
   const handleZoom = useCallback(
@@ -482,7 +475,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       canvasPanOffset.current.y = clamp(canvasPanOffset.current.y, -0.5, 0.5);
       canv.setPan(canvasPanOffset.current.x, canvasPanOffset.current.y);
     },
-    [canv, getCanvasSizePx, props.dataset]
+    [canv, getCanvasSizePx, dataset]
   );
 
   // Mouse event handlers
@@ -609,13 +602,13 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   /** Report hovered id via the passed callback. */
   const reportHoveredIdAtPixel = useCallback(
     (x: number, y: number): void => {
-      if (!props.dataset) {
+      if (!dataset) {
         return;
       }
       const id = canv.getIdAtPixel(x, y);
       props.onMouseHover(id);
     },
-    [props.dataset, canv]
+    [dataset, canv]
   );
 
   /** Track whether the canvas is hovered, so we can determine whether to send updates about the
@@ -645,7 +638,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       canv.domElement.removeEventListener("mousemove", onMouseMove);
       canv.domElement.removeEventListener("mouseleave", props.onMouseLeave);
     };
-  }, [props.dataset, canv]);
+  }, [dataset, canv]);
 
   const makeLinkStyleButton = (key: string, onClick: () => void, content: ReactNode): ReactNode => {
     return (
@@ -676,9 +669,9 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   const backdropTooltipContents: ReactNode[] = [];
   backdropTooltipContents.push(
     <span key="backdrop-name">
-      {props.selectedBackdropKey === null
+      {selectedBackdropKey === null
         ? "(No backdrops available)"
-        : props.dataset?.getBackdropData().get(props.selectedBackdropKey)?.name}
+        : dataset?.getBackdropData().get(selectedBackdropKey)?.name}
     </span>
   );
   // Link to viewer settings
@@ -776,7 +769,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
             onClick={() => {
               props.updateConfig({ backdropVisible: !props.config.backdropVisible });
             }}
-            disabled={props.selectedBackdropKey === null}
+            disabled={selectedBackdropKey === null}
           >
             {props.config.backdropVisible ? <ImagesSlashIconSVG /> : <ImagesIconSVG />}
             <VisuallyHidden>{props.config.backdropVisible ? "Hide backdrop" : "Show backdrop"}</VisuallyHidden>

--- a/src/components/Dropdowns/ColorRampDropdown.tsx
+++ b/src/components/Dropdowns/ColorRampDropdown.tsx
@@ -12,6 +12,7 @@ import {
   KNOWN_COLOR_RAMPS,
   PaletteData,
 } from "../../colorizer";
+import { arrayDeepEquals } from "../../colorizer/utils/data_utils";
 import { FlexRowAlignCenter } from "../../styles/utils";
 import { SelectItem } from "./types";
 
@@ -140,19 +141,6 @@ const defaultProps: Partial<ColorRampSelectionProps> = {
   useCategoricalPalettes: false,
   knownCategoricalPalettes: KNOWN_CATEGORICAL_PALETTES,
 };
-
-/** Returns whether the two arrays are deeply equal, where arr1[i] === arr2[i] for all i. */
-function arrayDeepEquals<T>(arr1: T[], arr2: T[]): boolean {
-  if (arr1.length !== arr2.length) {
-    return false;
-  }
-  for (let i = 0; i < arr2.length; i++) {
-    if (arr1[i] !== arr2[i]) {
-      return false;
-    }
-  }
-  return true;
-}
 
 export default function ColorRampSelection(inputProps: ColorRampSelectionProps): ReactElement {
   const props = { ...defaultProps, ...inputProps } as Required<ColorRampSelectionProps>;

--- a/src/components/Tabs/SettingsTab.tsx
+++ b/src/components/Tabs/SettingsTab.tsx
@@ -38,7 +38,7 @@ export default function SettingsTab(props: SettingsTabProps): ReactElement {
 
   const backdropOptions = useMemo(
     () =>
-      props.dataset
+      dataset
         ? Array.from(dataset.getBackdropData().entries()).map(([key, data]) => ({ value: key, label: data.name }))
         : [],
     [dataset]

--- a/src/components/Tabs/SettingsTab.tsx
+++ b/src/components/Tabs/SettingsTab.tsx
@@ -34,12 +34,14 @@ type SettingsTabProps = {
 };
 
 export default function SettingsTab(props: SettingsTabProps): ReactElement {
+  const dataset = useViewerStateStore((state) => state.dataset);
+
   const backdropOptions = useMemo(
     () =>
       props.dataset
-        ? Array.from(props.dataset.getBackdropData().entries()).map(([key, data]) => ({ value: key, label: data.name }))
+        ? Array.from(dataset.getBackdropData().entries()).map(([key, data]) => ({ value: key, label: data.name }))
         : [],
-    [props.dataset]
+    [dataset]
   );
 
   const backdropKey = useViewerStateStore((state) => state.backdropKey) ?? NO_BACKDROP.value;

--- a/src/components/Tabs/SettingsTab.tsx
+++ b/src/components/Tabs/SettingsTab.tsx
@@ -9,6 +9,7 @@ import { DrawMode, ViewerConfig } from "../../colorizer/types";
 import { FlexColumn } from "../../styles/utils";
 import { DEFAULT_OUTLINE_COLOR_PRESETS } from "./Settings/constants";
 
+import { useViewerStateStore } from "../../colorizer/state/ViewerState";
 import CustomCollapse from "../CustomCollapse";
 import DrawModeDropdown from "../Dropdowns/DrawModeDropdown";
 import SelectionDropdown from "../Dropdowns/SelectionDropdown";
@@ -29,9 +30,6 @@ type SettingsTabProps = {
   config: ViewerConfig;
   updateConfig(settings: Partial<ViewerConfig>): void;
 
-  selectedBackdropKey: string | null;
-  setSelectedBackdropKey: (key: string | null) => void;
-
   dataset: Dataset | null;
 };
 
@@ -44,9 +42,12 @@ export default function SettingsTab(props: SettingsTabProps): ReactElement {
     [props.dataset]
   );
 
-  const isBackdropDisabled = backdropOptions.length === 0 || props.selectedBackdropKey === null;
+  const backdropKey = useViewerStateStore((state) => state.backdropKey) ?? NO_BACKDROP.value;
+  const setBackdropKey = useViewerStateStore((state) => state.setBackdropKey);
+
+  const isBackdropDisabled = backdropOptions.length === 0 || backdropKey === null;
   const isBackdropOptionsDisabled = isBackdropDisabled || !props.config.backdropVisible;
-  let selectedBackdropKey = props.selectedBackdropKey ?? NO_BACKDROP.value;
+  let selectedBackdropKey = backdropKey ?? NO_BACKDROP.value;
   if (isBackdropDisabled) {
     backdropOptions.push(NO_BACKDROP);
     selectedBackdropKey = NO_BACKDROP.value;
@@ -70,7 +71,7 @@ export default function SettingsTab(props: SettingsTabProps): ReactElement {
             <SelectionDropdown
               selected={selectedBackdropKey}
               items={backdropOptions}
-              onChange={props.setSelectedBackdropKey}
+              onChange={setBackdropKey}
               disabled={isBackdropOptionsDisabled}
             />
           </SettingsItem>


### PR DESCRIPTION
Problem
=======
Part 1 of ??? for #492, "Refactor state management."

This change adds Zustand, a hook-based state management library. The long-term plan is to remove a lot of the state management behavior that's currently in `Viewer.tsx` into their own files that will be easier to parse and understand.

This change is a little demonstration of how the new store system works, and I'm looking for feedback on the pattern. This will be part of a LONG chain of PRs that slowly move more and more code logic into the store!

Solution
========
What I/we did to solve this problem

with @pairperson1

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* This change requires a documentation update
* This change requires updated or new tests

Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
2. other important file

Thanks for contributing!
