### PR TITLE
refactor: Moved feature thresholds into viewer state (state pt. 5)

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -173,7 +173,6 @@ function Viewer(): ReactElement {
   const setCategoricalPalette = useViewerStateStore((state) => state.setCategoricalPalette);
   const featureThresholds = useViewerStateStore((state) => state.thresholds);
   const setFeatureThresholds = useViewerStateStore((state) => state.setThresholds);
-  const inRangeLUT = useViewerStateStore((state) => state.inRangeLUT);
 
   const [playbackFps, setPlaybackFps] = useState(DEFAULT_PLAYBACK_FPS);
 
@@ -849,7 +848,6 @@ function Viewer(): ReactElement {
             isVisible={config.openTab === TabType.SCATTER_PLOT}
             isPlaying={timeControls.isPlaying() || isRecording}
             selectedFeatureKey={featureKey}
-            inRangeIds={inRangeLUT}
             viewerConfig={config}
             scatterPlotConfig={scatterPlotConfig}
             updateScatterPlotConfig={updateScatterPlotConfig}
@@ -1067,7 +1065,6 @@ function Viewer(): ReactElement {
                   config={config}
                   updateConfig={updateConfig}
                   onTrackClicked={onTrackClicked}
-                  inRangeLUT={inRangeLUT}
                   onMouseHover={(id: number): void => {
                     const isObject = id !== BACKGROUND_ID;
                     setShowObjectHoverInfo(isObject);

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -40,7 +40,7 @@ import {
   ViewerConfig,
 } from "./colorizer";
 import { AnalyticsEvent, triggerAnalyticsEvent } from "./colorizer/utils/analytics";
-import { thresholdMatchFinder, validateThresholds } from "./colorizer/utils/data_utils";
+import { thresholdMatchFinder } from "./colorizer/utils/data_utils";
 import {
   useAnnotations,
   useConstructor,
@@ -466,7 +466,6 @@ function Viewer(): ReactElement {
 
       setSelectedTrack(null);
       setDatasetOpen(true);
-      setFeatureThresholds(validateThresholds(newDataset, featureThresholds));
       console.log("Dataset metadata:", newDataset.metadata);
       console.log("Num Items:" + newDataset?.numObjects);
     },
@@ -603,11 +602,7 @@ function Viewer(): ReactElement {
     // fully implemented.
     const setupInitialParameters = async (): Promise<void> => {
       if (initialUrlParams.thresholds) {
-        if (dataset) {
-          setFeatureThresholds(validateThresholds(dataset, initialUrlParams.thresholds));
-        } else {
-          setFeatureThresholds(initialUrlParams.thresholds);
-        }
+        setFeatureThresholds(initialUrlParams.thresholds);
       }
       if (initialUrlParams.feature && dataset) {
         // Load feature (if unset, do nothing because replaceDataset already loads a default)
@@ -701,7 +696,6 @@ function Viewer(): ReactElement {
   const handleDatasetLoad = useCallback(
     (newCollection: Collection, newDatasetKey: string, newDataset: Dataset): void => {
       setCollection(newCollection);
-      setFeatureThresholds([]); // Clear when switching collections
       replaceDataset(newDataset, newDatasetKey);
     },
     [replaceDataset]

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -129,8 +129,6 @@ type CanvasWrapperProps = {
 
   selectedTrack: Track | null;
 
-  inRangeLUT?: Uint8Array;
-
   /** Called when the mouse hovers over the canvas; reports the currently hovered id. */
   onMouseHover?: (id: number) => void;
   /** Called when the mouse exits the canvas. */
@@ -148,7 +146,6 @@ const defaultProps: Partial<CanvasWrapperProps> = {
   onMouseHover() {},
   onMouseLeave() {},
   onTrackClicked: () => {},
-  inRangeLUT: new Uint8Array(0),
   maxWidthPx: 1400,
   maxHeightPx: 1000,
 };
@@ -172,6 +169,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       colorRamp: state.colorRamp,
       colorRampRange: state.colorRampRange,
       categoricalPalette: state.categoricalPalette,
+      inRangeLUT: state.inRangeLUT,
     }))
   );
 
@@ -308,8 +306,8 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   }, [props.config.outlierDrawSettings]);
 
   useMemo(() => {
-    canv.setInRangeLUT(props.inRangeLUT);
-  }, [props.inRangeLUT]);
+    canv.setInRangeLUT(store.inRangeLUT);
+  }, [store.inRangeLUT]);
 
   // Updated track-related settings
   useMemo(() => {

--- a/src/components/Tabs/FeatureThresholdsTab.tsx
+++ b/src/components/Tabs/FeatureThresholdsTab.tsx
@@ -2,6 +2,7 @@ import { CloseOutlined, FilterOutlined, SearchOutlined } from "@ant-design/icons
 import { Checkbox, List, Select } from "antd";
 import React, { ReactElement, ReactNode, useMemo, useRef, useState } from "react";
 import styled, { css } from "styled-components";
+import { useShallow } from "zustand/shallow";
 
 import { DropdownSVG } from "../../assets";
 import {
@@ -124,11 +125,13 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
   const { scrollShadowStyle, onScrollHandler, scrollRef } = useScrollShadow();
   const selectContainerRef = useRef<HTMLDivElement>(null);
 
-  const store = useViewerStateStore((state) => ({
-    thresholds: state.thresholds,
-    setThresholds: state.setThresholds,
-    dataset: state.dataset,
-  }));
+  const store = useViewerStateStore(
+    useShallow((state) => ({
+      thresholds: state.thresholds,
+      setThresholds: state.setThresholds,
+      dataset: state.dataset,
+    }))
+  );
 
   /** Converts a threshold to a unique key that can be used to look up its information later. Matches on feature key and unit. */
   const thresholdToKey = (threshold: FeatureThreshold): string => {

--- a/src/state/ViewerState.ts
+++ b/src/state/ViewerState.ts
@@ -7,18 +7,21 @@ import { BackdropSlice, createBackdropSlice } from "./slices/backdrop_slice";
 import { CollectionSlice, createCollectionSlice } from "./slices/collection_slice";
 import { addColorRampDerivedStateSubscribers, ColorRampSlice, createColorRampSlice } from "./slices/color_ramp_slice";
 import { createDatasetSlice, DatasetSlice } from "./slices/dataset_slice";
+import { addThresholdDerivedStateSubscribers, createThresholdSlice, ThresholdSlice } from "./slices/threshold_slice";
+import { SubscribableStore } from "./types";
 
 // The ViewerState is composed of many smaller slices, modules of related state,
 // actions, and selectors. See
 // https://github.com/pmndrs/zustand/blob/main/docs/guides/typescript.md#slices-pattern
 // for more details on the pattern.
-export type ViewerState = Spread<CollectionSlice & DatasetSlice & BackdropSlice & ColorRampSlice>;
+export type ViewerState = Spread<CollectionSlice & DatasetSlice & BackdropSlice & ColorRampSlice & ThresholdSlice>;
 
 export const viewerStateStoreCreator: StateCreator<ViewerState> = (...a) => ({
   ...createCollectionSlice(...a),
   ...createDatasetSlice(...a),
   ...createBackdropSlice(...a),
   ...createColorRampSlice(...a),
+  ...createThresholdSlice(...a),
 });
 
 /**
@@ -58,9 +61,12 @@ export const viewerStateStoreCreator: StateCreator<ViewerState> = (...a) => ({
  * );
  * ```
  */
-export const useViewerStateStore = create<ViewerState>()(subscribeWithSelector(viewerStateStoreCreator));
+export const useViewerStateStore: SubscribableStore<ViewerState> = create<ViewerState>()(
+  subscribeWithSelector(viewerStateStoreCreator)
+);
 
 addColorRampDerivedStateSubscribers(useViewerStateStore);
+addThresholdDerivedStateSubscribers(useViewerStateStore);
 
 // Adds compatibility with hot module reloading.
 // Adapted from https://github.com/pmndrs/zustand/discussions/827#discussioncomment-9843290

--- a/src/state/slices/color_ramp_slice.ts
+++ b/src/state/slices/color_ramp_slice.ts
@@ -183,8 +183,9 @@ export const addColorRampDerivedStateSubscribers = (
       } else if (dataset === null || featureKey === null) {
         return { colorRampRange: COLOR_RAMP_RANGE_DEFAULT };
       } else {
-        // Reset should occur. Reset to the range of the threshold (if the
-        // feature is thresholded on) or the feature range.
+        // Reset should occur. If a threshold is set on the selected feature,
+        // reset to the threshold range. Otherwise, reset to the feature data
+        // range.
         const featureData = dataset.getFeatureData(featureKey);
         if (!featureData) {
           throw new Error(

--- a/src/state/slices/color_ramp_slice.ts
+++ b/src/state/slices/color_ramp_slice.ts
@@ -142,8 +142,8 @@ export const addColorRampDerivedStateSubscribers = (
   // Update color ramp range if the threshold changes for the currently selected feature
   addDerivedStateSubscriber(
     store,
-    (state) => [state.thresholds],
-    ([thresholds], [prevThresholds]) => {
+    (state) => state.thresholds,
+    (thresholds, prevThresholds) => {
       const dataset = store.getState().dataset;
       const featureKey = store.getState().featureKey;
       if (dataset === null || featureKey === null) {
@@ -169,7 +169,7 @@ export const addColorRampDerivedStateSubscribers = (
           return { colorRampRange: [newThreshold.min, newThreshold.max] as [number, number] };
         }
       }
-      return;
+      return undefined;
     }
   );
 
@@ -179,7 +179,7 @@ export const addColorRampDerivedStateSubscribers = (
     (state) => ({ dataset: state.dataset, featureKey: state.featureKey }),
     ({ dataset, featureKey }) => {
       if (store.getState().keepColorRampRange) {
-        return;
+        return undefined;
       } else if (dataset === null || featureKey === null) {
         return { colorRampRange: COLOR_RAMP_RANGE_DEFAULT };
       } else {

--- a/src/state/slices/threshold_slice.ts
+++ b/src/state/slices/threshold_slice.ts
@@ -1,0 +1,38 @@
+import { StateCreator } from "zustand";
+
+import { FeatureThreshold } from "../../colorizer";
+import { getInRangeLUT } from "../../colorizer/utils/data_utils";
+import { SubscribableStore } from "../types";
+import { addDerivedStateSubscriber } from "../utils/store_utils";
+import { DatasetSlice } from "./dataset_slice";
+
+type ThresholdSliceState = {
+  thresholds: FeatureThreshold[];
+
+  // Derived state
+  /** Lookup table from object ID to whether it is in range (=1) or not (=0). */
+  inRangeLUT: Uint8Array;
+};
+
+type ThresholdSliceActions = {
+  setThresholds: (thresholds: FeatureThreshold[]) => void;
+};
+
+export type ThresholdSlice = ThresholdSliceState & ThresholdSliceActions;
+
+export const createThresholdSlice: StateCreator<ThresholdSlice, [], [], ThresholdSlice> = (set, _get) => ({
+  thresholds: [],
+  inRangeLUT: new Uint8Array(0),
+  setThresholds: (thresholds) => {
+    set({ thresholds });
+  },
+});
+
+export const addThresholdDerivedStateSubscribers = (store: SubscribableStore<ThresholdSlice & DatasetSlice>): void => {
+  addDerivedStateSubscriber(
+    store,
+    (state) => [state.thresholds, state.dataset],
+    // TODO: Use workers for calculation to avoid slowing UI thread
+    ([thresholds, dataset]) => ({ inRangeLUT: dataset ? getInRangeLUT(dataset, thresholds) : new Uint8Array(0) })
+  );
+};

--- a/src/state/slices/threshold_slice.ts
+++ b/src/state/slices/threshold_slice.ts
@@ -1,9 +1,10 @@
 import { StateCreator } from "zustand";
 
 import { FeatureThreshold } from "../../colorizer";
-import { getInRangeLUT } from "../../colorizer/utils/data_utils";
+import { getInRangeLUT, validateThresholds } from "../../colorizer/utils/data_utils";
 import { SubscribableStore } from "../types";
 import { addDerivedStateSubscriber } from "../utils/store_utils";
+import { CollectionSlice } from "./collection_slice";
 import { DatasetSlice } from "./dataset_slice";
 
 type ThresholdSliceState = {
@@ -20,19 +21,52 @@ type ThresholdSliceActions = {
 
 export type ThresholdSlice = ThresholdSliceState & ThresholdSliceActions;
 
-export const createThresholdSlice: StateCreator<ThresholdSlice, [], [], ThresholdSlice> = (set, _get) => ({
+export const createThresholdSlice: StateCreator<ThresholdSlice & DatasetSlice, [], [], ThresholdSlice> = (
+  set,
+  get
+) => ({
   thresholds: [],
   inRangeLUT: new Uint8Array(0),
   setThresholds: (thresholds) => {
-    set({ thresholds });
+    const dataset = get().dataset;
+    if (!dataset) {
+      set({ thresholds });
+    } else {
+      set({ thresholds: validateThresholds(dataset, thresholds) });
+    }
   },
 });
 
-export const addThresholdDerivedStateSubscribers = (store: SubscribableStore<ThresholdSlice & DatasetSlice>): void => {
+export const addThresholdDerivedStateSubscribers = (
+  store: SubscribableStore<ThresholdSlice & DatasetSlice & CollectionSlice>
+): void => {
+  // Compute in-range lookup table on thresholds or dataset change
+  // TODO: Use workers for calculation to avoid slowing UI thread
   addDerivedStateSubscriber(
     store,
     (state) => [state.thresholds, state.dataset],
-    // TODO: Use workers for calculation to avoid slowing UI thread
     ([thresholds, dataset]) => ({ inRangeLUT: dataset ? getInRangeLUT(dataset, thresholds) : new Uint8Array(0) })
+  );
+
+  // Validate thresholds on dataset change
+  addDerivedStateSubscriber(
+    store,
+    (state) => [state.dataset],
+    ([dataset]) => {
+      const thresholds = store.getState().thresholds;
+      if (dataset) {
+        return { thresholds: validateThresholds(dataset, thresholds) };
+      }
+      return;
+    }
+  );
+
+  // Clear thresholds on collections change
+  // TODO: Show warning before switching collections if thresholds will be lost
+  // TODO: Should we clear this at all?
+  addDerivedStateSubscriber(
+    store,
+    (state) => [state.collection],
+    () => ({ thresholds: [] })
   );
 };

--- a/src/state/slices/threshold_slice.ts
+++ b/src/state/slices/threshold_slice.ts
@@ -51,13 +51,13 @@ export const addThresholdDerivedStateSubscribers = (
   // Validate thresholds on dataset change
   addDerivedStateSubscriber(
     store,
-    (state) => [state.dataset],
-    ([dataset]) => {
+    (state) => state.dataset,
+    (dataset) => {
       const thresholds = store.getState().thresholds;
       if (dataset) {
         return { thresholds: validateThresholds(dataset, thresholds) };
       }
-      return;
+      return undefined;
     }
   );
 
@@ -66,7 +66,7 @@ export const addThresholdDerivedStateSubscribers = (
   // TODO: Should we clear this at all?
   addDerivedStateSubscriber(
     store,
-    (state) => [state.collection],
+    (state) => state.collection,
     () => ({ thresholds: [] })
   );
 };

--- a/tests/state/ViewerState/color_ramp_slice.test.ts
+++ b/tests/state/ViewerState/color_ramp_slice.test.ts
@@ -217,6 +217,7 @@ describe("useViewerStateStore: ColorRampSlice", () => {
       act(() => {
         result.current.setDataset("mockDataset", MOCK_DATASET);
         result.current.setFeatureKey(MockFeatureKeys.FEATURE1);
+        result.current.setThresholds([threshold]);
         result.current.setColorRampRange([56, 78]);
       });
       expect(result.current.colorRampRange).toStrictEqual([56, 78]);

--- a/tests/state/ViewerState/color_ramp_slice.test.ts
+++ b/tests/state/ViewerState/color_ramp_slice.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import { FeatureThreshold, KNOWN_CATEGORICAL_PALETTES, KNOWN_COLOR_RAMPS, ThresholdType } from "../../../src/colorizer";
 import { ANY_ERROR } from "../../test_utils";
-import { MOCK_DATASET, MOCK_FEATURE_KEY_TO_UNIT, MockFeatureKeys } from "./constants";
+import { MOCK_DATASET, MOCK_FEATURE_DATA, MockFeatureKeys } from "./constants";
 
 import { useViewerStateStore } from "../../../src/state/ViewerState";
 
@@ -185,7 +185,7 @@ describe("useViewerStateStore: ColorRampSlice", () => {
       const { result } = renderHook(() => useViewerStateStore());
       const threshold: FeatureThreshold = {
         featureKey: MockFeatureKeys.FEATURE2,
-        unit: MOCK_FEATURE_KEY_TO_UNIT[MockFeatureKeys.FEATURE2],
+        unit: MOCK_FEATURE_DATA[MockFeatureKeys.FEATURE2].unit!,
         type: ThresholdType.NUMERIC,
         min: 56.5,
         max: 23.3,
@@ -208,7 +208,7 @@ describe("useViewerStateStore: ColorRampSlice", () => {
       const { result } = renderHook(() => useViewerStateStore());
       const threshold: FeatureThreshold = {
         featureKey: MockFeatureKeys.FEATURE1,
-        unit: MOCK_FEATURE_KEY_TO_UNIT[MockFeatureKeys.FEATURE1],
+        unit: MOCK_FEATURE_DATA[MockFeatureKeys.FEATURE1].unit!,
         type: ThresholdType.NUMERIC,
         min: 10,
         max: 20,

--- a/tests/state/ViewerState/constants.ts
+++ b/tests/state/ViewerState/constants.ts
@@ -1,5 +1,5 @@
 import { FeatureDataType } from "../../../src/colorizer";
-import { AnyManifestFile } from "../../../src/colorizer/utils/dataset_utils";
+import { AnyManifestFile, ManifestFile } from "../../../src/colorizer/utils/dataset_utils";
 import { DEFAULT_DATASET_DIR, makeMockDataset, MockArrayLoader, MockArraySource } from "../../test_utils";
 
 export enum MockFeatureKeys {
@@ -8,10 +8,35 @@ export enum MockFeatureKeys {
   FEATURE3 = "feature3",
 }
 
-export const MOCK_FEATURE_KEY_TO_UNIT = {
-  [MockFeatureKeys.FEATURE1]: "meters",
-  [MockFeatureKeys.FEATURE2]: "(m)",
-  [MockFeatureKeys.FEATURE3]: "",
+export const MOCK_FEATURE_DATA: Record<MockFeatureKeys, ManifestFile["features"][0]> = {
+  [MockFeatureKeys.FEATURE1]: {
+    key: MockFeatureKeys.FEATURE1,
+    name: "Feature1",
+    data: "feature1.json",
+    unit: "meters",
+    type: "continuous",
+    min: 0,
+    max: 1,
+  },
+  [MockFeatureKeys.FEATURE2]: {
+    key: MockFeatureKeys.FEATURE2,
+    name: "Feature2",
+    data: "feature2.json",
+    unit: "(m)",
+    type: "discrete",
+    min: 0,
+    max: 100,
+  },
+  [MockFeatureKeys.FEATURE3]: {
+    key: MockFeatureKeys.FEATURE3,
+    name: "feature3",
+    data: "feature3.json",
+    type: "categorical",
+    unit: "",
+    categories: ["small", "medium", "large"],
+    min: 0,
+    max: 2,
+  },
 };
 
 export const DEFAULT_BACKDROP_KEY = "test_backdrop_key";
@@ -19,34 +44,9 @@ export const DEFAULT_INITIAL_FEATURE_KEY = MockFeatureKeys.FEATURE1;
 
 const MOCK_DATASET_MANIFEST: AnyManifestFile = {
   features: [
-    {
-      key: MockFeatureKeys.FEATURE1,
-      name: "Feature1",
-      data: "feature1.json",
-      unit: MOCK_FEATURE_KEY_TO_UNIT[MockFeatureKeys.FEATURE1],
-      type: "continuous",
-      min: 0,
-      max: 1,
-    },
-    {
-      key: MockFeatureKeys.FEATURE2,
-      name: "Feature2",
-      data: "feature2.json",
-      unit: MOCK_FEATURE_KEY_TO_UNIT[MockFeatureKeys.FEATURE2],
-      type: "discrete",
-      min: 0,
-      max: 100,
-    },
-    {
-      key: MockFeatureKeys.FEATURE3,
-      name: "feature3",
-      data: "feature3.json",
-      type: "categorical",
-      unit: MOCK_FEATURE_KEY_TO_UNIT[MockFeatureKeys.FEATURE3],
-      categories: ["small", "medium", "large"],
-      min: 0,
-      max: 2,
-    },
+    MOCK_FEATURE_DATA[MockFeatureKeys.FEATURE1],
+    MOCK_FEATURE_DATA[MockFeatureKeys.FEATURE2],
+    MOCK_FEATURE_DATA[MockFeatureKeys.FEATURE3],
   ],
   frames: ["frame0.png"],
   backdrops: [{ name: DEFAULT_BACKDROP_KEY, key: DEFAULT_BACKDROP_KEY, frames: ["frame0.png"] }],

--- a/tests/state/ViewerState/constants.ts
+++ b/tests/state/ViewerState/constants.ts
@@ -7,6 +7,12 @@ export enum MockFeatureKeys {
   FEATURE3 = "feature3",
 }
 
+export const MOCK_FEATURE_KEY_TO_UNIT = {
+  [MockFeatureKeys.FEATURE1]: "meters",
+  [MockFeatureKeys.FEATURE2]: "(m)",
+  [MockFeatureKeys.FEATURE3]: "",
+};
+
 export const DEFAULT_BACKDROP_KEY = "test_backdrop_key";
 export const DEFAULT_INITIAL_FEATURE_KEY = MockFeatureKeys.FEATURE1;
 
@@ -17,7 +23,7 @@ const MOCK_DATASET_MANIFEST: AnyManifestFile = {
       key: MockFeatureKeys.FEATURE1,
       name: "Feature1",
       data: "feature1.json",
-      unit: "meters",
+      unit: MOCK_FEATURE_KEY_TO_UNIT[MockFeatureKeys.FEATURE1],
       type: "continuous",
       min: 0,
       max: 1,
@@ -26,7 +32,7 @@ const MOCK_DATASET_MANIFEST: AnyManifestFile = {
       key: MockFeatureKeys.FEATURE2,
       name: "Feature2",
       data: "feature2.json",
-      unit: "(m)",
+      unit: MOCK_FEATURE_KEY_TO_UNIT[MockFeatureKeys.FEATURE2],
       type: "discrete",
       min: 0,
       max: 100,
@@ -36,6 +42,7 @@ const MOCK_DATASET_MANIFEST: AnyManifestFile = {
       name: "feature3",
       data: "feature3.json",
       type: "categorical",
+      unit: MOCK_FEATURE_KEY_TO_UNIT[MockFeatureKeys.FEATURE3],
       categories: ["small", "medium", "large"],
       min: 0,
       max: 2,

--- a/tests/state/ViewerState/constants.ts
+++ b/tests/state/ViewerState/constants.ts
@@ -1,5 +1,6 @@
+import { FeatureDataType } from "../../../src/colorizer";
 import { AnyManifestFile } from "../../../src/colorizer/utils/dataset_utils";
-import { makeMockDataset } from "../../test_utils";
+import { DEFAULT_DATASET_DIR, makeMockDataset, MockArrayLoader, MockArraySource } from "../../test_utils";
 
 export enum MockFeatureKeys {
   FEATURE1 = "feature1",
@@ -17,7 +18,6 @@ export const DEFAULT_BACKDROP_KEY = "test_backdrop_key";
 export const DEFAULT_INITIAL_FEATURE_KEY = MockFeatureKeys.FEATURE1;
 
 const MOCK_DATASET_MANIFEST: AnyManifestFile = {
-  frames: ["frame0.json"],
   features: [
     {
       key: MockFeatureKeys.FEATURE1,
@@ -48,10 +48,36 @@ const MOCK_DATASET_MANIFEST: AnyManifestFile = {
       max: 2,
     },
   ],
-  backdrops: [{ name: DEFAULT_BACKDROP_KEY, key: DEFAULT_BACKDROP_KEY, frames: ["frame0.json"] }],
+  frames: ["frame0.png"],
+  backdrops: [{ name: DEFAULT_BACKDROP_KEY, key: DEFAULT_BACKDROP_KEY, frames: ["frame0.png"] }],
+  times: "times.json",
+  tracks: "tracks.json",
 };
 
-export const MOCK_DATASET = await makeMockDataset(MOCK_DATASET_MANIFEST);
+const mockArrayLoader = new MockArrayLoader({
+  [DEFAULT_DATASET_DIR + "times.json"]: new MockArraySource(
+    FeatureDataType.U32,
+    new Uint32Array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+  ),
+  [DEFAULT_DATASET_DIR + "tracks.json"]: new MockArraySource(
+    FeatureDataType.U32,
+    new Uint32Array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+  ),
+  [DEFAULT_DATASET_DIR + "feature1.json"]: new MockArraySource(
+    FeatureDataType.F32,
+    new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+  ),
+  [DEFAULT_DATASET_DIR + "feature2.json"]: new MockArraySource(
+    FeatureDataType.F32,
+    new Float32Array([0, 10, 20, 30, 40, 50, 60, 70, 80])
+  ),
+  [DEFAULT_DATASET_DIR + "feature3.json"]: new MockArraySource(
+    FeatureDataType.F32,
+    new Float32Array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+  ),
+});
+
+export const MOCK_DATASET = await makeMockDataset(MOCK_DATASET_MANIFEST, mockArrayLoader);
 
 export const MOCK_DATASET_WITHOUT_BACKDROP = await makeMockDataset({
   ...MOCK_DATASET_MANIFEST,

--- a/tests/state/ViewerState/threshold_slice.test.ts
+++ b/tests/state/ViewerState/threshold_slice.test.ts
@@ -22,6 +22,7 @@ const OUTDATED_THRESHOLDS: FeatureThreshold[] = [
 ];
 
 const VALIDATED_THRESHOLDS = validateThresholds(MOCK_DATASET, OUTDATED_THRESHOLDS);
+const EXPECTED_IN_RANGE_LUT = new Uint8Array([0, 0, 0, 1, 1, 1, 1, 0, 0]);
 
 describe("ThresholdSlice", () => {
   describe("setThresholds", () => {
@@ -85,8 +86,7 @@ describe("ThresholdSlice", () => {
         result.current.setDataset("some-dataset", MOCK_DATASET);
         result.current.setThresholds(VALIDATED_THRESHOLDS);
       });
-      // TODO: Need to have mock dataset actually retrieve data
-      expect(result.current.inRangeLUT).to.deep.equal(new Uint8Array(0));
+      expect(result.current.inRangeLUT).to.deep.equal(EXPECTED_IN_RANGE_LUT);
     });
 
     it("updates inRangeLUT on dataset change", () => {
@@ -100,8 +100,7 @@ describe("ThresholdSlice", () => {
       act(() => {
         result.current.setDataset("some-dataset", MOCK_DATASET);
       });
-      // TODO: Need to have mock dataset actually retrieve data
-      expect(result.current.inRangeLUT).to.deep.equal(new Uint8Array(0));
+      expect(result.current.inRangeLUT).to.deep.equal(EXPECTED_IN_RANGE_LUT);
     });
   });
 });

--- a/tests/state/ViewerState/threshold_slice.test.ts
+++ b/tests/state/ViewerState/threshold_slice.test.ts
@@ -1,0 +1,107 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { FeatureThreshold, ThresholdType } from "../../../src/colorizer";
+import { validateThresholds } from "../../../src/colorizer/utils/data_utils";
+import { MOCK_DATASET, MockFeatureKeys } from "./constants";
+
+import Collection from "../../../src/colorizer/Collection";
+import { useViewerStateStore } from "../../../src/state/ViewerState";
+
+const OUTDATED_THRESHOLDS: FeatureThreshold[] = [
+  // Will be changed to numeric
+  {
+    featureKey: MockFeatureKeys.FEATURE1,
+    unit: "meters",
+    type: ThresholdType.CATEGORICAL,
+    enabledCategories: [true, false],
+  },
+  { featureKey: MockFeatureKeys.FEATURE2, unit: "(m)", type: ThresholdType.NUMERIC, min: 24, max: 60 },
+  // Will be changed to categorical
+  { featureKey: MockFeatureKeys.FEATURE3, unit: "", type: ThresholdType.NUMERIC, min: 0, max: 1 },
+];
+
+const VALIDATED_THRESHOLDS = validateThresholds(MOCK_DATASET, OUTDATED_THRESHOLDS);
+
+describe("ThresholdSlice", () => {
+  describe("setThresholds", () => {
+    it("sets the thresholds", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      act(() => {
+        result.current.setThresholds(OUTDATED_THRESHOLDS);
+      });
+      expect(result.current.thresholds).to.deep.equal(OUTDATED_THRESHOLDS);
+    });
+
+    it("sets and validates thresholds when Dataset is set", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      act(() => {
+        result.current.setDataset("some-dataset", MOCK_DATASET);
+        result.current.setThresholds(OUTDATED_THRESHOLDS);
+      });
+      expect(result.current.thresholds).to.deep.equal(VALIDATED_THRESHOLDS);
+    });
+  });
+
+  it("clears threshold on collections change", () => {
+    const { result } = renderHook(() => useViewerStateStore());
+    act(() => {
+      result.current.setThresholds(OUTDATED_THRESHOLDS);
+    });
+    expect(result.current.thresholds).to.deep.equal(OUTDATED_THRESHOLDS);
+    act(() => {
+      // TODO: Replace with actual Collection
+      result.current.setCollection({} as unknown as Collection);
+    });
+    expect(result.current.thresholds).to.deep.equal([]);
+  });
+
+  it("validates thresholds on dataset change", () => {
+    const { result } = renderHook(() => useViewerStateStore());
+    act(() => {
+      result.current.setThresholds(OUTDATED_THRESHOLDS);
+    });
+    expect(result.current.thresholds).to.deep.equal(OUTDATED_THRESHOLDS);
+    act(() => {
+      result.current.setDataset("some-dataset", MOCK_DATASET);
+    });
+    expect(result.current.thresholds).to.deep.equal(VALIDATED_THRESHOLDS);
+  });
+
+  describe("inRangeLUT", () => {
+    it("sets default inRangeLUT if dataset is not set", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      expect(result.current.inRangeLUT).to.deep.equal(new Uint8Array(0));
+      act(() => {
+        result.current.setThresholds(OUTDATED_THRESHOLDS);
+      });
+      expect(result.current.inRangeLUT).to.deep.equal(new Uint8Array(0));
+    });
+
+    it("updates inRangeLUT on threshold change", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      expect(result.current.inRangeLUT).to.deep.equal(new Uint8Array(0));
+      act(() => {
+        result.current.setDataset("some-dataset", MOCK_DATASET);
+        result.current.setThresholds(VALIDATED_THRESHOLDS);
+      });
+      // TODO: Need to have mock dataset actually retrieve data
+      expect(result.current.inRangeLUT).to.deep.equal(new Uint8Array(0));
+    });
+
+    it("updates inRangeLUT on dataset change", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      act(() => {
+        result.current.setThresholds(VALIDATED_THRESHOLDS);
+      });
+      expect(result.current.inRangeLUT).to.deep.equal(new Uint8Array(0));
+
+      // Set dataset
+      act(() => {
+        result.current.setDataset("some-dataset", MOCK_DATASET);
+      });
+      // TODO: Need to have mock dataset actually retrieve data
+      expect(result.current.inRangeLUT).to.deep.equal(new Uint8Array(0));
+    });
+  });
+});

--- a/tests/state/ViewerState/threshold_slice.test.ts
+++ b/tests/state/ViewerState/threshold_slice.test.ts
@@ -23,6 +23,7 @@ const OUTDATED_THRESHOLDS: FeatureThreshold[] = [
 
 const VALIDATED_THRESHOLDS = validateThresholds(MOCK_DATASET, OUTDATED_THRESHOLDS);
 const EXPECTED_IN_RANGE_LUT = new Uint8Array([0, 0, 0, 1, 1, 1, 1, 0, 0]);
+const EXPECTED_IN_RANGE_LUT_NO_THRESHOLD = new Uint8Array([1, 1, 1, 1, 1, 1, 1, 1, 1]);
 
 describe("ThresholdSlice", () => {
   describe("setThresholds", () => {
@@ -81,9 +82,11 @@ describe("ThresholdSlice", () => {
 
     it("updates inRangeLUT on threshold change", () => {
       const { result } = renderHook(() => useViewerStateStore());
-      expect(result.current.inRangeLUT).to.deep.equal(new Uint8Array(0));
       act(() => {
         result.current.setDataset("some-dataset", MOCK_DATASET);
+      });
+      expect(result.current.inRangeLUT).to.deep.equal(EXPECTED_IN_RANGE_LUT_NO_THRESHOLD);
+      act(() => {
         result.current.setThresholds(VALIDATED_THRESHOLDS);
       });
       expect(result.current.inRangeLUT).to.deep.equal(EXPECTED_IN_RANGE_LUT);
@@ -95,8 +98,6 @@ describe("ThresholdSlice", () => {
         result.current.setThresholds(VALIDATED_THRESHOLDS);
       });
       expect(result.current.inRangeLUT).to.deep.equal(new Uint8Array(0));
-
-      // Set dataset
       act(() => {
         result.current.setDataset("some-dataset", MOCK_DATASET);
       });

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -13,7 +13,8 @@ import { AnyManifestFile } from "../src/colorizer/utils/dataset_utils";
 import { fetchWithTimeout } from "../src/colorizer/utils/url_utils";
 
 export const ANY_ERROR = /[.]*/;
-export const DEFAULT_DATASET_PATH = "https://some-path.json";
+export const DEFAULT_DATASET_DIR = "https://some-path/";
+export const DEFAULT_DATASET_PATH = "https://some-path/manifest.json";
 
 export async function sleep(timeoutMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, timeoutMs));
@@ -98,14 +99,14 @@ export class MockFrameLoader implements ITextureImageLoader {
 }
 
 export class MockArraySource<T extends FeatureDataType> implements ArraySource<T> {
-  private type: T;
+  private data: FeatureArrayType[T];
 
-  constructor(type: T) {
-    this.type = type;
+  constructor(type: T, data: FeatureArrayType[T] = new featureTypeSpecs[type].ArrayConstructor([])) {
+    this.data = data;
   }
 
   getBuffer<T extends FeatureDataType>(): FeatureArrayType[T] {
-    return new featureTypeSpecs[this.type].ArrayConstructor([]) as unknown as FeatureArrayType[T];
+    return this.data as unknown as FeatureArrayType[T];
   }
   getTexture(): Texture {
     return new Texture();
@@ -119,15 +120,27 @@ export class MockArraySource<T extends FeatureDataType> implements ArraySource<T
 }
 
 export class MockArrayLoader implements IArrayLoader {
+  urlToMockData: { [url: string]: MockArraySource<any> } = {};
+
+  constructor(urlToMockData: { [url: string]: MockArraySource<any> } = {}) {
+    this.urlToMockData = urlToMockData;
+  }
+
   dispose(): void {}
 
-  load<T extends FeatureDataType>(_url: string, type: T): Promise<ArraySource<T>> {
+  load<T extends FeatureDataType>(url: string, type: T): Promise<ArraySource<T>> {
+    if (this.urlToMockData[url]) {
+      return Promise.resolve(this.urlToMockData[url]);
+    }
     return Promise.resolve(new MockArraySource(type));
   }
 }
 
-export const makeMockDataset = async (manifest: AnyManifestFile): Promise<Dataset> => {
-  const dataset = new Dataset(DEFAULT_DATASET_PATH, new MockFrameLoader(), new MockArrayLoader());
+export const makeMockDataset = async (
+  manifest: AnyManifestFile,
+  loader: MockArrayLoader = new MockArrayLoader()
+): Promise<Dataset> => {
+  const dataset = new Dataset(DEFAULT_DATASET_PATH, new MockFrameLoader(), loader);
   const mockLoader = makeMockAsyncLoader(DEFAULT_DATASET_PATH, manifest);
   await dataset.open({ manifestLoader: mockLoader });
   return dataset;


### PR DESCRIPTION
Problem
=======
Part 5 of ??? for #492, "refactor state management."

This change moves the feature thresholds into shared viewer state.

*Estimated review size: medium, 30-40 minutes*

Solution
========
- Changes the `mockDataset` test utility to allow the mock Dataset to load mock data.
- Moved feature thresholds and inRangeLUT calculation into the `useViewerStateStore`.
- Moved logic for syncing feature thresholds with Dataset and Collection into `useViewerStateStore`.
- Updated color ramp range to sync with feature thresholds.
- Added unit tests for new threshold and color ramp behavior.

Steps to Verify:
----------------
1. Open the PR preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-580/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&feature=volume&t=4&filters=volume%3A%25CE%25BCm%25C2%25B3%3A43.818%3A1004.818%2Cheight%3A%25CE%25BCm%3A3.250%3A14.733
2. Switch to the filters tab. Add a filter for the default feature (Volume).
3. Change the filter range. The color ramp should update in sync.
4. Switch to another dataset. The thresholds should remain onscreen.
5. Switch to a different collection. The filters should be cleared:  https://raw.githubusercontent.com/allen-cell-animated/colorizer-data/refs/heads/main/documentation/example_dataset/manifest.json

Screenshots (optional):
-----------------------

**Video talk-through (🔊):**

https://github.com/user-attachments/assets/7d11cf87-50c4-41d3-85e8-f68aaa718a2d

