### PR TITLE
fix: Fixed alert banners not rendering on load

### DIFF
--- a/src/components/Banner/hooks.tsx
+++ b/src/components/Banner/hooks.tsx
@@ -1,4 +1,4 @@
-import React, { DependencyList, ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { DependencyList, ReactElement, useCallback, useMemo, useRef, useState } from "react";
 
 import AlertBanner, { AlertBannerProps } from "./AlertBanner";
 
@@ -67,7 +67,7 @@ export const useAlertBanner = (
   }, []);
 
   // Automatically clear banners when the dependency list changes.
-  useEffect(() => {
+  useMemo(() => {
     clearBanners();
   }, deps);
 


### PR DESCRIPTION
Problem
=======
Closes #366, "Default message banner when no dataset is loaded does not appear."

Fixes a bug that was occurring in developer mode where the error banner when datasets cannot be loaded would not appear. This was caused by React running the `useEffect` that clears the banners twice, and one of the calls occurred after the error message was created. 

You can see this working in production mode here: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-571/viewer
And in developer mode by cloning and running the branch, and going to http://localhost:5173/viewer

*Estimated review size: tiny, 2 minutes*

Solution
========
- Switched from a `useEffect` to a `useMemo` since the hook did not rely on the component to be mounted, and also to bypass React running `useEffect`'s twice in developer mode.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

