### PR TITLE
refactor: Moved `backdropKey`, changed store access to use inline selector pattern (state pt. 10)

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -88,18 +88,13 @@ function Viewer(): ReactElement {
     return canvas;
   });
 
-  const store = useViewerStateStore(
-    useShallow((state) => ({
-      dataset: state.dataset,
-      datasetKey: state.datasetKey,
-      featureKey: state.featureKey,
-      collection: state.collection,
-      setCollection: state.setCollection,
-      setFeatureKey: state.setFeatureKey,
-      setDataset: state.setDataset,
-    }))
-  );
-  const { dataset, datasetKey, featureKey, collection, setCollection, setDataset, setFeatureKey } = store;
+  const collection = useViewerStateStore((state) => state.collection);
+  const dataset = useViewerStateStore((state) => state.dataset);
+  const datasetKey = useViewerStateStore((state) => state.datasetKey);
+  const featureKey = useViewerStateStore((state) => state.featureKey);
+  const setCollection = useViewerStateStore((state) => state.setCollection);
+  const setDataset = useViewerStateStore((state) => state.setDataset);
+  const setFeatureKey = useViewerStateStore((state) => state.setFeatureKey);
 
   const isFeatureSelected = dataset !== null && featureKey !== null;
   const isFeatureCategorical = isFeatureSelected && dataset.isFeatureCategorical(featureKey);
@@ -600,7 +595,7 @@ function Viewer(): ReactElement {
       const backdropKey = initialUrlParams.selectedBackdropKey;
       if (backdropKey) {
         if (dataset?.hasBackdrop(backdropKey)) {
-          setSelectedBackdropKey(dataset, backdropKey);
+          setSelectedBackdropKey(backdropKey);
         }
       }
       if (initialUrlParams.config) {

--- a/src/components/CategoricalColorPicker.tsx
+++ b/src/components/CategoricalColorPicker.tsx
@@ -3,7 +3,6 @@ import { Color as AntColor } from "antd/es/color-picker/color";
 import React, { ReactElement, useMemo } from "react";
 import styled from "styled-components";
 import { Color, ColorRepresentation } from "three";
-import { useShallow } from "zustand/shallow";
 
 import { FlexRow, FlexRowAlignCenter } from "../styles/utils";
 
@@ -50,22 +49,19 @@ const ColorPickerContainer = styled(FlexRow)<{
 
 export default function CategoricalColorPicker(inputProps: CategoricalColorPickerProps): ReactElement {
   const props = { ...defaultProps, ...inputProps } as Required<CategoricalColorPickerProps>;
-  const store = useViewerStateStore(
-    useShallow((state) => ({
-      categoricalPalette: state.categoricalPalette,
-      setCategoricalPalette: state.setCategoricalPalette,
-    }))
-  );
+
+  const categoricalPalette = useViewerStateStore((state) => state.categoricalPalette);
+  const setCategoricalPalette = useViewerStateStore((state) => state.setCategoricalPalette);
 
   const colorPickers = useMemo(() => {
     const elements = [];
     for (let i = 0; i < props.categories.length; i++) {
-      const color = store.categoricalPalette[i];
+      const color = categoricalPalette[i];
       const label = props.categories[i];
       const onChange = (_value: AntColor, hex: string): void => {
-        const newPalette = [...store.categoricalPalette];
+        const newPalette = [...categoricalPalette];
         newPalette[i] = new Color(hex as ColorRepresentation);
-        store.setCategoricalPalette(newPalette);
+        setCategoricalPalette(newPalette);
       };
 
       // Make the color picker component

--- a/src/components/Tabs/PlotTab.tsx
+++ b/src/components/Tabs/PlotTab.tsx
@@ -2,7 +2,6 @@ import { SearchOutlined } from "@ant-design/icons";
 import { Input } from "antd";
 import React, { ReactElement, useEffect, useState } from "react";
 import styled from "styled-components";
-import { useShallow } from "zustand/shallow";
 
 import { useViewerStateStore } from "../../state";
 import { FlexRowAlignCenter, NoSpinnerContainer } from "../../styles/utils";
@@ -31,17 +30,13 @@ type PlotTabProps = {
 };
 
 export default function PlotTab(props: PlotTabProps): ReactElement {
-  const store = useViewerStateStore(
-    useShallow((state) => ({
-      currentFrame: state.currentFrame,
-      pendingFrame: state.pendingFrame,
-      dataset: state.dataset,
-      featureKey: state.featureKey,
-      selectedTrack: state.track,
-      setFrame: state.setFrame,
-      setTrack: state.setTrack,
-    }))
-  );
+  const currentFrame = useViewerStateStore((state) => state.currentFrame);
+  const dataset = useViewerStateStore((state) => state.dataset);
+  const featureKey = useViewerStateStore((state) => state.featureKey);
+  const pendingFrame = useViewerStateStore((state) => state.pendingFrame);
+  const selectedTrack = useViewerStateStore((state) => state.track);
+  const setFrame = useViewerStateStore((state) => state.setFrame);
+  const setTrack = useViewerStateStore((state) => state.setTrack);
 
   // Sync track searchbox with selected track
   useEffect(() => {
@@ -59,18 +54,18 @@ export default function PlotTab(props: PlotTabProps): ReactElement {
   }, []);
 
   const [findTrackInput, setFindTrackInput] = useState("");
-  const isLoading = store.currentFrame !== store.pendingFrame;
+  const isLoading = currentFrame !== pendingFrame;
 
   const searchForTrack = (): void => {
-    if (findTrackInput === "" || !store.dataset) {
+    if (findTrackInput === "" || !dataset) {
       return;
     }
     const trackId = parseInt(findTrackInput, 10);
-    const track = store.dataset.getTrack(trackId);
+    const track = dataset.getTrack(trackId);
     // TODO: Show error text if track is not found?
     if (track) {
-      store.setTrack(track);
-      store.setFrame(track.times[0]);
+      setTrack(track);
+      setFrame(track.times[0]);
     }
   };
 
@@ -100,11 +95,11 @@ export default function PlotTab(props: PlotTabProps): ReactElement {
       <div>
         <LoadingSpinner loading={isLoading}>
           <PlotWrapper
-            setFrame={store.setFrame}
-            frame={store.currentFrame}
-            dataset={store.dataset}
-            featureKey={store.featureKey}
-            selectedTrack={store.selectedTrack}
+            setFrame={setFrame}
+            frame={currentFrame}
+            dataset={dataset}
+            featureKey={featureKey}
+            selectedTrack={selectedTrack}
           />
         </LoadingSpinner>
       </div>

--- a/src/components/Tabs/SettingsTab.tsx
+++ b/src/components/Tabs/SettingsTab.tsx
@@ -83,7 +83,7 @@ export default function SettingsTab(): ReactElement {
             <SelectionDropdown
               selected={selectedBackdropKey}
               items={backdropOptions}
-              onChange={(key) => dataset && setBackdropKey(dataset, key)}
+              onChange={(key) => dataset && setBackdropKey(key)}
               disabled={isBackdropOptionsDisabled}
             />
           </SettingsItem>

--- a/src/state/ViewerState.ts
+++ b/src/state/ViewerState.ts
@@ -3,7 +3,7 @@ import { StateCreator } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 
 import { Spread } from "../colorizer/utils/type_utils";
-import { BackdropSlice, createBackdropSlice } from "./slices/backdrop_slice";
+import { addBackdropDerivedStateSubscribers, BackdropSlice, createBackdropSlice } from "./slices/backdrop_slice";
 import { CollectionSlice, createCollectionSlice } from "./slices/collection_slice";
 import { addColorRampDerivedStateSubscribers, ColorRampSlice, createColorRampSlice } from "./slices/color_ramp_slice";
 import { ConfigSlice, createConfigSlice } from "./slices/config_slice";
@@ -91,6 +91,7 @@ export const useViewerStateStore: SubscribableStore<ViewerState> = create<Viewer
   subscribeWithSelector(viewerStateStoreCreator)
 );
 
+addBackdropDerivedStateSubscribers(useViewerStateStore);
 addColorRampDerivedStateSubscribers(useViewerStateStore);
 addScatterPlotSliceDerivedStateSubscribers(useViewerStateStore);
 addThresholdDerivedStateSubscribers(useViewerStateStore);

--- a/src/state/slices/backdrop_slice.ts
+++ b/src/state/slices/backdrop_slice.ts
@@ -75,6 +75,6 @@ export const addBackdropDerivedStateSubscribers = (store: SubscribableStore<Back
   // Hide backdrop when backdrop key is null
   store.subscribe(
     (state) => state.backdropKey,
-    (backdropKey) => store.setState({ backdropVisible: backdropKey !== null })
+    (backdropKey) => store.setState({ backdropVisible: store.getState().backdropVisible && backdropKey !== null })
   );
 };

--- a/src/state/slices/backdrop_slice.ts
+++ b/src/state/slices/backdrop_slice.ts
@@ -11,14 +11,11 @@ import {
   BACKDROP_SATURATION_MAX,
   BACKDROP_SATURATION_MIN,
 } from "../../constants";
+import { SubscribableStore } from "../types";
 import { clampWithNanCheck } from "../utils/data_validation";
-
-import Dataset from "../../colorizer/Dataset";
+import { DatasetSlice } from "./dataset_slice";
 
 type BackdropSliceState = {
-  /** The key of the backdrop image set in the current dataset. `null` if there
-   * is no Dataset loaded or if the dataset does not have backdrops. */
-  backdropKey: string | null;
   backdropVisible: boolean;
   /** Brightness, as a percentage in the `[0, 200]` range. 100 by default. */
   backdropBrightness: number;
@@ -30,10 +27,6 @@ type BackdropSliceState = {
 };
 
 type BackdropSliceActions = {
-  /**
-   * Sets the backdrop key. Will be ignored if it does not exist in the dataset.
-   */
-  setBackdropKey: (dataset: Dataset, key: string) => void;
   /**
    * Sets the visibility of the backdrop layer. The backdrop will be hidden if
    * the current backdrop key is `null`.
@@ -61,23 +54,13 @@ type BackdropSliceActions = {
 
 export type BackdropSlice = BackdropSliceState & BackdropSliceActions;
 
-export const createBackdropSlice: StateCreator<BackdropSlice, [], [], BackdropSlice> = (set, get) => ({
+export const createBackdropSlice: StateCreator<BackdropSlice & DatasetSlice, [], [], BackdropSlice> = (set, get) => ({
   backdropKey: null,
   backdropVisible: false,
   backdropBrightness: BACKDROP_BRIGHTNESS_DEFAULT,
   backdropSaturation: BACKDROP_SATURATION_DEFAULT,
   objectOpacity: BACKDROP_OBJECT_OPACITY_DEFAULT,
 
-  setBackdropKey: (dataset: Dataset, key: string) => {
-    if (key !== null && !dataset.hasBackdrop(key)) {
-      // Ignore if key is not in the dataset
-      throw new Error(
-        `Backdrop key "${key}" could not be found in dataset. (Available keys: ${dataset.getBackdropData().keys()})`
-      );
-    }
-    const backdropVisible = get().backdropVisible && key !== null;
-    set({ backdropKey: key, backdropVisible });
-  },
   // Only enable when backdrop key is not null
   setBackdropVisible: (visible: boolean) => set({ backdropVisible: visible && get().backdropKey !== null }),
   setBackdropBrightness: (brightness: number) =>
@@ -87,3 +70,11 @@ export const createBackdropSlice: StateCreator<BackdropSlice, [], [], BackdropSl
   setObjectOpacity: (opacity: number) =>
     set({ objectOpacity: clampWithNanCheck(opacity, BACKDROP_OBJECT_OPACITY_MIN, BACKDROP_OBJECT_OPACITY_MAX) }),
 });
+
+export const addBackdropDerivedStateSubscribers = (store: SubscribableStore<BackdropSlice & DatasetSlice>): void => {
+  // Hide backdrop when backdrop key is null
+  store.subscribe(
+    (state) => state.backdropKey,
+    (backdropKey) => store.setState({ backdropVisible: backdropKey !== null })
+  );
+};

--- a/src/state/slices/dataset_slice.ts
+++ b/src/state/slices/dataset_slice.ts
@@ -1,7 +1,6 @@
 import { StateCreator } from "zustand";
 
 import { Track } from "../../colorizer";
-import { BackdropSlice } from "./backdrop_slice";
 import { CollectionSlice } from "./collection_slice";
 
 import Dataset from "../../colorizer/Dataset";
@@ -41,10 +40,7 @@ type DatasetSliceActions = {
 
 export type DatasetSlice = DatasetSliceState & DatasetSliceActions;
 
-export const createDatasetSlice: StateCreator<CollectionSlice & DatasetSlice & BackdropSlice, [], [], DatasetSlice> = (
-  set,
-  get
-) => ({
+export const createDatasetSlice: StateCreator<CollectionSlice & DatasetSlice, [], [], DatasetSlice> = (set, get) => ({
   datasetKey: null,
   dataset: null,
   featureKey: null,
@@ -104,12 +100,10 @@ export const createDatasetSlice: StateCreator<CollectionSlice & DatasetSlice & B
     if (backdropKey === null || !dataset.hasBackdrop(backdropKey)) {
       backdropKey = dataset.getDefaultBackdropKey();
     }
-    const backdropVisible = get().backdropVisible && backdropKey !== null;
 
     // TODO: Dispose of old dataset?
-    set({ datasetKey: key, dataset, track: null, featureKey, backdropKey, backdropVisible });
+    set({ datasetKey: key, dataset, track: null, featureKey, backdropKey });
   },
 
-  clearDataset: () =>
-    set({ datasetKey: null, dataset: null, track: null, featureKey: null, backdropKey: null, backdropVisible: false }),
+  clearDataset: () => set({ datasetKey: null, dataset: null, track: null, featureKey: null, backdropKey: null }),
 });

--- a/src/state/slices/dataset_slice.ts
+++ b/src/state/slices/dataset_slice.ts
@@ -12,12 +12,18 @@ type DatasetSliceState =
       dataset: null;
       featureKey: null;
       track: null;
+      /** The key of the backdrop image set in the current dataset. `null` if there
+       * is no Dataset loaded or if the dataset does not have backdrops. */
+      backdropKey: null;
     }
   | {
       datasetKey: string;
       dataset: Dataset;
       featureKey: string;
       track: Track | null;
+      /** The key of the backdrop image set in the current dataset. `null` if there
+       * is no Dataset loaded or if the dataset does not have backdrops. */
+      backdropKey: string | null;
     };
 
 type DatasetSliceActions = {
@@ -30,6 +36,7 @@ type DatasetSliceActions = {
   setFeatureKey: (featureKey: string) => void;
   setTrack: (track: Track) => void;
   clearTrack: () => void;
+  setBackdropKey: (key: string) => void;
 };
 
 export type DatasetSlice = DatasetSliceState & DatasetSliceActions;
@@ -42,7 +49,23 @@ export const createDatasetSlice: StateCreator<CollectionSlice & DatasetSlice & B
   dataset: null,
   featureKey: null,
   track: null,
+  backdropKey: null,
 
+  setBackdropKey: (key: string) => {
+    const dataset = get().dataset;
+    if (dataset === null) {
+      throw new Error("DatasetSlice.setBackdropKey: Cannot set backdrop key when no dataset loaded");
+    }
+    if (!dataset.hasBackdrop(key)) {
+      // Ignore if key is not in the dataset
+      throw new Error(
+        `Backdrop key "${key}" could not be found in dataset. (Available keys: ${Array.from(
+          dataset.getBackdropData().keys()
+        )})`
+      );
+    }
+    set({ backdropKey: key });
+  },
   setFeatureKey: (featureKey: string) => {
     const dataset = get().dataset;
     if (!dataset) {

--- a/tests/state/ViewerState/backdrop_slice.test.ts
+++ b/tests/state/ViewerState/backdrop_slice.test.ts
@@ -10,7 +10,7 @@ import {
   BACKDROP_SATURATION_MIN,
 } from "../../../src/constants";
 import { ANY_ERROR } from "../../test_utils";
-import { MOCK_DATASET, MOCK_DATASET_WITHOUT_BACKDROP, MockBackdropKeys } from "./constants";
+import { MOCK_DATASET, MockBackdropKeys } from "./constants";
 import { setDatasetAsync } from "./utils";
 
 import { useViewerStateStore } from "../../../src/state/ViewerState";
@@ -99,7 +99,9 @@ describe("useViewerStateStore: BackdropSlice", () => {
     });
     expect(result.current.backdropVisible).toBe(true);
 
-    await setDatasetAsync(result, MOCK_DATASET_WITHOUT_BACKDROP);
+    act(() => {
+      useViewerStateStore.setState({ backdropKey: null });
+    });
     expect(result.current.backdropVisible).toBe(false);
   });
 });

--- a/tests/state/ViewerState/backdrop_slice.test.ts
+++ b/tests/state/ViewerState/backdrop_slice.test.ts
@@ -1,7 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { Dataset } from "../../../src/colorizer";
 import {
   BACKDROP_BRIGHTNESS_MAX,
   BACKDROP_BRIGHTNESS_MIN,
@@ -11,46 +10,12 @@ import {
   BACKDROP_SATURATION_MIN,
 } from "../../../src/constants";
 import { ANY_ERROR } from "../../test_utils";
-import { MOCK_DATASET_WITHOUT_BACKDROP } from "./constants";
+import { MOCK_DATASET, MOCK_DATASET_WITHOUT_BACKDROP, MockBackdropKeys } from "./constants";
+import { setDatasetAsync } from "./utils";
 
 import { useViewerStateStore } from "../../../src/state/ViewerState";
 
 describe("useViewerStateStore: BackdropSlice", () => {
-  describe("setBackdropKey", () => {
-    it("does not allow backdrop slice to be set when provided Dataset has no backdrops", () => {
-      const { result } = renderHook(() => useViewerStateStore());
-
-      // Initialized as null
-      expect(result.current.backdropKey).toBeNull();
-      expect(() => {
-        act(() => {
-          result.current.setBackdropKey(MOCK_DATASET_WITHOUT_BACKDROP, "test");
-        });
-      }).toThrowError(ANY_ERROR);
-      expect(result.current.backdropKey).toBeNull();
-    });
-
-    it("allows setting backdrop keys that are in the dataset.", () => {
-      const mockDataset = {
-        hasBackdrop: (key: string) => key === "test1" || key === "test2",
-        getDefaultBackdropKey: () => "test1",
-      } as unknown as Dataset;
-      const { result } = renderHook(() => useViewerStateStore());
-
-      // Should initialize to default backdrop key
-      act(() => {
-        result.current.setBackdropKey(mockDataset, "test1");
-      });
-      expect(result.current.backdropKey).toBe("test1");
-
-      // Can set another valid backdrop key
-      act(() => {
-        result.current.setBackdropKey(mockDataset, "test2");
-      });
-      expect(result.current.backdropKey).toBe("test2");
-    });
-  });
-
   describe("setBackdropVisible", () => {
     it("does not allow visibility to be enabled when backdrop key is null", () => {
       const { result } = renderHook(() => useViewerStateStore());
@@ -122,5 +87,19 @@ describe("useViewerStateStore: BackdropSlice", () => {
     expect(() => {
       result.current.setObjectOpacity(NaN);
     }).toThrowError(ANY_ERROR);
+  });
+
+  it("disables backdrop visibility if key is set to null", async () => {
+    const { result } = renderHook(() => useViewerStateStore());
+
+    await setDatasetAsync(result, MOCK_DATASET);
+    act(() => {
+      result.current.setBackdropKey(MockBackdropKeys.BACKDROP1);
+      result.current.setBackdropVisible(true);
+    });
+    expect(result.current.backdropVisible).toBe(true);
+
+    await setDatasetAsync(result, MOCK_DATASET_WITHOUT_BACKDROP);
+    expect(result.current.backdropVisible).toBe(false);
   });
 });

--- a/tests/state/ViewerState/constants.ts
+++ b/tests/state/ViewerState/constants.ts
@@ -39,7 +39,11 @@ export const MOCK_FEATURE_DATA: Record<MockFeatureKeys, ManifestFile["features"]
   },
 };
 
-export const DEFAULT_BACKDROP_KEY = "test_backdrop_key";
+export enum MockBackdropKeys {
+  BACKDROP1 = "backdrop1",
+  BACKDROP2 = "backdrop2",
+}
+
 export const DEFAULT_INITIAL_FEATURE_KEY = MockFeatureKeys.FEATURE1;
 
 const MOCK_DATASET_MANIFEST: AnyManifestFile = {
@@ -51,8 +55,13 @@ const MOCK_DATASET_MANIFEST: AnyManifestFile = {
   frames: ["frame0.png", "frame1.png", "frame2.png", "frame3.png"],
   backdrops: [
     {
-      name: DEFAULT_BACKDROP_KEY,
-      key: DEFAULT_BACKDROP_KEY,
+      name: MockBackdropKeys.BACKDROP1,
+      key: MockBackdropKeys.BACKDROP1,
+      frames: ["frame0.png", "frame1.png", "frame2.png", "frame3.png"],
+    },
+    {
+      name: MockBackdropKeys.BACKDROP2,
+      key: MockBackdropKeys.BACKDROP2,
       frames: ["frame0.png", "frame1.png", "frame2.png", "frame3.png"],
     },
   ],

--- a/tests/state/ViewerState/dataset_slice.test.ts
+++ b/tests/state/ViewerState/dataset_slice.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it } from "vitest";
 
 import { ANY_ERROR } from "../../test_utils";
 import {
-  DEFAULT_BACKDROP_KEY,
   DEFAULT_INITIAL_FEATURE_KEY,
   MOCK_DATASET,
   MOCK_DATASET_DEFAULT_TRACK,
   MOCK_DATASET_WITHOUT_BACKDROP,
+  MockBackdropKeys,
   MockFeatureKeys,
 } from "./constants";
 import { setDatasetAsync } from "./utils";
@@ -27,7 +27,7 @@ describe("useViewerStateStore: DatasetSlice", () => {
       const { result } = renderHook(() => useViewerStateStore());
       await setDatasetAsync(result, MOCK_DATASET, "some-key");
       expect(result.current.dataset).toBe(MOCK_DATASET);
-      expect(result.current.backdropKey).toBe(DEFAULT_BACKDROP_KEY);
+      expect(result.current.backdropKey).toBe(MockBackdropKeys.BACKDROP1);
 
       // Change dataset to one without default backdrop, backdropKey should
       // be reset to null.
@@ -69,7 +69,7 @@ describe("useViewerStateStore: DatasetSlice", () => {
       act(() => {
         result.current.setBackdropVisible(true);
       });
-      expect(result.current.backdropKey).toBe(DEFAULT_BACKDROP_KEY);
+      expect(result.current.backdropKey).toBe(MockBackdropKeys.BACKDROP1);
       expect(result.current.backdropVisible).toBe(true);
 
       act(() => {
@@ -152,6 +152,38 @@ describe("useViewerStateStore: DatasetSlice", () => {
           result.current.setFeatureKey("non-existent-key");
         });
       }).toThrowError(ANY_ERROR);
+    });
+  });
+
+  describe("setBackdropKey", () => {
+    it("does not allow backdrop slice to be set when provided Dataset has no backdrops", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+
+      // Initialized as null
+      expect(result.current.backdropKey).toBeNull();
+      expect(() => {
+        act(() => {
+          result.current.setBackdropKey("test");
+        });
+      }).toThrowError(ANY_ERROR);
+      expect(result.current.backdropKey).toBeNull();
+    });
+
+    it("allows setting backdrop keys that are in the dataset.", async () => {
+      const { result } = renderHook(() => useViewerStateStore());
+
+      // Should initialize to default backdrop key
+      await setDatasetAsync(result, MOCK_DATASET);
+      act(() => {
+        result.current.setBackdropKey(MockBackdropKeys.BACKDROP1);
+      });
+      expect(result.current.backdropKey).toBe(MockBackdropKeys.BACKDROP1);
+
+      // Can set another valid backdrop key
+      act(() => {
+        result.current.setBackdropKey(MockBackdropKeys.BACKDROP2);
+      });
+      expect(result.current.backdropKey).toBe(MockBackdropKeys.BACKDROP2);
     });
   });
 });


### PR DESCRIPTION
Problem
=======
Part 10 of (12)??? for #492, "refactor state management."

This change is pretty unexciting. It moves the `backdropKey` into the `DatasetSlice` which cleans up some dependencies. It also changes our state access to the inline selector pattern which is better for linting & detecting deprecated dependencies.

*Estimated review size: small, 10 minutes*

Solution
========
- Changed state accessors to use the inline selector pattern, removing dependence on `useShallow`.
- Moved `backdropKey` into `DatasetSlice`, allowing `DatasetSlice` to be agnostic of `BackdropSlice`.
- Added a listener for `backdropKey` in `BackdropSlice` to sync backdrop visibility.

Steps to Verify:
----------------
1. Open PR preview: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-588/viewer?dataset=https%3A%2F%2Fraw.githubusercontent.com%2Fallen-cell-animated%2Fcolorizer-data%2Frefs%2Fheads%2Fmain%2Fdocumentation%2Fexample_dataset%2Fmanifest.json
2. Toggle backdrops on/off, try switching backdrops or datasets.
(Note: there's a known bug when switching datasets/collections where the frame may be incorrect. I'm going to see if it goes away when I move more Dataset/Collection switching logic into the store.)
