### PR TITLE
fix: Fixed bug where time playback could not be stopped

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -335,7 +335,7 @@ function Viewer(): ReactElement {
     }
   }, [timeControls.isPlaying(), isRecording, getUrlParams, isInitialDatasetLoaded]);
 
-  // Callback for setting time, to be used only with timeControls.
+  // Callback for setting time, to be used directly only with timeControls.
   const setFrameCallback = useCallback(
     async (frame: number) => {
       await canv.setFrame(frame);

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -220,6 +220,7 @@ function Viewer(): ReactElement {
     }
   }, [timeControls.isPlaying()]);
 
+  const timeSliderContainerRef = useRef<HTMLDivElement>(null);
   /** The frame selected by the time UI. Changes to frameInput are reflected in
    * canvas after a short delay.
    */
@@ -843,7 +844,13 @@ function Viewer(): ReactElement {
   // We need to attach the pointerup event listener to the document because it will not fire
   // if the user releases the pointer outside of the slider.
   useEffect(() => {
-    const checkIfPlaybackShouldUnpause = async (): Promise<void> => {
+    const checkIfPlaybackShouldUnpause = async (event: PointerEvent): Promise<void> => {
+      const target = event.target;
+      if (target && timeSliderContainerRef.current?.contains(target as Node)) {
+        // If the user clicked and released on the slider, update the
+        // time immediately.
+        setFrame(frameInput);
+      }
       if (isTimeSliderDraggedDuringPlayback) {
         setFrame(frameInput);
         // Update the frame and unpause playback when the slider is released.
@@ -1247,6 +1254,7 @@ function Viewer(): ReactElement {
               )}
 
               <div
+                ref={timeSliderContainerRef}
                 className={styles.timeSliderContainer}
                 onPointerDownCapture={() => {
                   if (timeControls.isPlaying()) {


### PR DESCRIPTION
Problem
=======
Closes #575, "cannot stop playback when frame loading is slow."

*Estimated review size: tiny, <5 minutes*

Solution
========
- Adds a check to prevent the time slider from setting the current time during playback.
- Fixes a behavior where playback would start/resume anytime the mouse was clicked and released.
- Syncs the time slider and the current frame when time playback is paused.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open PR preview and load a dataset: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-577/
2. Turn on backdrops.
3. Start playback, pause playback, jump through time, click and drag the slider during time playback, etc.

Screenshots (optional):
-----------------------

**Video talk-through (🔊):**

https://github.com/user-attachments/assets/24bd71e3-14dd-4999-b424-5b2c882ea607


