### PR TITLE
refactor: Serialization/deserialization for time, config, and vector slice (state pt. 12)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -90,9 +90,10 @@
           // Anything not matched in another group.
           ["^"],
           // Relative imports - lowercase utilities and submodules
-          ["^[.]+.*/[a-z]+[\\w]*$"],
+          // "\\u0000" is added to the end of imported types.
+          ["^[.]+.*/[a-z]+[\\w]*(\\u0000)?$"],
           // Relative imports - other classes and components
-          ["^[./].*/[\\w?&]*$"],
+          ["^[./].*/[\\w?&]*(\\u0000)?$"],
           // Relative imports - resource files
           ["^[.].*/[\\w?_\\-]*[.][\\w.?&_\\-]*$"]
         ]

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -552,10 +552,6 @@ function Viewer(): ReactElement {
         setFeatureThresholds(initialUrlParams.thresholds);
       }
 
-      if (initialUrlParams.config) {
-        // updateConfig(initialUrlParams.config);
-      }
-
       if (initialUrlParams.scatterPlotConfig) {
         const newScatterPlotConfig = initialUrlParams.scatterPlotConfig;
         // For backwards-compatibility, cast xAxis and yAxis to feature keys.

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -106,7 +106,6 @@ function Viewer(): ReactElement {
   // into a helper method/out of the component
   /** Backdrop key is null if the dataset has no backdrops, or during initialization. */
   const selectedBackdropKey = useViewerStateStore((state) => state.backdropKey);
-  const setSelectedBackdropKey = useViewerStateStore((state) => state.setBackdropKey);
 
   const [, addRecentCollection] = useRecentCollections();
 
@@ -552,19 +551,7 @@ function Viewer(): ReactElement {
       if (initialUrlParams.thresholds) {
         setFeatureThresholds(initialUrlParams.thresholds);
       }
-      if (initialUrlParams.time && initialUrlParams.time >= 0) {
-        // Load time (if unset, defaults to track time or default t=0)
-        const newTime = initialUrlParams.time;
-        setFrame(newTime);
-        setFrameInput(newTime);
-      }
 
-      const backdropKey = initialUrlParams.selectedBackdropKey;
-      if (backdropKey) {
-        if (dataset?.hasBackdrop(backdropKey)) {
-          setSelectedBackdropKey(backdropKey);
-        }
-      }
       if (initialUrlParams.config) {
         // updateConfig(initialUrlParams.config);
       }

--- a/src/components/PlotWrapper.tsx
+++ b/src/components/PlotWrapper.tsx
@@ -1,9 +1,9 @@
 import Plotly, { PlotlyHTMLElement } from "plotly.js-dist-min";
 import React, { ReactElement, useEffect, useMemo, useRef, useState } from "react";
 
-import type { TrackPlotLayoutConfig } from "../colorizer/Plotting";
-
 import { Dataset, Plotting, Track } from "../colorizer";
+
+import type { TrackPlotLayoutConfig } from "../colorizer/Plotting";
 
 type PlotWrapperProps = {
   frame: number;

--- a/src/state/slices/config_slice.ts
+++ b/src/state/slices/config_slice.ts
@@ -18,7 +18,7 @@ import {
   parseDrawSettings,
   UrlParam,
 } from "../../colorizer/utils/url_utils";
-import { SerializedStoreData } from "../types";
+import type { SerializedStoreData } from "../types";
 import { setValueIfDefined } from "../utils/data_validation";
 
 const OUT_OF_RANGE_DRAW_SETTINGS_DEFAULT: DrawSettings = {
@@ -81,19 +81,18 @@ export const createConfigSlice: StateCreator<ConfigSlice, [], [], ConfigSlice> =
 });
 
 export const serializeConfigSlice = (slice: ConfigSlice): SerializedStoreData => {
-  const ret: SerializedStoreData = {};
-  ret[UrlParam.SHOW_PATH] = encodeBoolean(slice.showTrackPath);
-  ret[UrlParam.SHOW_SCALEBAR] = encodeBoolean(slice.showScaleBar);
-  ret[UrlParam.SHOW_TIMESTAMP] = encodeBoolean(slice.showTimestamp);
-  // Export settings are currently not serialized.
-  ret[UrlParam.FILTERED_COLOR] = encodeColor(slice.outOfRangeDrawSettings.color);
-  ret[UrlParam.FILTERED_MODE] = slice.outOfRangeDrawSettings.mode.toString();
-  ret[UrlParam.OUTLIER_COLOR] = encodeColor(slice.outlierDrawSettings.color);
-  ret[UrlParam.OUTLIER_MODE] = slice.outlierDrawSettings.mode.toString();
-  ret[UrlParam.OUTLINE_COLOR] = encodeColor(slice.outlineColor);
-
-  ret[UrlParam.OPEN_TAB] = slice.openTab;
-  return ret;
+  return {
+    [UrlParam.SHOW_PATH]: encodeBoolean(slice.showTrackPath),
+    [UrlParam.SHOW_SCALEBAR]: encodeBoolean(slice.showScaleBar),
+    [UrlParam.SHOW_TIMESTAMP]: encodeBoolean(slice.showTimestamp),
+    // Export settings are currently not serialized.
+    [UrlParam.FILTERED_COLOR]: encodeColor(slice.outOfRangeDrawSettings.color),
+    [UrlParam.FILTERED_MODE]: slice.outOfRangeDrawSettings.mode.toString(),
+    [UrlParam.OUTLIER_COLOR]: encodeColor(slice.outlierDrawSettings.color),
+    [UrlParam.OUTLIER_MODE]: slice.outlierDrawSettings.mode.toString(),
+    [UrlParam.OUTLINE_COLOR]: encodeColor(slice.outlineColor),
+    [UrlParam.OPEN_TAB]: slice.openTab,
+  };
 };
 
 export const loadConfigSliceFromParams = (slice: ConfigSlice, params: URLSearchParams): void => {

--- a/src/state/slices/config_slice.ts
+++ b/src/state/slices/config_slice.ts
@@ -19,6 +19,7 @@ import {
   UrlParam,
 } from "../../colorizer/utils/url_utils";
 import { SerializedStoreData } from "../types";
+import { setValueIfDefined } from "../utils/data_validation";
 
 const OUT_OF_RANGE_DRAW_SETTINGS_DEFAULT: DrawSettings = {
   color: new Color(OUT_OF_RANGE_COLOR_DEFAULT),
@@ -96,18 +97,9 @@ export const serializeConfigSlice = (slice: ConfigSlice): SerializedStoreData =>
 };
 
 export const loadConfigSliceFromParams = (slice: ConfigSlice, params: URLSearchParams): void => {
-  const showPathParam = decodeBoolean(params.get(UrlParam.SHOW_PATH));
-  if (showPathParam !== undefined) {
-    slice.setShowTrackPath(showPathParam);
-  }
-  const showScaleBarParam = decodeBoolean(params.get(UrlParam.SHOW_SCALEBAR));
-  if (showScaleBarParam !== undefined) {
-    slice.setShowScaleBar(showScaleBarParam);
-  }
-  const showTimestampParam = decodeBoolean(params.get(UrlParam.SHOW_TIMESTAMP));
-  if (showTimestampParam !== undefined) {
-    slice.setShowTimestamp(showTimestampParam);
-  }
+  setValueIfDefined(decodeBoolean(params.get(UrlParam.SHOW_PATH)), slice.setShowTrackPath);
+  setValueIfDefined(decodeBoolean(params.get(UrlParam.SHOW_SCALEBAR)), slice.setShowScaleBar);
+  setValueIfDefined(decodeBoolean(params.get(UrlParam.SHOW_TIMESTAMP)), slice.setShowTimestamp);
 
   slice.setOutOfRangeDrawSettings(
     parseDrawSettings(

--- a/src/state/slices/time_slice.ts
+++ b/src/state/slices/time_slice.ts
@@ -1,7 +1,8 @@
 import { StateCreator } from "zustand";
 
+import { UrlParam } from "../../colorizer/utils/url_utils";
 import { DEFAULT_PLAYBACK_FPS } from "../../constants";
-import { SubscribableStore } from "../types";
+import { SerializedStoreData, SubscribableStore } from "../types";
 import { clampWithNanCheck } from "../utils/data_validation";
 import { addDerivedStateSubscriber } from "../utils/store_utils";
 import { DatasetSlice } from "./dataset_slice";
@@ -98,4 +99,21 @@ export const addTimeDerivedStateSubscribers = (store: SubscribableStore<DatasetS
       }
     }
   );
+};
+
+export const serializeTimeSlice = (state: TimeSlice): SerializedStoreData => {
+  return {
+    [UrlParam.TIME]: state.currentFrame.toString(),
+  };
+};
+
+export const loadTimeSliceFromParams = (state: TimeSlice & DatasetSlice, params: URLSearchParams): void => {
+  // Load time from URL. If no time is set but a track is, set the time
+  // to the start of the track.
+  const time = params.get(UrlParam.TIME);
+  if (time !== null) {
+    state.setFrame(parseInt(time));
+  } else if (state.track !== null) {
+    state.setFrame(state.track.startTime());
+  }
 };

--- a/src/state/slices/time_slice.ts
+++ b/src/state/slices/time_slice.ts
@@ -1,6 +1,6 @@
 import { StateCreator } from "zustand";
 
-import { UrlParam } from "../../colorizer/utils/url_utils";
+import { decodeInt, UrlParam } from "../../colorizer/utils/url_utils";
 import { DEFAULT_PLAYBACK_FPS } from "../../constants";
 import { SerializedStoreData, SubscribableStore } from "../types";
 import { clampWithNanCheck } from "../utils/data_validation";
@@ -108,11 +108,11 @@ export const serializeTimeSlice = (state: TimeSlice): SerializedStoreData => {
 };
 
 export const loadTimeSliceFromParams = (state: TimeSlice & DatasetSlice, params: URLSearchParams): void => {
-  // Load time from URL. If no time is set but a track is, set the time
-  // to the start of the track.
-  const time = params.get(UrlParam.TIME);
-  if (time !== null) {
-    state.setFrame(parseInt(time));
+  // Load time from URL. If no time is set but a track is, set the time to the
+  // start of the track.
+  const time = decodeInt(params.get(UrlParam.TIME));
+  if (time !== undefined) {
+    state.setFrame(time);
   } else if (state.track !== null) {
     state.setFrame(state.track.startTime());
   }

--- a/src/state/slices/time_slice.ts
+++ b/src/state/slices/time_slice.ts
@@ -2,10 +2,10 @@ import { StateCreator } from "zustand";
 
 import { decodeInt, UrlParam } from "../../colorizer/utils/url_utils";
 import { DEFAULT_PLAYBACK_FPS } from "../../constants";
-import { SerializedStoreData, SubscribableStore } from "../types";
+import type { SerializedStoreData, SubscribableStore } from "../types";
 import { clampWithNanCheck } from "../utils/data_validation";
 import { addDerivedStateSubscriber } from "../utils/store_utils";
-import { DatasetSlice } from "./dataset_slice";
+import type { DatasetSlice } from "./dataset_slice";
 
 import TimeControls from "../../colorizer/TimeControls";
 

--- a/src/state/slices/vector_slice.ts
+++ b/src/state/slices/vector_slice.ts
@@ -162,7 +162,7 @@ export function loadVectorSliceFromParams(slice: VectorSlice, params: URLSearchP
   }
 
   const vectorScale = decodeFloat(params.get(UrlParam.VECTOR_SCALE));
-  if (vectorScale !== undefined) {
+  if (vectorScale !== undefined && Number.isFinite(vectorScale)) {
     slice.setVectorScaleFactor(vectorScale);
   }
 
@@ -172,7 +172,7 @@ export function loadVectorSliceFromParams(slice: VectorSlice, params: URLSearchP
   }
 
   const vectorTimeIntervals = decodeInt(params.get(UrlParam.VECTOR_TIME_INTERVALS));
-  if (vectorTimeIntervals !== undefined) {
+  if (vectorTimeIntervals !== undefined && Number.isFinite(vectorTimeIntervals)) {
     slice.setVectorMotionTimeIntervals(vectorTimeIntervals);
   }
 }

--- a/src/state/slices/vector_slice.ts
+++ b/src/state/slices/vector_slice.ts
@@ -18,10 +18,10 @@ import {
   encodeNumber,
   UrlParam,
 } from "../../colorizer/utils/url_utils";
-import { SerializedStoreData, SubscribableStore } from "../types";
+import type { SerializedStoreData, SubscribableStore } from "../types";
 import { setValueIfDefined, validateFiniteValue } from "../utils/data_validation";
 import { addDerivedStateSubscriber, makeDebouncedCallback } from "../utils/store_utils";
-import { DatasetSlice } from "./dataset_slice";
+import type { DatasetSlice } from "./dataset_slice";
 
 import { getSharedWorkerPool } from "../../colorizer/workers/SharedWorkerPool";
 
@@ -134,14 +134,14 @@ export const selectVectorConfigFromState = (state: VectorSlice): VectorConfig =>
 });
 
 export const serializeVectorSlice = (slice: VectorSlice): SerializedStoreData => {
-  const ret: SerializedStoreData = {};
-  ret[UrlParam.SHOW_VECTOR] = encodeBoolean(slice.vectorVisible);
-  ret[UrlParam.VECTOR_KEY] = slice.vectorKey;
-  ret[UrlParam.VECTOR_COLOR] = encodeColor(slice.vectorColor);
-  ret[UrlParam.VECTOR_SCALE] = encodeNumber(slice.vectorScaleFactor);
-  ret[UrlParam.VECTOR_TOOLTIP_MODE] = slice.vectorTooltipMode.toString();
-  ret[UrlParam.VECTOR_TIME_INTERVALS] = encodeNumber(slice.vectorMotionTimeIntervals);
-  return ret;
+  return {
+    [UrlParam.SHOW_VECTOR]: encodeBoolean(slice.vectorVisible),
+    [UrlParam.VECTOR_KEY]: slice.vectorKey,
+    [UrlParam.VECTOR_COLOR]: encodeColor(slice.vectorColor),
+    [UrlParam.VECTOR_SCALE]: encodeNumber(slice.vectorScaleFactor),
+    [UrlParam.VECTOR_TOOLTIP_MODE]: slice.vectorTooltipMode.toString(),
+    [UrlParam.VECTOR_TIME_INTERVALS]: encodeNumber(slice.vectorMotionTimeIntervals),
+  };
 };
 
 export function loadVectorSliceFromParams(slice: VectorSlice, params: URLSearchParams): void {

--- a/src/state/slices/vector_slice.ts
+++ b/src/state/slices/vector_slice.ts
@@ -1,8 +1,24 @@
 import { Color } from "three";
 import { StateCreator } from "zustand";
 
-import { getDefaultVectorConfig, VECTOR_KEY_MOTION_DELTA, VectorConfig, VectorTooltipMode } from "../../colorizer";
-import { SubscribableStore } from "../types";
+import {
+  getDefaultVectorConfig,
+  isVectorTooltipMode,
+  VECTOR_KEY_MOTION_DELTA,
+  VectorConfig,
+  VectorTooltipMode,
+} from "../../colorizer";
+import {
+  decodeBoolean,
+  decodeFloat,
+  decodeHexColor,
+  decodeInt,
+  encodeBoolean,
+  encodeColor,
+  encodeNumber,
+  UrlParam,
+} from "../../colorizer/utils/url_utils";
+import { SerializedStoreData, SubscribableStore } from "../types";
 import { validateFiniteValue } from "../utils/data_validation";
 import { addDerivedStateSubscriber, makeDebouncedCallback } from "../utils/store_utils";
 import { DatasetSlice } from "./dataset_slice";
@@ -79,9 +95,7 @@ export const createVectorSlice: StateCreator<VectorSlice & DatasetSlice, [], [],
   setVectorTooltipMode: (mode: VectorTooltipMode) => set({ vectorTooltipMode: mode }),
 });
 
-export const addVectorDerivedStateSubscribers = (
-  store: SubscribableStore<VectorSlice & DatasetSlice>
-): void => {
+export const addVectorDerivedStateSubscribers = (store: SubscribableStore<VectorSlice & DatasetSlice>): void => {
   // Update motion deltas when the dataset, vector key, or motion time intervals change.
   addDerivedStateSubscriber(
     store,
@@ -118,3 +132,47 @@ export const selectVectorConfigFromState = (state: VectorSlice): VectorConfig =>
   scaleFactor: state.vectorScaleFactor,
   tooltipMode: state.vectorTooltipMode,
 });
+
+export const serializeVectorSlice = (slice: VectorSlice): SerializedStoreData => {
+  const ret: SerializedStoreData = {};
+  ret[UrlParam.SHOW_VECTOR] = encodeBoolean(slice.vectorVisible);
+  ret[UrlParam.VECTOR_KEY] = slice.vectorKey;
+  ret[UrlParam.VECTOR_COLOR] = encodeColor(slice.vectorColor);
+  ret[UrlParam.VECTOR_SCALE] = encodeNumber(slice.vectorScaleFactor);
+  ret[UrlParam.VECTOR_TOOLTIP_MODE] = slice.vectorTooltipMode.toString();
+  ret[UrlParam.VECTOR_TIME_INTERVALS] = encodeNumber(slice.vectorMotionTimeIntervals);
+  return ret;
+};
+
+export function loadVectorSliceFromParams(slice: VectorSlice, params: URLSearchParams): void {
+  const vectorVisible = decodeBoolean(params.get(UrlParam.SHOW_VECTOR));
+  if (vectorVisible !== undefined) {
+    slice.setVectorVisible(vectorVisible);
+  }
+
+  const vectorKey = params.get(UrlParam.VECTOR_KEY);
+  // TODO: Do validation for vector keys if added to Dataset
+  if (vectorKey === VECTOR_KEY_MOTION_DELTA) {
+    slice.setVectorKey(vectorKey);
+  }
+
+  const vectorColor = decodeHexColor(params.get(UrlParam.VECTOR_COLOR));
+  if (vectorColor !== undefined) {
+    slice.setVectorColor(new Color(vectorColor));
+  }
+
+  const vectorScale = decodeFloat(params.get(UrlParam.VECTOR_SCALE));
+  if (vectorScale !== undefined) {
+    slice.setVectorScaleFactor(vectorScale);
+  }
+
+  const vectorTooltipMode = params.get(UrlParam.VECTOR_TOOLTIP_MODE);
+  if (vectorTooltipMode && isVectorTooltipMode(vectorTooltipMode)) {
+    slice.setVectorTooltipMode(vectorTooltipMode);
+  }
+
+  const vectorTimeIntervals = decodeInt(params.get(UrlParam.VECTOR_TIME_INTERVALS));
+  if (vectorTimeIntervals !== undefined) {
+    slice.setVectorMotionTimeIntervals(vectorTimeIntervals);
+  }
+}

--- a/src/state/slices/vector_slice.ts
+++ b/src/state/slices/vector_slice.ts
@@ -19,7 +19,7 @@ import {
   UrlParam,
 } from "../../colorizer/utils/url_utils";
 import { SerializedStoreData, SubscribableStore } from "../types";
-import { validateFiniteValue } from "../utils/data_validation";
+import { setValueIfDefined, validateFiniteValue } from "../utils/data_validation";
 import { addDerivedStateSubscriber, makeDebouncedCallback } from "../utils/store_utils";
 import { DatasetSlice } from "./dataset_slice";
 
@@ -145,10 +145,7 @@ export const serializeVectorSlice = (slice: VectorSlice): SerializedStoreData =>
 };
 
 export function loadVectorSliceFromParams(slice: VectorSlice, params: URLSearchParams): void {
-  const vectorVisible = decodeBoolean(params.get(UrlParam.SHOW_VECTOR));
-  if (vectorVisible !== undefined) {
-    slice.setVectorVisible(vectorVisible);
-  }
+  setValueIfDefined(decodeBoolean(params.get(UrlParam.SHOW_VECTOR)), slice.setVectorVisible);
 
   const vectorKey = params.get(UrlParam.VECTOR_KEY);
   // TODO: Do validation for vector keys if added to Dataset

--- a/src/state/utils/data_validation.ts
+++ b/src/state/utils/data_validation.ts
@@ -21,3 +21,10 @@ export const validateFiniteValue = (value: number, source: string): number => {
   }
   return value;
 };
+
+/** Calls the setter with the provided value if not `undefined`. */
+export const setValueIfDefined = <T>(value: T | undefined, setter: (value: T) => void): void => {
+  if (value !== undefined) {
+    setter(value);
+  }
+};

--- a/src/state/utils/store_io.ts
+++ b/src/state/utils/store_io.ts
@@ -15,11 +15,12 @@ import { ViewerState } from "../ViewerState";
 // SERIALIZATION /////////////////////////////////////////////////////////////////////////
 
 export const serializeViewerStateStore = (store: Store<ViewerState>): Partial<SerializedStoreData> => {
+  // Ordered by approximate importance in the URL
   return {
     ...serializeDatasetSlice(store.getState()),
     ...serializeTimeSlice(store.getState()),
-    ...serializeConfigSlice(store.getState()),
     ...serializeColorRampSlice(store.getState()),
+    ...serializeConfigSlice(store.getState()),
   };
 };
 
@@ -34,18 +35,18 @@ export const serializedStoreDataToUrl = (data: SerializedStoreData): string => {
 // DESERIALIZATION ///////////////////////////////////////////////////////////////////////
 
 /**
- * Loads the viewer state from the given URL parameters. Note that this MUST be
+ * Loads the viewer state from the given URL  parameters. Note that this MUST be
  * called after the dataset is loaded and set in the store.
  */
 export const loadViewerStateFromParams = async (store: Store<ViewerState>, params: URLSearchParams): Promise<void> => {
-  // NOTE: Ordering is important here, because of slice dependencies.
-  // No dependencies:
+  // NOTE: Ordering is important here, because of dependencies between slices.
+  // 1. No dependencies:
   loadDatasetSliceFromParams(store.getState(), params);
   loadConfigSliceFromParams(store.getState(), params);
 
-  // Dependent on dataset fields:
+  // 2. Dependent on dataset fields:
   loadTimeSliceFromParams(store.getState(), params);
 
-  // Dependent on dataset + thresholds:
+  // 3. Dependent on dataset + thresholds:
   loadColorRampSliceFromParams(store.getState(), params);
 };

--- a/src/state/utils/store_io.ts
+++ b/src/state/utils/store_io.ts
@@ -1,8 +1,10 @@
 import {
   loadColorRampSliceFromParams,
+  loadConfigSliceFromParams,
   loadDatasetSliceFromParams,
   loadTimeSliceFromParams,
   serializeColorRampSlice,
+  serializeConfigSlice,
   serializeDatasetSlice,
   serializeTimeSlice,
 } from "../slices";
@@ -16,6 +18,7 @@ export const serializeViewerStateStore = (store: Store<ViewerState>): Partial<Se
   return {
     ...serializeDatasetSlice(store.getState()),
     ...serializeTimeSlice(store.getState()),
+    ...serializeConfigSlice(store.getState()),
     ...serializeColorRampSlice(store.getState()),
   };
 };
@@ -31,11 +34,14 @@ export const serializedStoreDataToUrl = (data: SerializedStoreData): string => {
 // DESERIALIZATION ///////////////////////////////////////////////////////////////////////
 
 /**
- * Loads the viewer state from the given URL parameters. Note that this MUST be called after the dataset is loaded and set in the store.
+ * Loads the viewer state from the given URL parameters. Note that this MUST be
+ * called after the dataset is loaded and set in the store.
  */
 export const loadViewerStateFromParams = async (store: Store<ViewerState>, params: URLSearchParams): Promise<void> => {
   // NOTE: Ordering is important here, because of slice dependencies.
+  // No dependencies:
   loadDatasetSliceFromParams(store.getState(), params);
+  loadConfigSliceFromParams(store.getState(), params);
 
   // Dependent on dataset fields:
   loadTimeSliceFromParams(store.getState(), params);

--- a/src/state/utils/store_io.ts
+++ b/src/state/utils/store_io.ts
@@ -3,10 +3,12 @@ import {
   loadConfigSliceFromParams,
   loadDatasetSliceFromParams,
   loadTimeSliceFromParams,
+  loadVectorSliceFromParams,
   serializeColorRampSlice,
   serializeConfigSlice,
   serializeDatasetSlice,
   serializeTimeSlice,
+  serializeVectorSlice,
 } from "../slices";
 import { SerializedStoreData, Store } from "../types";
 
@@ -21,6 +23,7 @@ export const serializeViewerStateStore = (store: Store<ViewerState>): Partial<Se
     ...serializeTimeSlice(store.getState()),
     ...serializeColorRampSlice(store.getState()),
     ...serializeConfigSlice(store.getState()),
+    ...serializeVectorSlice(store.getState()),
   };
 };
 
@@ -46,6 +49,7 @@ export const loadViewerStateFromParams = async (store: Store<ViewerState>, param
 
   // 2. Dependent on dataset fields:
   loadTimeSliceFromParams(store.getState(), params);
+  loadVectorSliceFromParams(store.getState(), params);
 
   // 3. Dependent on dataset + thresholds:
   loadColorRampSliceFromParams(store.getState(), params);

--- a/src/state/utils/store_io.ts
+++ b/src/state/utils/store_io.ts
@@ -1,8 +1,10 @@
 import {
   loadColorRampSliceFromParams,
   loadDatasetSliceFromParams,
+  loadTimeSliceFromParams,
   serializeColorRampSlice,
   serializeDatasetSlice,
+  serializeTimeSlice,
 } from "../slices";
 import { SerializedStoreData, Store } from "../types";
 
@@ -13,6 +15,7 @@ import { ViewerState } from "../ViewerState";
 export const serializeViewerStateStore = (store: Store<ViewerState>): Partial<SerializedStoreData> => {
   return {
     ...serializeDatasetSlice(store.getState()),
+    ...serializeTimeSlice(store.getState()),
     ...serializeColorRampSlice(store.getState()),
   };
 };
@@ -33,7 +36,10 @@ export const serializedStoreDataToUrl = (data: SerializedStoreData): string => {
 export const loadViewerStateFromParams = async (store: Store<ViewerState>, params: URLSearchParams): Promise<void> => {
   // NOTE: Ordering is important here, because of slice dependencies.
   loadDatasetSliceFromParams(store.getState(), params);
-  // TODO: Add other slices here
-  // Ramp MUST be loaded last because it updates whenever thresholds or feature changes
+
+  // Dependent on dataset fields:
+  loadTimeSliceFromParams(store.getState(), params);
+
+  // Dependent on dataset + thresholds:
   loadColorRampSliceFromParams(store.getState(), params);
 };

--- a/tests/state/ViewerState/config_slice.test.ts
+++ b/tests/state/ViewerState/config_slice.test.ts
@@ -8,7 +8,7 @@ import { UrlParam } from "../../../src/colorizer/utils/url_utils";
 import { useViewerStateStore } from "../../../src/state";
 import { ConfigSlice, loadConfigSliceFromParams, serializeConfigSlice } from "../../../src/state/slices";
 import { SerializedStoreData } from "../../../src/state/types";
-import { compareSerializedData, compareSlice } from "./utils";
+import { compareRecord } from "./utils";
 
 const EXAMPLE_SLICE_1: Partial<ConfigSlice> = {
   showTrackPath: false,
@@ -108,13 +108,13 @@ describe("ConfigSlice", () => {
         useViewerStateStore.setState(EXAMPLE_SLICE_1);
       });
       let serializedData = serializeConfigSlice(result.current);
-      compareSerializedData(serializedData, EXAMPLE_SLICE_1_PARAMS);
+      compareRecord(serializedData, EXAMPLE_SLICE_1_PARAMS);
 
       act(() => {
         useViewerStateStore.setState(EXAMPLE_SLICE_2);
       });
       serializedData = serializeConfigSlice(result.current);
-      compareSerializedData(serializedData, EXAMPLE_SLICE_2_PARAMS);
+      compareRecord(serializedData, EXAMPLE_SLICE_2_PARAMS);
     });
   });
 
@@ -124,12 +124,12 @@ describe("ConfigSlice", () => {
       act(() => {
         loadConfigSliceFromParams(result.current, new URLSearchParams(EXAMPLE_SLICE_1_PARAMS));
       });
-      compareSlice(result.current, EXAMPLE_SLICE_1);
+      compareRecord(result.current, EXAMPLE_SLICE_1);
 
       act(() => {
         loadConfigSliceFromParams(result.current, new URLSearchParams(EXAMPLE_SLICE_2_PARAMS));
       });
-      compareSlice(result.current, EXAMPLE_SLICE_2);
+      compareRecord(result.current, EXAMPLE_SLICE_2);
     });
 
     it("ignores invalid draw setting modes", () => {

--- a/tests/state/ViewerState/config_slice.test.ts
+++ b/tests/state/ViewerState/config_slice.test.ts
@@ -4,7 +4,9 @@ import { Color } from "three";
 import { describe, expect, it } from "vitest";
 
 import { DrawMode, TabType } from "../../../src/colorizer";
+import { UrlParam } from "../../../src/colorizer/utils/url_utils";
 import { useViewerStateStore } from "../../../src/state";
+import { loadConfigSliceFromParams, serializeConfigSlice } from "../../../src/state/slices";
 
 describe("ConfigSlice", () => {
   it("can set properties", () => {
@@ -51,5 +53,121 @@ describe("ConfigSlice", () => {
     expect(result.current.outlierDrawSettings).toEqual({ color: new Color(0xff0000), mode: DrawMode.HIDE });
     expect(result.current.outlineColor).toEqual(new Color(0x00ff00));
     expect(result.current.openTab).toBe(TabType.TRACK_PLOT);
+  });
+
+  describe("serializeConfigSlice", () => {
+    it("serializes config settings", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      act(() => {
+        result.current.setShowTrackPath(false);
+        result.current.setShowScaleBar(false);
+        result.current.setShowTimestamp(false);
+        result.current.setOutOfRangeDrawSettings({ color: new Color(0xff0000), mode: DrawMode.USE_COLOR });
+        result.current.setOutlierDrawSettings({ color: new Color(0x00ff00), mode: DrawMode.USE_COLOR });
+        result.current.setOutlineColor(new Color(0x0000ff));
+        result.current.setOpenTab(TabType.SCATTER_PLOT);
+      });
+      let serializedData = serializeConfigSlice(result.current);
+      expect(serializedData[UrlParam.SHOW_PATH]).toBe("0");
+      expect(serializedData[UrlParam.SHOW_SCALEBAR]).toBe("0");
+      expect(serializedData[UrlParam.SHOW_TIMESTAMP]).toBe("0");
+      expect(serializedData[UrlParam.FILTERED_COLOR]).toBe("ff0000");
+      expect(serializedData[UrlParam.FILTERED_MODE]).toBe(DrawMode.USE_COLOR.toString());
+      expect(serializedData[UrlParam.OUTLIER_COLOR]).toBe("00ff00");
+      expect(serializedData[UrlParam.OUTLIER_MODE]).toBe(DrawMode.USE_COLOR.toString());
+      expect(serializedData[UrlParam.OUTLINE_COLOR]).toBe("0000ff");
+      expect(serializedData[UrlParam.OPEN_TAB]).toBe(TabType.SCATTER_PLOT);
+
+      act(() => {
+        result.current.setShowTrackPath(true);
+        result.current.setShowScaleBar(true);
+        result.current.setShowTimestamp(true);
+        result.current.setOutOfRangeDrawSettings({ color: new Color(0xffff00), mode: DrawMode.HIDE });
+        result.current.setOutlierDrawSettings({ color: new Color(0x00ffff), mode: DrawMode.HIDE });
+        result.current.setOutlineColor(new Color(0xff00ff));
+        result.current.setOpenTab(TabType.SETTINGS);
+      });
+      serializedData = serializeConfigSlice(result.current);
+      expect(serializedData[UrlParam.SHOW_PATH]).toBe("1");
+      expect(serializedData[UrlParam.SHOW_SCALEBAR]).toBe("1");
+      expect(serializedData[UrlParam.SHOW_TIMESTAMP]).toBe("1");
+      expect(serializedData[UrlParam.FILTERED_COLOR]).toBe("ffff00");
+      expect(serializedData[UrlParam.FILTERED_MODE]).toBe(DrawMode.HIDE.toString());
+      expect(serializedData[UrlParam.OUTLIER_COLOR]).toBe("00ffff");
+      expect(serializedData[UrlParam.OUTLIER_MODE]).toBe(DrawMode.HIDE.toString());
+      expect(serializedData[UrlParam.OUTLINE_COLOR]).toBe("ff00ff");
+      expect(serializedData[UrlParam.OPEN_TAB]).toBe(TabType.SETTINGS);
+    });
+  });
+
+  describe("loadConfigSliceFromParams", () => {
+    it("loads basic config settings", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      const params = new URLSearchParams();
+      params.set(UrlParam.SHOW_PATH, "0");
+      params.set(UrlParam.SHOW_SCALEBAR, "0");
+      params.set(UrlParam.SHOW_TIMESTAMP, "0");
+      params.set(UrlParam.FILTERED_COLOR, "ff0000");
+      params.set(UrlParam.FILTERED_MODE, DrawMode.USE_COLOR.toString());
+      params.set(UrlParam.OUTLIER_COLOR, "00ff00");
+      params.set(UrlParam.OUTLIER_MODE, DrawMode.USE_COLOR.toString());
+      params.set(UrlParam.OUTLINE_COLOR, "0000ff");
+      params.set(UrlParam.OPEN_TAB, TabType.SCATTER_PLOT);
+      act(() => {
+        loadConfigSliceFromParams(result.current, params);
+      });
+      expect(result.current.showTrackPath).toBe(false);
+      expect(result.current.showScaleBar).toBe(false);
+      expect(result.current.showTimestamp).toBe(false);
+      expect(result.current.outOfRangeDrawSettings).toEqual({ color: new Color(0xff0000), mode: DrawMode.USE_COLOR });
+      expect(result.current.outlierDrawSettings).toEqual({ color: new Color(0x00ff00), mode: DrawMode.USE_COLOR });
+      expect(result.current.outlineColor).toEqual(new Color(0x0000ff));
+      expect(result.current.openTab).toBe(TabType.SCATTER_PLOT);
+
+      params.set(UrlParam.SHOW_PATH, "1");
+      params.set(UrlParam.SHOW_SCALEBAR, "1");
+      params.set(UrlParam.SHOW_TIMESTAMP, "1");
+      params.set(UrlParam.FILTERED_COLOR, "ffff00");
+      params.set(UrlParam.FILTERED_MODE, DrawMode.HIDE.toString());
+      params.set(UrlParam.OUTLIER_COLOR, "00ffff");
+      params.set(UrlParam.OUTLIER_MODE, DrawMode.HIDE.toString());
+      params.set(UrlParam.OUTLINE_COLOR, "ff00ff");
+      params.set(UrlParam.OPEN_TAB, TabType.SETTINGS);
+      act(() => {
+        loadConfigSliceFromParams(result.current, params);
+      });
+      expect(result.current.showTrackPath).toBe(true);
+      expect(result.current.showScaleBar).toBe(true);
+      expect(result.current.showTimestamp).toBe(true);
+      expect(result.current.outOfRangeDrawSettings).toEqual({ color: new Color(0xffff00), mode: DrawMode.HIDE });
+      expect(result.current.outlierDrawSettings).toEqual({ color: new Color(0x00ffff), mode: DrawMode.HIDE });
+      expect(result.current.outlineColor).toEqual(new Color(0xff00ff));
+      expect(result.current.openTab).toBe(TabType.SETTINGS);
+    });
+
+    it("ignores invalid draw setting modes", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      const initialOutOfRangeDrawSettings = result.current.outOfRangeDrawSettings;
+      const initialOutlierDrawSettings = result.current.outlierDrawSettings;
+      const params = new URLSearchParams();
+      params.set(UrlParam.FILTERED_MODE, "invalid");
+      params.set(UrlParam.OUTLIER_MODE, "invalid");
+      act(() => {
+        loadConfigSliceFromParams(result.current, params);
+      });
+      expect(result.current.outOfRangeDrawSettings).toStrictEqual(initialOutOfRangeDrawSettings);
+      expect(result.current.outlierDrawSettings).toStrictEqual(initialOutlierDrawSettings);
+    });
+
+    it("ignores invalid tabs", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      const initialOpenTab = result.current.openTab;
+      const params = new URLSearchParams();
+      params.set(UrlParam.OPEN_TAB, "invalid");
+      act(() => {
+        loadConfigSliceFromParams(result.current, params);
+      });
+      expect(result.current.openTab).toBe(initialOpenTab);
+    });
   });
 });

--- a/tests/state/ViewerState/config_slice.test.ts
+++ b/tests/state/ViewerState/config_slice.test.ts
@@ -6,7 +6,53 @@ import { describe, expect, it } from "vitest";
 import { DrawMode, TabType } from "../../../src/colorizer";
 import { UrlParam } from "../../../src/colorizer/utils/url_utils";
 import { useViewerStateStore } from "../../../src/state";
-import { loadConfigSliceFromParams, serializeConfigSlice } from "../../../src/state/slices";
+import { ConfigSlice, loadConfigSliceFromParams, serializeConfigSlice } from "../../../src/state/slices";
+import { SerializedStoreData } from "../../../src/state/types";
+import { compareSerializedData, compareSlice } from "./utils";
+
+const EXAMPLE_SLICE_1: Partial<ConfigSlice> = {
+  showTrackPath: false,
+  showScaleBar: false,
+  showTimestamp: false,
+  outOfRangeDrawSettings: { color: new Color(0xff0000), mode: DrawMode.USE_COLOR },
+  outlierDrawSettings: { color: new Color(0x00ff00), mode: DrawMode.USE_COLOR },
+  outlineColor: new Color(0x0000ff),
+  openTab: TabType.SCATTER_PLOT,
+};
+
+const EXAMPLE_SLICE_1_PARAMS: SerializedStoreData = {
+  [UrlParam.SHOW_PATH]: "0",
+  [UrlParam.SHOW_SCALEBAR]: "0",
+  [UrlParam.SHOW_TIMESTAMP]: "0",
+  [UrlParam.FILTERED_COLOR]: "ff0000",
+  [UrlParam.FILTERED_MODE]: DrawMode.USE_COLOR.toString(),
+  [UrlParam.OUTLIER_COLOR]: "00ff00",
+  [UrlParam.OUTLIER_MODE]: DrawMode.USE_COLOR.toString(),
+  [UrlParam.OUTLINE_COLOR]: "0000ff",
+  [UrlParam.OPEN_TAB]: TabType.SCATTER_PLOT,
+};
+
+const EXAMPLE_SLICE_2: Partial<ConfigSlice> = {
+  showTrackPath: true,
+  showScaleBar: true,
+  showTimestamp: true,
+  outOfRangeDrawSettings: { color: new Color(0xffff00), mode: DrawMode.HIDE },
+  outlierDrawSettings: { color: new Color(0x00ffff), mode: DrawMode.HIDE },
+  outlineColor: new Color(0xff00ff),
+  openTab: TabType.SETTINGS,
+};
+
+const EXAMPLE_SLICE_2_PARAMS: SerializedStoreData = {
+  [UrlParam.SHOW_PATH]: "1",
+  [UrlParam.SHOW_SCALEBAR]: "1",
+  [UrlParam.SHOW_TIMESTAMP]: "1",
+  [UrlParam.FILTERED_COLOR]: "ffff00",
+  [UrlParam.FILTERED_MODE]: DrawMode.HIDE.toString(),
+  [UrlParam.OUTLIER_COLOR]: "00ffff",
+  [UrlParam.OUTLIER_MODE]: DrawMode.HIDE.toString(),
+  [UrlParam.OUTLINE_COLOR]: "ff00ff",
+  [UrlParam.OPEN_TAB]: TabType.SETTINGS,
+};
 
 describe("ConfigSlice", () => {
   it("can set properties", () => {
@@ -59,90 +105,31 @@ describe("ConfigSlice", () => {
     it("serializes config settings", () => {
       const { result } = renderHook(() => useViewerStateStore());
       act(() => {
-        result.current.setShowTrackPath(false);
-        result.current.setShowScaleBar(false);
-        result.current.setShowTimestamp(false);
-        result.current.setOutOfRangeDrawSettings({ color: new Color(0xff0000), mode: DrawMode.USE_COLOR });
-        result.current.setOutlierDrawSettings({ color: new Color(0x00ff00), mode: DrawMode.USE_COLOR });
-        result.current.setOutlineColor(new Color(0x0000ff));
-        result.current.setOpenTab(TabType.SCATTER_PLOT);
+        useViewerStateStore.setState(EXAMPLE_SLICE_1);
       });
       let serializedData = serializeConfigSlice(result.current);
-      expect(serializedData[UrlParam.SHOW_PATH]).toBe("0");
-      expect(serializedData[UrlParam.SHOW_SCALEBAR]).toBe("0");
-      expect(serializedData[UrlParam.SHOW_TIMESTAMP]).toBe("0");
-      expect(serializedData[UrlParam.FILTERED_COLOR]).toBe("ff0000");
-      expect(serializedData[UrlParam.FILTERED_MODE]).toBe(DrawMode.USE_COLOR.toString());
-      expect(serializedData[UrlParam.OUTLIER_COLOR]).toBe("00ff00");
-      expect(serializedData[UrlParam.OUTLIER_MODE]).toBe(DrawMode.USE_COLOR.toString());
-      expect(serializedData[UrlParam.OUTLINE_COLOR]).toBe("0000ff");
-      expect(serializedData[UrlParam.OPEN_TAB]).toBe(TabType.SCATTER_PLOT);
+      compareSerializedData(serializedData, EXAMPLE_SLICE_1_PARAMS);
 
       act(() => {
-        result.current.setShowTrackPath(true);
-        result.current.setShowScaleBar(true);
-        result.current.setShowTimestamp(true);
-        result.current.setOutOfRangeDrawSettings({ color: new Color(0xffff00), mode: DrawMode.HIDE });
-        result.current.setOutlierDrawSettings({ color: new Color(0x00ffff), mode: DrawMode.HIDE });
-        result.current.setOutlineColor(new Color(0xff00ff));
-        result.current.setOpenTab(TabType.SETTINGS);
+        useViewerStateStore.setState(EXAMPLE_SLICE_2);
       });
       serializedData = serializeConfigSlice(result.current);
-      expect(serializedData[UrlParam.SHOW_PATH]).toBe("1");
-      expect(serializedData[UrlParam.SHOW_SCALEBAR]).toBe("1");
-      expect(serializedData[UrlParam.SHOW_TIMESTAMP]).toBe("1");
-      expect(serializedData[UrlParam.FILTERED_COLOR]).toBe("ffff00");
-      expect(serializedData[UrlParam.FILTERED_MODE]).toBe(DrawMode.HIDE.toString());
-      expect(serializedData[UrlParam.OUTLIER_COLOR]).toBe("00ffff");
-      expect(serializedData[UrlParam.OUTLIER_MODE]).toBe(DrawMode.HIDE.toString());
-      expect(serializedData[UrlParam.OUTLINE_COLOR]).toBe("ff00ff");
-      expect(serializedData[UrlParam.OPEN_TAB]).toBe(TabType.SETTINGS);
+      compareSerializedData(serializedData, EXAMPLE_SLICE_2_PARAMS);
     });
   });
 
   describe("loadConfigSliceFromParams", () => {
     it("loads basic config settings", () => {
       const { result } = renderHook(() => useViewerStateStore());
-      const params = new URLSearchParams();
-      params.set(UrlParam.SHOW_PATH, "0");
-      params.set(UrlParam.SHOW_SCALEBAR, "0");
-      params.set(UrlParam.SHOW_TIMESTAMP, "0");
-      params.set(UrlParam.FILTERED_COLOR, "ff0000");
-      params.set(UrlParam.FILTERED_MODE, DrawMode.USE_COLOR.toString());
-      params.set(UrlParam.OUTLIER_COLOR, "00ff00");
-      params.set(UrlParam.OUTLIER_MODE, DrawMode.USE_COLOR.toString());
-      params.set(UrlParam.OUTLINE_COLOR, "0000ff");
-      params.set(UrlParam.OPEN_TAB, TabType.SCATTER_PLOT);
       act(() => {
-        loadConfigSliceFromParams(result.current, params);
+        loadConfigSliceFromParams(result.current, new URLSearchParams(EXAMPLE_SLICE_1_PARAMS));
       });
-      expect(result.current.showTrackPath).toBe(false);
-      expect(result.current.showScaleBar).toBe(false);
-      expect(result.current.showTimestamp).toBe(false);
-      expect(result.current.outOfRangeDrawSettings).toEqual({ color: new Color(0xff0000), mode: DrawMode.USE_COLOR });
-      expect(result.current.outlierDrawSettings).toEqual({ color: new Color(0x00ff00), mode: DrawMode.USE_COLOR });
-      expect(result.current.outlineColor).toEqual(new Color(0x0000ff));
-      expect(result.current.openTab).toBe(TabType.SCATTER_PLOT);
+      compareSlice(result.current, EXAMPLE_SLICE_1);
 
-      params.set(UrlParam.SHOW_PATH, "1");
-      params.set(UrlParam.SHOW_SCALEBAR, "1");
-      params.set(UrlParam.SHOW_TIMESTAMP, "1");
-      params.set(UrlParam.FILTERED_COLOR, "ffff00");
-      params.set(UrlParam.FILTERED_MODE, DrawMode.HIDE.toString());
-      params.set(UrlParam.OUTLIER_COLOR, "00ffff");
-      params.set(UrlParam.OUTLIER_MODE, DrawMode.HIDE.toString());
-      params.set(UrlParam.OUTLINE_COLOR, "ff00ff");
-      params.set(UrlParam.OPEN_TAB, TabType.SETTINGS);
       act(() => {
-        loadConfigSliceFromParams(result.current, params);
+        loadConfigSliceFromParams(result.current, new URLSearchParams(EXAMPLE_SLICE_2_PARAMS));
       });
-      expect(result.current.showTrackPath).toBe(true);
-      expect(result.current.showScaleBar).toBe(true);
-      expect(result.current.showTimestamp).toBe(true);
-      expect(result.current.outOfRangeDrawSettings).toEqual({ color: new Color(0xffff00), mode: DrawMode.HIDE });
-      expect(result.current.outlierDrawSettings).toEqual({ color: new Color(0x00ffff), mode: DrawMode.HIDE });
-      expect(result.current.outlineColor).toEqual(new Color(0xff00ff));
-      expect(result.current.openTab).toBe(TabType.SETTINGS);
+      compareSlice(result.current, EXAMPLE_SLICE_2);
     });
 
     it("ignores invalid draw setting modes", () => {

--- a/tests/state/ViewerState/time_slice.test.ts
+++ b/tests/state/ViewerState/time_slice.test.ts
@@ -108,7 +108,6 @@ describe("useViewerStateStore: TimeSlice", () => {
       await result.current.setFrame(3);
     });
     expect(result.current.pendingFrame).toBe(3);
-    expect(result.current.currentFrame).toBe(3);
 
     await setDatasetAsync(result, MOCK_DATASET_WITH_TWO_FRAMES);
     expect(result.current.pendingFrame).toBe(1);
@@ -120,11 +119,9 @@ describe("useViewerStateStore: TimeSlice", () => {
     await act(async () => {
       await result.current.setFrame(3);
     });
-    expect(result.current.currentFrame).toBe(3);
     expect(result.current.pendingFrame).toBe(3);
 
     await clearDatasetAsync(result);
-    expect(result.current.currentFrame).toBe(0);
     expect(result.current.pendingFrame).toBe(0);
   });
 

--- a/tests/state/ViewerState/time_slice.test.ts
+++ b/tests/state/ViewerState/time_slice.test.ts
@@ -1,7 +1,10 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, Mock, vi } from "vitest";
 
+import { Track } from "../../../src/colorizer";
+import { UrlParam } from "../../../src/colorizer/utils/url_utils";
 import { useViewerStateStore } from "../../../src/state";
+import { loadTimeSliceFromParams, serializeTimeSlice } from "../../../src/state/slices";
 import { ANY_ERROR, sleep } from "../../test_utils";
 import { MOCK_DATASET, MOCK_DATASET_WITH_TWO_FRAMES } from "./constants";
 import { clearDatasetAsync, setDatasetAsync } from "./utils";
@@ -123,5 +126,55 @@ describe("useViewerStateStore: TimeSlice", () => {
     await clearDatasetAsync(result);
     expect(result.current.currentFrame).toBe(0);
     expect(result.current.pendingFrame).toBe(0);
+  });
+
+  describe("serializeTimeSlice", () => {
+    it("serializes 0 values", async () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      await act(async () => {
+        await result.current.setFrame(0);
+      });
+      expect(serializeTimeSlice(result.current)[UrlParam.TIME]).toBe("0");
+    });
+
+    it("serializes time value", async () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      await act(async () => {
+        await result.current.setFrame(155);
+      });
+      expect(serializeTimeSlice(result.current)[UrlParam.TIME]).toBe("155");
+    });
+  });
+
+  describe("loadTimeSliceFromParams", () => {
+    it("loads time from params", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      const params = new URLSearchParams();
+      params.set(UrlParam.TIME, "100");
+      act(() => {
+        loadTimeSliceFromParams(result.current, params);
+      });
+      expect(result.current.pendingFrame).toBe(100);
+
+      params.set(UrlParam.TIME, "0");
+      act(() => {
+        loadTimeSliceFromParams(result.current, params);
+      });
+      expect(result.current.pendingFrame).toBe(0);
+    });
+
+    it("uses track start time if no time is provided", async () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      await setDatasetAsync(result, MOCK_DATASET);
+      act(() => {
+        // Fake track with start time at 50
+        result.current.setTrack(new Track(15, [50], [0], [0, 0], [1, 1]));
+      });
+      const params = new URLSearchParams();
+      act(() => {
+        loadTimeSliceFromParams(result.current, params);
+      });
+      expect(result.current.pendingFrame).toBe(50);
+    });
   });
 });

--- a/tests/state/ViewerState/time_slice.test.ts
+++ b/tests/state/ViewerState/time_slice.test.ts
@@ -135,11 +135,12 @@ describe("useViewerStateStore: TimeSlice", () => {
     });
 
     it("serializes time value", async () => {
+      const frameNumber = 155;
       const { result } = renderHook(() => useViewerStateStore());
       await act(async () => {
-        await result.current.setFrame(155);
+        await result.current.setFrame(frameNumber);
       });
-      expect(serializeTimeSlice(result.current)[UrlParam.TIME]).toBe("155");
+      expect(serializeTimeSlice(result.current)[UrlParam.TIME]).toBe(frameNumber.toString());
     });
   });
 

--- a/tests/state/ViewerState/utils.ts
+++ b/tests/state/ViewerState/utils.ts
@@ -3,9 +3,7 @@ import { act } from "react-dom/test-utils";
 import { expect } from "vitest";
 
 import { Dataset } from "../../../src/colorizer";
-import { UrlParam } from "../../../src/colorizer/utils/url_utils";
 import { ViewerState } from "../../../src/state";
-import { SerializedStoreData } from "../../../src/state/types";
 
 /**
  * Wrapper around `store.setDataset()`. Allows for async operations to complete
@@ -35,19 +33,8 @@ export const clearDatasetAsync = async (result: { current: ViewerState }): Promi
  * Note that `actual` may contain additional key-value pairs not present in
  * `expected` and still pass this check.
  */
-export const compareSlice = (actual: Partial<ViewerState>, expected: Partial<ViewerState>): void => {
+export const compareRecord = <T extends Record<string, unknown>>(actual: T, expected: T): void => {
   for (const key in expected) {
-    expect(actual[key as keyof ViewerState]).toEqual(expected[key as keyof ViewerState]);
-  }
-};
-
-/**
- * Checks whether all key-value pairs in `expected` are present in `actual`.
- * Note that `actual` may contain additional key-value pairs not present in
- * `expected` and still pass this check.
- */
-export const compareSerializedData = (actual: SerializedStoreData, expected: SerializedStoreData): void => {
-  for (const key in expected) {
-    expect(actual[key as UrlParam]).toEqual(expected[key as UrlParam]);
+    expect(actual[key]).toEqual(expected[key]);
   }
 };

--- a/tests/state/ViewerState/utils.ts
+++ b/tests/state/ViewerState/utils.ts
@@ -30,12 +30,22 @@ export const clearDatasetAsync = async (result: { current: ViewerState }): Promi
   await waitFor(() => {});
 };
 
+/**
+ * Checks whether all key-value pairs in `expected` are present in `actual`.
+ * Note that `actual` may contain additional key-value pairs not present in
+ * `expected` and still pass this check.
+ */
 export const compareSlice = (actual: Partial<ViewerState>, expected: Partial<ViewerState>): void => {
   for (const key in expected) {
     expect(actual[key as keyof ViewerState]).toEqual(expected[key as keyof ViewerState]);
   }
 };
 
+/**
+ * Checks whether all key-value pairs in `expected` are present in `actual`.
+ * Note that `actual` may contain additional key-value pairs not present in
+ * `expected` and still pass this check.
+ */
 export const compareSerializedData = (actual: SerializedStoreData, expected: SerializedStoreData): void => {
   for (const key in expected) {
     expect(actual[key as UrlParam]).toEqual(expected[key as UrlParam]);

--- a/tests/state/ViewerState/utils.ts
+++ b/tests/state/ViewerState/utils.ts
@@ -1,8 +1,11 @@
 import { waitFor } from "@testing-library/react";
 import { act } from "react-dom/test-utils";
+import { expect } from "vitest";
 
 import { Dataset } from "../../../src/colorizer";
+import { UrlParam } from "../../../src/colorizer/utils/url_utils";
 import { ViewerState } from "../../../src/state";
+import { SerializedStoreData } from "../../../src/state/types";
 
 /**
  * Wrapper around `store.setDataset()`. Allows for async operations to complete
@@ -25,4 +28,16 @@ export const clearDatasetAsync = async (result: { current: ViewerState }): Promi
     result.current.clearDataset();
   });
   await waitFor(() => {});
+};
+
+export const compareSlice = (actual: Partial<ViewerState>, expected: Partial<ViewerState>): void => {
+  for (const key in expected) {
+    expect(actual[key as keyof ViewerState]).toEqual(expected[key as keyof ViewerState]);
+  }
+};
+
+export const compareSerializedData = (actual: SerializedStoreData, expected: SerializedStoreData): void => {
+  for (const key in expected) {
+    expect(actual[key as UrlParam]).toEqual(expected[key as UrlParam]);
+  }
 };

--- a/tests/state/ViewerState/vector_slice.test.ts
+++ b/tests/state/ViewerState/vector_slice.test.ts
@@ -3,7 +3,9 @@ import { Color } from "three";
 import { describe, expect, it } from "vitest";
 
 import { VECTOR_KEY_MOTION_DELTA, VectorTooltipMode } from "../../../src/colorizer";
+import { UrlParam } from "../../../src/colorizer/utils/url_utils";
 import { useViewerStateStore } from "../../../src/state";
+import { loadVectorSliceFromParams, serializeVectorSlice } from "../../../src/state/slices";
 import { ANY_ERROR } from "../../test_utils";
 
 describe("VectorSlice", () => {
@@ -82,6 +84,137 @@ describe("VectorSlice", () => {
       expect(() => {
         result.current.setVectorMotionTimeIntervals(NaN);
       }).toThrowError(ANY_ERROR);
+    });
+  });
+
+  describe("serializeVectorSlice", () => {
+    it("serializes vector slice", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      act(() => {
+        result.current.setVectorVisible(true);
+        result.current.setVectorKey(VECTOR_KEY_MOTION_DELTA);
+        result.current.setVectorMotionTimeIntervals(1);
+        result.current.setVectorColor(new Color("#ff0000"));
+        result.current.setVectorScaleFactor(2);
+        result.current.setVectorTooltipMode(VectorTooltipMode.COMPONENTS);
+      });
+      let serializedData = serializeVectorSlice(result.current);
+      expect(serializedData[UrlParam.SHOW_VECTOR]).toBe("1");
+      expect(serializedData[UrlParam.VECTOR_KEY]).toBe(VECTOR_KEY_MOTION_DELTA);
+      expect(serializedData[UrlParam.VECTOR_TIME_INTERVALS]).toBe("1");
+      expect(serializedData[UrlParam.VECTOR_COLOR]).toBe("ff0000");
+      expect(serializedData[UrlParam.VECTOR_SCALE]).toBe("2");
+      expect(serializedData[UrlParam.VECTOR_TOOLTIP_MODE]).toBe(VectorTooltipMode.COMPONENTS);
+
+      act(() => {
+        result.current.setVectorVisible(false);
+        // Currently there are no other valid vector keys.
+        result.current.setVectorKey(VECTOR_KEY_MOTION_DELTA);
+        result.current.setVectorMotionTimeIntervals(15);
+        result.current.setVectorColor(new Color("#ffffff"));
+        result.current.setVectorScaleFactor(12);
+        result.current.setVectorTooltipMode(VectorTooltipMode.MAGNITUDE);
+      });
+      serializedData = serializeVectorSlice(result.current);
+      expect(serializedData[UrlParam.SHOW_VECTOR]).toBe("0");
+      expect(serializedData[UrlParam.VECTOR_KEY]).toBe(VECTOR_KEY_MOTION_DELTA);
+      expect(serializedData[UrlParam.VECTOR_TIME_INTERVALS]).toBe("15");
+      expect(serializedData[UrlParam.VECTOR_COLOR]).toBe("ffffff");
+      expect(serializedData[UrlParam.VECTOR_SCALE]).toBe("12");
+      expect(serializedData[UrlParam.VECTOR_TOOLTIP_MODE]).toBe(VectorTooltipMode.MAGNITUDE);
+    });
+  });
+
+  describe("loadVectorSliceFromParams", () => {
+    it("loads basic vector settings", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      const params = new URLSearchParams();
+
+      params.set(UrlParam.SHOW_VECTOR, "1");
+      params.set(UrlParam.VECTOR_KEY, VECTOR_KEY_MOTION_DELTA);
+      params.set(UrlParam.VECTOR_TIME_INTERVALS, "1");
+      params.set(UrlParam.VECTOR_COLOR, "ff0000");
+      params.set(UrlParam.VECTOR_SCALE, "2");
+      params.set(UrlParam.VECTOR_TOOLTIP_MODE, VectorTooltipMode.COMPONENTS);
+      act(() => {
+        loadVectorSliceFromParams(result.current, params);
+      });
+      expect(result.current.vectorVisible).toBe(true);
+      expect(result.current.vectorKey).toBe(VECTOR_KEY_MOTION_DELTA);
+      expect(result.current.vectorMotionTimeIntervals).toBe(1);
+      expect(result.current.vectorColor.getHexString()).toBe("ff0000");
+      expect(result.current.vectorScaleFactor).toBe(2);
+      expect(result.current.vectorTooltipMode).toBe(VectorTooltipMode.COMPONENTS);
+
+      params.set(UrlParam.SHOW_VECTOR, "0");
+      // TODO: Do validation for vector keys if added to Dataset
+      // params.set(UrlParam.VECTOR_KEY, VECTOR_KEY_MOTION_DELTA);
+      params.set(UrlParam.VECTOR_TIME_INTERVALS, "15");
+      params.set(UrlParam.VECTOR_COLOR, "ffffff");
+      params.set(UrlParam.VECTOR_SCALE, "12");
+      params.set(UrlParam.VECTOR_TOOLTIP_MODE, VectorTooltipMode.MAGNITUDE);
+      act(() => {
+        loadVectorSliceFromParams(result.current, params);
+      });
+      expect(result.current.vectorVisible).toBe(false);
+      expect(result.current.vectorKey).toBe(VECTOR_KEY_MOTION_DELTA);
+      expect(result.current.vectorMotionTimeIntervals).toBe(15);
+      expect(result.current.vectorColor.getHexString()).toBe("ffffff");
+      expect(result.current.vectorScaleFactor).toBe(12);
+      expect(result.current.vectorTooltipMode).toBe(VectorTooltipMode.MAGNITUDE);
+    });
+
+    it("ignores invalid vector keys", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      const params = new URLSearchParams();
+      params.set(UrlParam.VECTOR_KEY, "invalid_key");
+      act(() => {
+        loadVectorSliceFromParams(result.current, params);
+      });
+      expect(result.current.vectorKey).not.toBe("invalid_key");
+    });
+
+    it("ignores infinite or NaN scale values", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      const params = new URLSearchParams();
+
+      const initialScale = result.current.vectorScaleFactor;
+      const invalidValues = ["NaN", "Infinity"];
+      for (const value of invalidValues) {
+        params.set(UrlParam.VECTOR_SCALE, value);
+        act(() => {
+          loadVectorSliceFromParams(result.current, params);
+        });
+        expect(result.current.vectorScaleFactor).toBe(initialScale);
+      }
+    });
+
+    it("ignores infinite, NaN, or negative time intervals", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      act(() => {
+        result.current.setVectorMotionTimeIntervals(1);
+      });
+      const initialTimeIntervals = result.current.vectorMotionTimeIntervals;
+
+      const params = new URLSearchParams();
+      const invalidValues = ["NaN", "Infinity", "-1"];
+      for (const value of invalidValues) {
+        params.set(UrlParam.VECTOR_TIME_INTERVALS, value);
+        act(() => {
+          loadVectorSliceFromParams(result.current, params);
+        });
+        expect(result.current.vectorMotionTimeIntervals).toBe(initialTimeIntervals);
+      }
+    });
+
+    it("ignores invalid vector tooltip keys", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      const params = new URLSearchParams();
+      params.set(UrlParam.VECTOR_TOOLTIP_MODE, "invalid");
+      act(() => {
+        loadVectorSliceFromParams(result.current, params);
+      });
+      expect(result.current.vectorTooltipMode).not.toBe("invalid");
     });
   });
 });

--- a/tests/state/ViewerState/vector_slice.test.ts
+++ b/tests/state/ViewerState/vector_slice.test.ts
@@ -130,12 +130,6 @@ describe("VectorSlice", () => {
       const { result } = renderHook(() => useViewerStateStore());
       act(() => {
         useViewerStateStore.setState(EXAMPLE_SLICE_1);
-        result.current.setVectorVisible(true);
-        result.current.setVectorKey(VECTOR_KEY_MOTION_DELTA);
-        result.current.setVectorMotionTimeIntervals(1);
-        result.current.setVectorColor(new Color("#ff0000"));
-        result.current.setVectorScaleFactor(2);
-        result.current.setVectorTooltipMode(VectorTooltipMode.COMPONENTS);
       });
       let serializedData = serializeVectorSlice(result.current);
       compareSerializedData(serializedData, EXAMPLE_SLICE_1_PARAMS);

--- a/tests/state/ViewerState/vector_slice.test.ts
+++ b/tests/state/ViewerState/vector_slice.test.ts
@@ -8,7 +8,7 @@ import { useViewerStateStore } from "../../../src/state";
 import { loadVectorSliceFromParams, serializeVectorSlice, VectorSlice } from "../../../src/state/slices";
 import { SerializedStoreData } from "../../../src/state/types";
 import { ANY_ERROR } from "../../test_utils";
-import { compareSerializedData, compareSlice } from "./utils";
+import { compareRecord } from "./utils";
 
 const EXAMPLE_SLICE_1: Partial<VectorSlice> = {
   vectorVisible: true,
@@ -132,13 +132,13 @@ describe("VectorSlice", () => {
         useViewerStateStore.setState(EXAMPLE_SLICE_1);
       });
       let serializedData = serializeVectorSlice(result.current);
-      compareSerializedData(serializedData, EXAMPLE_SLICE_1_PARAMS);
+      compareRecord(serializedData, EXAMPLE_SLICE_1_PARAMS);
 
       act(() => {
         useViewerStateStore.setState(EXAMPLE_SLICE_2);
       });
       serializedData = serializeVectorSlice(result.current);
-      compareSerializedData(serializedData, EXAMPLE_SLICE_2_PARAMS);
+      compareRecord(serializedData, EXAMPLE_SLICE_2_PARAMS);
     });
   });
 
@@ -148,12 +148,12 @@ describe("VectorSlice", () => {
       act(() => {
         loadVectorSliceFromParams(result.current, new URLSearchParams(EXAMPLE_SLICE_1_PARAMS));
       });
-      compareSlice(result.current, EXAMPLE_SLICE_1);
+      compareRecord(result.current, EXAMPLE_SLICE_1);
 
       act(() => {
         loadVectorSliceFromParams(result.current, new URLSearchParams(EXAMPLE_SLICE_2_PARAMS));
       });
-      compareSlice(result.current, EXAMPLE_SLICE_2);
+      compareRecord(result.current, EXAMPLE_SLICE_2);
     });
 
     it("ignores invalid vector keys", () => {


### PR DESCRIPTION
Problem
=======
Part 12 of (15?) for #492, "refactor state management."

This change continues the URL serialization/deserialization work for the time, config, and vector slices of state. These slices should now be loaded from the URL successfully (but won't be synced to the URL until later).

There are four more slices that need to be serialized in the next PR.

*Estimated review size: medium, 30-40 minutes*

Solution
========
- Added serialization and deserialization for the TimeSlice, ConfigSlice, and VectorSlice data.
- Added utility methods for comparing store values.
- Added unit tests.

## Type of change
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

Steps to Verify:
----------------
1. Open the preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-593/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&feature=volume&track=74164&t=285&filters=growth_outlier_filter%3A%3A3%2Cbaseline_colonies_dataset_filter%3A%3A3%2Cfullinterphase_dataset_filter%3A%3A3%2Clineageannotated_dataset_filter%3A%3A3&color=matplotlib-cool&palette-key=adobe&bg-sat=100&bg-brightness=100&fg-alpha=50&outlier-color=00ff19&outlier-mode=1&filter-color=dddddd&filter-mode=0&outline-color=ff4e00&tab=settings&vc=1&vc-color=0048ff&vc-key=_motion_&vc-scale=12&vc-time-int=11&vc-tooltip=c&bg=0&scalebar=0&timestamp=0&path=0&keep-range=0&bg-key=max_intensity_zprojection_of_lamin_b1&scatter-range=all
2. The view and settings tab should match the below screenshot:

![image](https://github.com/user-attachments/assets/31cafc9c-653d-453b-a3a7-40ae6edfa46e)

