### PR TITLE
fix: Fixed bug where selected object outline would flicker during playback

### DIFF
--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -163,6 +163,7 @@ export default class ColorizeCanvas {
   protected colorMapRangeMax: number;
   protected categoricalPalette: ColorRamp;
   private currentFrame: number;
+  private pendingFrame: number;
 
   private onFrameChangeCallback: (isMissing: boolean) => void;
 
@@ -232,6 +233,7 @@ export default class ColorizeCanvas {
     this.colorMapRangeMin = 0;
     this.colorMapRangeMax = 0;
     this.currentFrame = 0;
+    this.pendingFrame = 0;
 
     this.frameSizeInCanvasCoordinates = new Vector2(1, 1);
     this.frameToCanvasCoordinates = new Vector2(1, 1);
@@ -355,6 +357,7 @@ export default class ColorizeCanvas {
 
     const frame = this.currentFrame;
     this.currentFrame = -1;
+    this.pendingFrame = -1;
     await this.setFrame(frame);
     this.updateScaling(this.dataset.frameResolution, this.canvasResolution);
     this.vectorField.setDataset(dataset);
@@ -597,7 +600,7 @@ export default class ColorizeCanvas {
       return;
     }
     // New frame, so load the frame data.
-    this.currentFrame = index;
+    this.pendingFrame = index;
     let backdropPromise = undefined;
     if (this.selectedBackdropKey && this.dataset?.hasBackdrop(this.selectedBackdropKey)) {
       backdropPromise = this.dataset?.loadBackdrop(this.selectedBackdropKey, index);
@@ -606,7 +609,7 @@ export default class ColorizeCanvas {
     const result = await Promise.allSettled([framePromise, backdropPromise]);
     const [frame, backdrop] = result;
 
-    if (this.currentFrame !== index) {
+    if (this.pendingFrame !== index) {
       // This load request has been superceded by a request for another frame, which has already loaded in image data.
       // Drop this request.
       return;
@@ -647,6 +650,7 @@ export default class ColorizeCanvas {
     this.onFrameChangeCallback(isMissingFile);
     // Force rescale in case frame dimensions changed
     this.updateScaling(this.dataset?.frameResolution || null, this.canvasResolution);
+    this.currentFrame = index;
     this.vectorField.setFrame(this.currentFrame);
   }
 


### PR DESCRIPTION
Problem
=======

Closes #432, "outlines on selected cell flicker during playback."

*Estimated review size: tiny, 5 minutes*

Solution
========
What I/we did to solve this problem

with @pairperson1

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* This change requires a documentation update
* This change requires updated or new tests

Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
2. other important file

Thanks for contributing!
