### PR TITLE
refactor: Use mock Dataset in ViewerStateStore tests (state pt. 4a)

### DIFF
--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -2,7 +2,6 @@ import semver from "semver";
 import { Vector2 } from "three";
 import { describe, expect, it } from "vitest";
 
-import Dataset, { FeatureType } from "../src/colorizer/Dataset";
 import { AnyManifestFile, ManifestFile } from "../src/colorizer/utils/dataset_utils";
 import { MAX_FEATURE_CATEGORIES } from "../src/constants";
 import {
@@ -13,6 +12,8 @@ import {
   MockArrayLoader,
   MockFrameLoader,
 } from "./test_utils";
+
+import Dataset, { FeatureType } from "../src/colorizer/Dataset";
 
 describe("Dataset", () => {
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/tests/data_utils.test.ts
+++ b/tests/data_utils.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { FeatureThreshold, ThresholdType } from "../src/colorizer/types";
 import { getIntervals, getKeyFromName, validateThresholds } from "../src/colorizer/utils/data_utils";
-
-import { makeMockDataset } from "./Dataset.test";
+import { makeMockDataset } from "./test_utils";
 
 describe("data_utils", () => {
   describe("getKeyFromName", () => {

--- a/tests/state/ViewerState/constants.ts
+++ b/tests/state/ViewerState/constants.ts
@@ -1,15 +1,50 @@
-import { Dataset } from "../../../src/colorizer";
+import { AnyManifestFile } from "../../../src/colorizer/utils/dataset_utils";
+import { makeMockDataset } from "../../test_utils";
 
 export const DEFAULT_BACKDROP_KEY = "test_backdrop_key";
 
-// TODO: This will likely need to be an actual dataset object at some point
-// as changing the dataset has more side effects.
-export const MOCK_DATASET_WITH_BACKDROP = {
-  getDefaultBackdropKey: () => DEFAULT_BACKDROP_KEY,
-  hasBackdrop: (key: string) => key === DEFAULT_BACKDROP_KEY,
-} as unknown as Dataset;
+export enum MOCK_FEATURE_KEYS {
+  FEATURE1 = "feature1",
+  FEATURE2 = "feature2",
+  FEATURE3 = "feature3",
+}
+const MOCK_DATASET_MANIFEST: AnyManifestFile = {
+  frames: ["frame0.json"],
+  features: [
+    {
+      key: MOCK_FEATURE_KEYS.FEATURE1,
+      name: "Feature1",
+      data: "feature1.json",
+      unit: "meters",
+      type: "continuous",
+      min: 0,
+      max: 1,
+    },
+    {
+      key: MOCK_FEATURE_KEYS.FEATURE2,
+      name: "Feature2",
+      data: "feature2.json",
+      unit: "(m)",
+      type: "discrete",
+      min: 0,
+      max: 100,
+    },
+    {
+      key: MOCK_FEATURE_KEYS.FEATURE3,
+      name: "feature3",
+      data: "feature3.json",
+      type: "categorical",
+      categories: ["small", "medium", "large"],
+      min: 0,
+      max: 2,
+    },
+  ],
+  backdrops: [{ name: DEFAULT_BACKDROP_KEY, key: DEFAULT_BACKDROP_KEY, frames: ["frame0.json"] }],
+};
 
-export const MOCK_DATASET_WITHOUT_BACKDROP = {
-  getDefaultBackdropKey: () => null,
-  hasBackdrop: () => false,
-} as unknown as Dataset;
+export const MOCK_DATASET = await makeMockDataset(MOCK_DATASET_MANIFEST);
+
+export const MOCK_DATASET_WITHOUT_BACKDROP = await makeMockDataset({
+  ...MOCK_DATASET_MANIFEST,
+  backdrops: [],
+});

--- a/tests/state/ViewerState/constants.ts
+++ b/tests/state/ViewerState/constants.ts
@@ -1,18 +1,20 @@
 import { AnyManifestFile } from "../../../src/colorizer/utils/dataset_utils";
 import { makeMockDataset } from "../../test_utils";
 
-export const DEFAULT_BACKDROP_KEY = "test_backdrop_key";
-
-export enum MOCK_FEATURE_KEYS {
+export enum MockFeatureKeys {
   FEATURE1 = "feature1",
   FEATURE2 = "feature2",
   FEATURE3 = "feature3",
 }
+
+export const DEFAULT_BACKDROP_KEY = "test_backdrop_key";
+export const DEFAULT_INITIAL_FEATURE_KEY = MockFeatureKeys.FEATURE1;
+
 const MOCK_DATASET_MANIFEST: AnyManifestFile = {
   frames: ["frame0.json"],
   features: [
     {
-      key: MOCK_FEATURE_KEYS.FEATURE1,
+      key: MockFeatureKeys.FEATURE1,
       name: "Feature1",
       data: "feature1.json",
       unit: "meters",
@@ -21,7 +23,7 @@ const MOCK_DATASET_MANIFEST: AnyManifestFile = {
       max: 1,
     },
     {
-      key: MOCK_FEATURE_KEYS.FEATURE2,
+      key: MockFeatureKeys.FEATURE2,
       name: "Feature2",
       data: "feature2.json",
       unit: "(m)",
@@ -30,7 +32,7 @@ const MOCK_DATASET_MANIFEST: AnyManifestFile = {
       max: 100,
     },
     {
-      key: MOCK_FEATURE_KEYS.FEATURE3,
+      key: MockFeatureKeys.FEATURE3,
       name: "feature3",
       data: "feature3.json",
       type: "categorical",

--- a/tests/state/ViewerState/dataset_slice.test.ts
+++ b/tests/state/ViewerState/dataset_slice.test.ts
@@ -1,19 +1,18 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { DEFAULT_BACKDROP_KEY, MOCK_DATASET_WITH_BACKDROP, MOCK_DATASET_WITHOUT_BACKDROP } from "./constants";
-
 import { useViewerStateStore } from "../../../src/state/ViewerState";
+import { DEFAULT_BACKDROP_KEY, MOCK_DATASET, MOCK_DATASET_WITHOUT_BACKDROP } from "./constants";
 
 describe("useViewerStateStore: DatasetSlice", () => {
   describe("setDataset", () => {
     it("initializes backdrop keys to default", () => {
       const { result } = renderHook(() => useViewerStateStore());
       act(() => {
-        result.current.setDataset("some-key", MOCK_DATASET_WITH_BACKDROP);
+        result.current.setDataset("some-key", MOCK_DATASET);
       });
 
-      expect(result.current.dataset).toBe(MOCK_DATASET_WITH_BACKDROP);
+      expect(result.current.dataset).toBe(MOCK_DATASET);
       expect(result.current.backdropKey).toBe(DEFAULT_BACKDROP_KEY);
 
       // Change dataset to one without default backdrop, backdropKey should
@@ -29,7 +28,7 @@ describe("useViewerStateStore: DatasetSlice", () => {
       const { result } = renderHook(() => useViewerStateStore());
 
       act(() => {
-        result.current.setDataset("some-key", MOCK_DATASET_WITH_BACKDROP);
+        result.current.setDataset("some-key", MOCK_DATASET);
         result.current.setBackdropVisible(true);
       });
       expect(result.current.backdropVisible).toBe(true);
@@ -45,7 +44,7 @@ describe("useViewerStateStore: DatasetSlice", () => {
     it("clears backdrop key and visibility", () => {
       const { result } = renderHook(() => useViewerStateStore());
       act(() => {
-        result.current.setDataset("some-key", MOCK_DATASET_WITH_BACKDROP);
+        result.current.setDataset("some-key", MOCK_DATASET);
         result.current.setBackdropVisible(true);
       });
       expect(result.current.backdropKey).toBe(DEFAULT_BACKDROP_KEY);

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -51,9 +51,6 @@ export function makeMockFetchMethod(validUrl: string, bodyJson: any): typeof fet
     text: function (): Promise<string> {
       throw new Error("Function not implemented.");
     },
-    bytes: function (): Promise<Uint8Array> {
-      throw new Error("Function not implemented.");
-    },
   };
   return (url: string, _timeoutMs?: number, _options?: Object) => {
     if (url === validUrl) {

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -1,6 +1,19 @@
+import { DataTexture, RGBAFormat, Texture, UnsignedByteType } from "three";
+
+import {
+  ArraySource,
+  Dataset,
+  FeatureArrayType,
+  FeatureDataType,
+  featureTypeSpecs,
+  IArrayLoader,
+  ITextureImageLoader,
+} from "../src/colorizer";
+import { AnyManifestFile } from "../src/colorizer/utils/dataset_utils";
 import { fetchWithTimeout } from "../src/colorizer/utils/url_utils";
 
 export const ANY_ERROR = /[.]*/;
+export const DEFAULT_DATASET_PATH = "https://some-path.json";
 
 export async function sleep(timeoutMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, timeoutMs));
@@ -38,6 +51,9 @@ export function makeMockFetchMethod(validUrl: string, bodyJson: any): typeof fet
     text: function (): Promise<string> {
       throw new Error("Function not implemented.");
     },
+    bytes: function (): Promise<Uint8Array> {
+      throw new Error("Function not implemented.");
+    },
   };
   return (url: string, _timeoutMs?: number, _options?: Object) => {
     if (url === validUrl) {
@@ -52,3 +68,70 @@ export function makeMockFetchMethod(validUrl: string, bodyJson: any): typeof fet
     });
   };
 }
+
+export const makeMockAsyncLoader = <T>(url: string, manifestJson: T): ((url: string) => Promise<T>) => {
+  return async (inputUrl: string): Promise<T> => {
+    if (inputUrl !== url) {
+      throw new Error(`Input url '${inputUrl}' does not match expected url '${url}'.`);
+    }
+    return Promise.resolve(manifestJson);
+  };
+};
+
+export class MockFrameLoader implements ITextureImageLoader {
+  width: number;
+  height: number;
+
+  constructor(width: number = 1, height: number = 1) {
+    this.width = width;
+    this.height = height;
+  }
+
+  load(_url: string): Promise<Texture> {
+    return Promise.resolve(
+      new DataTexture(
+        new Uint8Array(this.width * this.height * 4),
+        this.width,
+        this.height,
+        RGBAFormat,
+        UnsignedByteType
+      )
+    );
+  }
+}
+
+export class MockArraySource<T extends FeatureDataType> implements ArraySource<T> {
+  private type: T;
+
+  constructor(type: T) {
+    this.type = type;
+  }
+
+  getBuffer<T extends FeatureDataType>(): FeatureArrayType[T] {
+    return new featureTypeSpecs[this.type].ArrayConstructor([]) as unknown as FeatureArrayType[T];
+  }
+  getTexture(): Texture {
+    return new Texture();
+  }
+  getMin(): number {
+    return 0;
+  }
+  getMax(): number {
+    return 1;
+  }
+}
+
+export class MockArrayLoader implements IArrayLoader {
+  dispose(): void {}
+
+  load<T extends FeatureDataType>(_url: string, type: T): Promise<ArraySource<T>> {
+    return Promise.resolve(new MockArraySource(type));
+  }
+}
+
+export const makeMockDataset = async (manifest: AnyManifestFile): Promise<Dataset> => {
+  const dataset = new Dataset(DEFAULT_DATASET_PATH, new MockFrameLoader(), new MockArrayLoader());
+  const mockLoader = makeMockAsyncLoader(DEFAULT_DATASET_PATH, manifest);
+  await dataset.open({ manifestLoader: mockLoader });
+  return dataset;
+};


### PR DESCRIPTION
Problem
=======
Mini-refactor to make Zustand state refactoring pt. 4 cleaner! This removes a TODO about using actual mocked `Dataset` classes.

*Estimated review size: small, <15 minutes, faster if skipping copied code*

Solution
========
- Moved utilities for making mock Dataset objects out of `Dataset.test.ts` and into shared utilities.
- Created mock dataset constants in test folder for the viewer state store.
