### PR TITLE
refactor: Serialization/deserialization for collection, thresholds, scatterplot, and backdrops (state pt. 13)

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -122,7 +122,6 @@ function Viewer(): ReactElement {
 
   const setScatterXAxis = useViewerStateStore((state) => state.setScatterXAxis);
   const setScatterYAxis = useViewerStateStore((state) => state.setScatterYAxis);
-  const setScatterRangeType = useViewerStateStore((state) => state.setScatterRangeType);
   const openTab = useViewerStateStore((state) => state.openTab);
   const setOpenTab = useViewerStateStore((state) => state.setOpenTab);
 
@@ -146,7 +145,6 @@ function Viewer(): ReactElement {
   const categoricalPalette = useViewerStateStore((state) => state.categoricalPalette);
   const setCategoricalPalette = useViewerStateStore((state) => state.setCategoricalPalette);
   const featureThresholds = useViewerStateStore((state) => state.thresholds);
-  const setFeatureThresholds = useViewerStateStore((state) => state.setThresholds);
 
   const [playbackFps, setPlaybackFps] = useState(DEFAULT_PLAYBACK_FPS);
 
@@ -532,47 +530,12 @@ function Viewer(): ReactElement {
         setIsInitialDatasetLoaded(true);
       }
       setIsDatasetLoading(false);
+      // Load the viewer state from the URL after the dataset is loaded.
+      loadViewerStateFromParams(useViewerStateStore, initialSearchParams);
       return;
     };
     loadInitialDataset();
   }, []);
-
-  // Load additional properties from the URL, including the time, track, and feature.
-  // Run only once after the first dataset has been loaded.
-  useEffect(() => {
-    if (!isInitialDatasetLoaded) {
-      return;
-    }
-    // TODO: Move initial parsing out of `Viewer.tsx` once state store is
-    // fully implemented.
-    const setupInitialParameters = async (): Promise<void> => {
-      loadViewerStateFromParams(useViewerStateStore, initialSearchParams);
-
-      if (initialUrlParams.thresholds) {
-        setFeatureThresholds(initialUrlParams.thresholds);
-      }
-
-      if (initialUrlParams.scatterPlotConfig) {
-        const newScatterPlotConfig = initialUrlParams.scatterPlotConfig;
-        // For backwards-compatibility, cast xAxis and yAxis to feature keys.
-        if (newScatterPlotConfig.xAxis) {
-          const xAxis = newScatterPlotConfig.xAxis;
-          const newXAxis = xAxis === SCATTERPLOT_TIME_FEATURE.value ? xAxis : dataset?.findFeatureByKeyOrName(xAxis);
-          setScatterXAxis(newXAxis ?? null);
-        }
-        if (newScatterPlotConfig.yAxis) {
-          const yAxis = newScatterPlotConfig.yAxis;
-          const newYAxis = yAxis === SCATTERPLOT_TIME_FEATURE.value ? yAxis : dataset?.findFeatureByKeyOrName(yAxis);
-          setScatterYAxis(newYAxis ?? null);
-        }
-        if (newScatterPlotConfig.rangeType) {
-          setScatterRangeType(newScatterPlotConfig.rangeType);
-        }
-      }
-    };
-
-    setupInitialParameters();
-  }, [isInitialDatasetLoaded]);
 
   // DISPLAY CONTROLS //////////////////////////////////////////////////////
   const handleDatasetChange = useCallback(

--- a/src/colorizer/canvas/elements/legend.ts
+++ b/src/colorizer/canvas/elements/legend.ts
@@ -1,6 +1,6 @@
 import { Color, Vector2 } from "three";
 
-import { numberToStringDecimal } from "../../utils/math_utils";
+import { formatNumber } from "../../utils/math_utils";
 import { BaseRenderParams, defaultFontStyle, EMPTY_RENDER_INFO, FontStyle, RenderInfo } from "../types";
 import { configureCanvasText, renderCanvasText } from "../utils";
 
@@ -184,8 +184,8 @@ function getNumericKeyRenderer(ctx: CanvasRenderingContext2D, params: LegendPara
 
       // Render min/max labels under color ramp
       const rangeLabelFontStyle: FontStyle = { ...style, fontSizePx: style.labelFontSizePx };
-      const minLabel = numberToStringDecimal(params.colorMapRangeMin, 3, true);
-      const maxLabel = numberToStringDecimal(params.colorMapRangeMax, 3, true);
+      const minLabel = formatNumber(params.colorMapRangeMin, 3);
+      const maxLabel = formatNumber(params.colorMapRangeMax, 3);
       configureCanvasText(ctx, rangeLabelFontStyle, "left", "top");
       renderCanvasText(ctx, origin.x, origin.y, minLabel, { maxWidth: maxWidthPx / 2 });
       configureCanvasText(ctx, rangeLabelFontStyle, "right", "top");

--- a/src/colorizer/utils/math_utils.ts
+++ b/src/colorizer/utils/math_utils.ts
@@ -10,8 +10,8 @@ import Track from "../Track";
  * digits after the decimal place. If `input` is less than 1, this will be the
  * number of significant digits. If `input is greater than 1, this will be the
  * number of digits after the decimal point.
- * @param skipIntegers If true (default), integers will be returned as strings
- * without decimal points.
+ * @param showIntegersAsDecimals If true, integers will be shown as numbers with
+ * decimal points. False by default.
  * @returns A string representation of the number.
  * - If the number is `undefined` or `null`, returns `"NaN"`.
  * - If the number is an integer and `skipIntegers` is true, returns the number
@@ -23,14 +23,14 @@ import Track from "../Track";
  *   digits after the decimal point (using `toFixed`).
  *
  */
-export function numberToStringDecimal(
+export function formatNumber(
   input: number | undefined | null,
   maxSignificantDigitsAfterDecimal: number,
-  skipIntegers: boolean = true
+  showIntegersAsDecimals: boolean = false
 ): string {
   if (input === undefined || input === null) {
     return "NaN";
-  } else if (Number.isInteger(input) && skipIntegers) {
+  } else if (Number.isInteger(input) && !showIntegersAsDecimals) {
     return input.toString();
   } else if (Math.abs(input) < 1) {
     // For numbers less than 1, return value by precision
@@ -44,7 +44,7 @@ export function numberToStringDecimal(
  * Returns the number with a maximum number of digits after the decimal place, rounded to nearest.
  */
 export function setMaxDecimalPrecision(input: number, decimalPlaces: number): number {
-  return Number.parseFloat(numberToStringDecimal(input, decimalPlaces, true));
+  return Number.parseFloat(formatNumber(input, decimalPlaces, true));
 }
 
 // Adapted from https://gist.github.com/ArneS/2ecfbe4a9d7072ac56c0.

--- a/src/colorizer/utils/math_utils.ts
+++ b/src/colorizer/utils/math_utils.ts
@@ -7,7 +7,9 @@ import Track from "../Track";
  * digits after the decimal place.
  * @param input The number to format.
  * @param maxSignificantDigitsAfterDecimal The maximum number of significant
- * digits after the decimal place.
+ * digits after the decimal place. If `input` is less than 1, this will be the
+ * number of significant digits. If `input is greater than 1, this will be the
+ * number of digits after the decimal point.
  * @param skipIntegers If true (default), integers will be returned as strings
  * without decimal points.
  * @returns A string representation of the number.

--- a/src/colorizer/utils/math_utils.ts
+++ b/src/colorizer/utils/math_utils.ts
@@ -3,21 +3,39 @@ import { Vector2 } from "three";
 import Track from "../Track";
 
 /**
- * Formats a number as a string decimal with a defined number of digits
- * after the decimal place. Optionally ignores integers and returns them as-is.
+ * Formats a number as a string decimal, with a maximum number of significant
+ * digits after the decimal place.
+ * @param input The number to format.
+ * @param maxSignificantDigitsAfterDecimal The maximum number of significant
+ * digits after the decimal place.
+ * @param skipIntegers If true (default), integers will be returned as strings
+ * without decimal points.
+ * @returns A string representation of the number.
+ * - If the number is `undefined` or `null`, returns `"NaN"`.
+ * - If the number is an integer and `skipIntegers` is true, returns the number
+ *   as a string without a decimal point.
+ * - If the number is less than 1, returns the number with
+ *   `maxSignificantDigitsAfterDecimal` significant digits. (using
+ *   `toPrecision`).
+ * - Otherwise, returns the number with `maxSignificantDigitsAfterDecimal`
+ *   digits after the decimal point (using `toFixed`).
+ *
  */
 export function numberToStringDecimal(
   input: number | undefined | null,
-  decimalPlaces: number,
+  maxSignificantDigitsAfterDecimal: number,
   skipIntegers: boolean = true
 ): string {
   if (input === undefined || input === null) {
     return "NaN";
-  }
-  if (Number.isInteger(input) && skipIntegers) {
+  } else if (Number.isInteger(input) && skipIntegers) {
     return input.toString();
+  } else if (Math.abs(input) < 1) {
+    // For numbers less than 1, return value by precision
+    return input.toPrecision(maxSignificantDigitsAfterDecimal);
+  } else {
+    return input.toFixed(maxSignificantDigitsAfterDecimal);
   }
-  return input.toFixed(decimalPlaces);
 }
 
 /**

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -24,7 +24,7 @@ import {
 } from "../types";
 import { nanToNull } from "./data_load_utils";
 import { AnyManifestFile } from "./dataset_utils";
-import { numberToStringDecimal } from "./math_utils";
+import { formatNumber } from "./math_utils";
 
 // TODO: This file needs to be split up for easier reading and unit testing.
 // This could also be a great opportunity to reconsider how we store and manage state.
@@ -184,8 +184,8 @@ function serializeThreshold(threshold: FeatureThreshold): string {
     return `${featureKey}:${featureUnit}:${selectedHex}`;
   } else {
     // Numeric feature
-    const min = numberToStringDecimal(threshold.min, 3);
-    const max = numberToStringDecimal(threshold.max, 3);
+    const min = formatNumber(threshold.min, 3);
+    const max = formatNumber(threshold.max, 3);
     return `${featureKey}:${featureUnit}:${min}:${max}`;
   }
 }
@@ -339,7 +339,7 @@ export function decodeHexColor(value: string | null): Color | undefined {
 }
 
 export function encodeNumber(value: number): string {
-  return numberToStringDecimal(value, 3);
+  return formatNumber(value, 3);
 }
 
 export function decodeFloat(value: string | null): number | undefined {
@@ -532,7 +532,7 @@ export function paramsToUrlQueryString(state: Partial<UrlParams>): string {
     includedParameters.push(`${UrlParam.THRESHOLDS}=${encodeURIComponent(serializeThresholds(state.thresholds))}`);
   }
   if (state.range && state.range.length === 2) {
-    const rangeString = `${numberToStringDecimal(state.range[0], 3)},${numberToStringDecimal(state.range[1], 3)}`;
+    const rangeString = `${formatNumber(state.range[0], 3)},${formatNumber(state.range[1], 3)}`;
     includedParameters.push(`${UrlParam.RANGE}=${encodeURIComponent(rangeString)}`);
   }
   if (state.colorRampKey) {

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -416,7 +416,7 @@ function deserializeViewerConfig(params: URLSearchParams): Partial<ViewerConfig>
   return Object.keys(finalConfig).length === 0 ? undefined : finalConfig;
 }
 
-const rangeTypeToUrlParam: Record<PlotRangeType, string> = {
+const scatterPlotRangeTypeToUrlParam: Record<PlotRangeType, string> = {
   [PlotRangeType.ALL_TIME]: "all",
   [PlotRangeType.CURRENT_TRACK]: "track",
   [PlotRangeType.CURRENT_FRAME]: "frame",
@@ -429,7 +429,7 @@ const urlParamToRangeType: Record<string, PlotRangeType> = {
 };
 
 export function encodeScatterPlotRangeType(rangeType: PlotRangeType): string {
-  return rangeTypeToUrlParam[rangeType];
+  return scatterPlotRangeTypeToUrlParam[rangeType];
 }
 
 export function decodeScatterPlotRangeType(rangeString: string | null): PlotRangeType | undefined {
@@ -442,7 +442,7 @@ export function decodeScatterPlotRangeType(rangeString: string | null): PlotRang
 function serializeScatterPlotConfig(config: Partial<ScatterPlotConfig>): string[] {
   const parameters: string[] = [];
   if (config.rangeType) {
-    const rangeString = rangeTypeToUrlParam[config.rangeType];
+    const rangeString = scatterPlotRangeTypeToUrlParam[config.rangeType];
     parameters.push(`${UrlParam.SCATTERPLOT_RANGE_MODE}=${rangeString}`);
   }
   config.xAxis && parameters.push(`${UrlParam.SCATTERPLOT_X_AXIS}=${encodeURIComponent(config.xAxis)}`);

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -45,7 +45,7 @@ export enum UrlParam {
   BACKDROP_KEY = "bg-key",
   BACKDROP_BRIGHTNESS = "bg-brightness",
   BACKDROP_SATURATION = "bg-sat",
-  FOREGROUND_ALPHA = "fg-alpha",
+  OBJECT_OPACITY = "fg-alpha",
   OUTLIER_MODE = "outlier-mode",
   OUTLIER_COLOR = "outlier-color",
   FILTERED_MODE = "filter-mode",
@@ -190,6 +190,10 @@ function serializeThreshold(threshold: FeatureThreshold): string {
   }
 }
 
+export function serializeThresholds(thresholds: FeatureThreshold[]): string {
+  return thresholds.map(serializeThreshold).join(",");
+}
+
 /**
  * Deserializes a single threshold string into a FeatureThreshold object.
  * @param thresholdString Threshold string to parse.
@@ -251,11 +255,7 @@ function deserializeThreshold(thresholdString: string): FeatureThreshold | undef
   return threshold;
 }
 
-function serializeThresholds(thresholds: FeatureThreshold[]): string {
-  return thresholds.map(serializeThreshold).join(",");
-}
-
-function deserializeThresholds(thresholds: string | null): FeatureThreshold[] | undefined {
+export function deserializeThresholds(thresholds: string | null): FeatureThreshold[] | undefined {
   if (!thresholds) {
     return undefined;
   }
@@ -289,7 +289,7 @@ function serializeViewerConfig(config: Partial<ViewerConfig>): string[] {
 
   // Foreground
   if (config.objectOpacity !== undefined) {
-    parameters.push(`${UrlParam.FOREGROUND_ALPHA}=${config.objectOpacity}`);
+    parameters.push(`${UrlParam.OBJECT_OPACITY}=${config.objectOpacity}`);
   }
 
   // Outlier + filter colors
@@ -378,7 +378,7 @@ function deserializeViewerConfig(params: URLSearchParams): Partial<ViewerConfig>
   const newConfig: Partial<ViewerConfig> = {};
   newConfig.backdropSaturation = decodeInt(params.get(UrlParam.BACKDROP_SATURATION));
   newConfig.backdropBrightness = decodeInt(params.get(UrlParam.BACKDROP_BRIGHTNESS));
-  newConfig.objectOpacity = decodeInt(params.get(UrlParam.FOREGROUND_ALPHA));
+  newConfig.objectOpacity = decodeInt(params.get(UrlParam.OBJECT_OPACITY));
 
   if (params.get(UrlParam.OUTLIER_COLOR) || params.get(UrlParam.OUTLIER_MODE)) {
     newConfig.outlierDrawSettings = parseDrawSettings(
@@ -427,6 +427,17 @@ const urlParamToRangeType: Record<string, PlotRangeType> = {
   track: PlotRangeType.CURRENT_TRACK,
   frame: PlotRangeType.CURRENT_FRAME,
 };
+
+export function encodeScatterPlotRangeType(rangeType: PlotRangeType): string {
+  return rangeTypeToUrlParam[rangeType];
+}
+
+export function decodeScatterPlotRangeType(rangeString: string | null): PlotRangeType | undefined {
+  if (rangeString === null) {
+    return;
+  }
+  return urlParamToRangeType[rangeString];
+}
 
 function serializeScatterPlotConfig(config: Partial<ScatterPlotConfig>): string[] {
   const parameters: string[] = [];

--- a/src/components/LabeledSlider.tsx
+++ b/src/components/LabeledSlider.tsx
@@ -4,7 +4,7 @@ import React, { ReactElement, ReactEventHandler, ReactNode, useRef } from "react
 import styled, { css } from "styled-components";
 import { clamp } from "three/src/math/MathUtils";
 
-import { numberToStringDecimal, setMaxDecimalPrecision } from "../colorizer/utils/math_utils";
+import { formatNumber, setMaxDecimalPrecision } from "../colorizer/utils/math_utils";
 import { excludeUndefinedValues } from "../colorizer/utils/react_utils";
 
 type BaseLabeledSliderProps = {
@@ -205,7 +205,7 @@ export default function LabeledSlider(inputProps: LabeledSliderProps): ReactElem
     });
   }
 
-  const defaultNumberFormatter = (value?: number): string => numberToStringDecimal(value, props.maxDecimalsToDisplay);
+  const defaultNumberFormatter = (value?: number): string => formatNumber(value, props.maxDecimalsToDisplay);
   const numberFormatter = props.numberFormatter ? props.numberFormatter : defaultNumberFormatter;
 
   // Use a placeholder if the min/max bounds are undefined

--- a/src/components/Tooltips/CanvasHoverTooltip.tsx
+++ b/src/components/Tooltips/CanvasHoverTooltip.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { useShallow } from "zustand/shallow";
 
 import { AnnotationSelectionMode, VECTOR_KEY_MOTION_DELTA, VectorTooltipMode } from "../../colorizer";
-import { numberToStringDecimal } from "../../colorizer/utils/math_utils";
+import { formatNumber } from "../../colorizer/utils/math_utils";
 import { AnnotationState } from "../../colorizer/utils/react_utils";
 import { selectVectorConfigFromState } from "../../state/slices";
 import { FlexColumn, FlexRow } from "../../styles/utils";
@@ -60,7 +60,7 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
       let featureValue = featureData?.data[id] ?? -1;
       featureValue = isFinite(featureValue) ? featureValue : NaN;
       const unitsLabel = featureData?.unit ? ` ${featureData?.unit}` : "";
-      return numberToStringDecimal(featureValue, 3) + unitsLabel;
+      return formatNumber(featureValue, 3) + unitsLabel;
     },
     [featureKey, dataset]
   );
@@ -96,13 +96,13 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
     if (vectorConfig.tooltipMode === VectorTooltipMode.MAGNITUDE) {
       const magnitude = Math.sqrt(motionDelta[0] ** 2 + motionDelta[1] ** 2);
       const angleDegrees = (360 + Math.atan2(-motionDelta[1], motionDelta[0]) * (180 / Math.PI)) % 360;
-      const magnitudeText = numberToStringDecimal(magnitude, 3);
-      const angleText = numberToStringDecimal(angleDegrees, 1);
+      const magnitudeText = formatNumber(magnitude, 3);
+      const angleText = formatNumber(angleDegrees, 1);
       return `${vectorName}: ${magnitudeText} px, ${angleText}°`;
     } else {
-      const allowIntegerTruncation = Number.isInteger(motionDelta[0]) && Number.isInteger(motionDelta[1]);
-      const x = numberToStringDecimal(motionDelta[0], 3, allowIntegerTruncation);
-      const y = numberToStringDecimal(motionDelta[1], 3, allowIntegerTruncation);
+      const showIntegersAsDecimals = !Number.isInteger(motionDelta[0]) || !Number.isInteger(motionDelta[1]);
+      const x = formatNumber(motionDelta[0], 3, showIntegersAsDecimals);
+      const y = formatNumber(motionDelta[1], 3, showIntegersAsDecimals);
       return `${vectorName}: (${x}, ${y}) px
        `;
     }

--- a/src/state/slices/backdrop_slice.ts
+++ b/src/state/slices/backdrop_slice.ts
@@ -1,5 +1,6 @@
 import { StateCreator } from "zustand";
 
+import { decodeBoolean, decodeFloat, encodeBoolean, encodeNumber, UrlParam } from "../../colorizer/utils/url_utils";
 import {
   BACKDROP_BRIGHTNESS_DEFAULT,
   BACKDROP_BRIGHTNESS_MAX,
@@ -11,7 +12,7 @@ import {
   BACKDROP_SATURATION_MAX,
   BACKDROP_SATURATION_MIN,
 } from "../../constants";
-import { SubscribableStore } from "../types";
+import { SerializedStoreData, SubscribableStore } from "../types";
 import { clampWithNanCheck } from "../utils/data_validation";
 import { DatasetSlice } from "./dataset_slice";
 
@@ -77,4 +78,32 @@ export const addBackdropDerivedStateSubscribers = (store: SubscribableStore<Back
     (state) => state.backdropKey,
     (backdropKey) => store.setState({ backdropVisible: store.getState().backdropVisible && backdropKey !== null })
   );
+};
+
+export const serializeBackdropSlice = (state: BackdropSlice): SerializedStoreData => {
+  const ret: SerializedStoreData = {};
+  ret[UrlParam.SHOW_BACKDROP] = encodeBoolean(state.backdropVisible);
+  ret[UrlParam.BACKDROP_BRIGHTNESS] = encodeNumber(state.backdropBrightness);
+  ret[UrlParam.BACKDROP_SATURATION] = encodeNumber(state.backdropSaturation);
+  ret[UrlParam.OBJECT_OPACITY] = encodeNumber(state.objectOpacity);
+  return ret;
+};
+
+export const loadBackdropSliceFromParams = (slice: BackdropSlice, params: URLSearchParams): void => {
+  const showBackdrop = decodeBoolean(params.get(UrlParam.SHOW_BACKDROP));
+  if (showBackdrop !== undefined) {
+    slice.setBackdropVisible(showBackdrop);
+  }
+  const backdropBrightness = decodeFloat(params.get(UrlParam.BACKDROP_BRIGHTNESS));
+  if (backdropBrightness !== undefined && Number.isFinite(backdropBrightness)) {
+    slice.setBackdropBrightness(backdropBrightness);
+  }
+  const backdropSaturation = decodeFloat(params.get(UrlParam.BACKDROP_SATURATION));
+  if (backdropSaturation !== undefined && Number.isFinite(backdropSaturation)) {
+    slice.setBackdropSaturation(backdropSaturation);
+  }
+  const objectOpacity = decodeFloat(params.get(UrlParam.OBJECT_OPACITY));
+  if (objectOpacity !== undefined && Number.isFinite(objectOpacity)) {
+    slice.setObjectOpacity(objectOpacity);
+  }
 };

--- a/src/state/slices/collection_slice.ts
+++ b/src/state/slices/collection_slice.ts
@@ -11,7 +11,6 @@ type CollectionSliceState = {
 
 type CollectionSliceActions = {
   setCollection: (collection: Collection) => void;
-  // TODO: Add action for loading and setting a dataset here
 };
 
 export type CollectionSlice = CollectionSliceState & CollectionSliceActions;
@@ -26,8 +25,8 @@ export const createCollectionSlice: StateCreator<CollectionSlice, [], [], Collec
 
 export const serializeCollectionSlice = (slice: CollectionSlice): SerializedStoreData => {
   const collection = slice.collection;
-  // Collection URl is null if a single dataset was loaded, so the collection is
-  // a mocked collection with a single dataset.
+  // Collection URL is null if a single dataset was loaded directly.
+  // In this case, the collection doesn't need to be included in the URL.
   if (collection === null || collection.url === null) {
     return {};
   }

--- a/src/state/slices/collection_slice.ts
+++ b/src/state/slices/collection_slice.ts
@@ -1,5 +1,7 @@
 import { StateCreator } from "zustand";
 
+import { UrlParam } from "../../colorizer/utils/url_utils";
+import { SerializedStoreData } from "../types";
 import { DatasetSlice } from "./dataset_slice";
 
 import Collection from "../../colorizer/Collection";
@@ -25,3 +27,15 @@ export const createCollectionSlice: StateCreator<CollectionSlice & DatasetSlice,
     set({ collection });
   },
 });
+
+export const serializeCollectionSlice = (slice: CollectionSlice): SerializedStoreData => {
+  const collection = slice.collection;
+  // Collection URl is null if a single dataset was loaded, so the collection is
+  // a mocked collection with a single dataset.
+  if (collection === null || collection.url === null) {
+    return {};
+  }
+  return {
+    [UrlParam.COLLECTION]: collection.url,
+  };
+};

--- a/src/state/slices/collection_slice.ts
+++ b/src/state/slices/collection_slice.ts
@@ -2,7 +2,6 @@ import { StateCreator } from "zustand";
 
 import { UrlParam } from "../../colorizer/utils/url_utils";
 import { SerializedStoreData } from "../types";
-import { DatasetSlice } from "./dataset_slice";
 
 import Collection from "../../colorizer/Collection";
 
@@ -17,10 +16,7 @@ type CollectionSliceActions = {
 
 export type CollectionSlice = CollectionSliceState & CollectionSliceActions;
 
-export const createCollectionSlice: StateCreator<CollectionSlice & DatasetSlice, [], [], CollectionSlice> = (
-  set,
-  _get
-) => ({
+export const createCollectionSlice: StateCreator<CollectionSlice, [], [], CollectionSlice> = (set, _get) => ({
   collection: null,
 
   setCollection: (collection: Collection) => {

--- a/src/state/slices/scatterplot_slice.ts
+++ b/src/state/slices/scatterplot_slice.ts
@@ -2,8 +2,9 @@ import { StateCreator } from "zustand";
 
 import { Dataset } from "../../colorizer";
 import { PlotRangeType } from "../../colorizer/types";
+import { decodeScatterPlotRangeType, encodeScatterPlotRangeType, UrlParam } from "../../colorizer/utils/url_utils";
 import { SCATTERPLOT_TIME_FEATURE } from "../../components/Tabs/scatter_plot_data_utils";
-import { SubscribableStore } from "../types";
+import { SerializedStoreData, SubscribableStore } from "../types";
 import { addDerivedStateSubscriber } from "../utils/store_utils";
 import { DatasetSlice } from "./dataset_slice";
 
@@ -75,4 +76,33 @@ export const addScatterPlotSliceDerivedStateSubscribers = (
       }
     }
   );
+};
+
+export const serializeScatterPlotSlice = (slice: ScatterPlotSlice): SerializedStoreData => {
+  const ret: SerializedStoreData = {};
+  if (slice.scatterXAxis !== null) {
+    ret[UrlParam.SCATTERPLOT_X_AXIS] = slice.scatterXAxis;
+  }
+  if (slice.scatterYAxis !== null) {
+    ret[UrlParam.SCATTERPLOT_Y_AXIS] = slice.scatterYAxis;
+  }
+  ret[UrlParam.SCATTERPLOT_RANGE_MODE] = encodeScatterPlotRangeType(slice.scatterRangeType);
+  return ret;
+};
+
+export const loadScatterPlotSliceFromParams = (slice: ScatterPlotSlice, params: URLSearchParams): void => {
+  const scatterXAxis = params.get(UrlParam.SCATTERPLOT_X_AXIS);
+  if (scatterXAxis !== null) {
+    slice.setScatterXAxis(scatterXAxis);
+  }
+
+  const scatterYAxis = params.get(UrlParam.SCATTERPLOT_Y_AXIS);
+  if (scatterYAxis !== null) {
+    slice.setScatterYAxis(scatterYAxis);
+  }
+
+  const scatterRangeType = decodeScatterPlotRangeType(params.get(UrlParam.SCATTERPLOT_RANGE_MODE));
+  if (scatterRangeType !== undefined) {
+    slice.setScatterRangeType(scatterRangeType);
+  }
 };

--- a/src/state/slices/threshold_slice.ts
+++ b/src/state/slices/threshold_slice.ts
@@ -2,7 +2,8 @@ import { StateCreator } from "zustand";
 
 import { FeatureThreshold } from "../../colorizer";
 import { getInRangeLUT, validateThresholds } from "../../colorizer/utils/data_utils";
-import { SubscribableStore } from "../types";
+import { deserializeThresholds, serializeThresholds, UrlParam } from "../../colorizer/utils/url_utils";
+import { SerializedStoreData, SubscribableStore } from "../types";
 import { addDerivedStateSubscriber } from "../utils/store_utils";
 import { CollectionSlice } from "./collection_slice";
 import { DatasetSlice } from "./dataset_slice";
@@ -69,4 +70,18 @@ export const addThresholdDerivedStateSubscribers = (
     (state) => state.collection,
     () => ({ thresholds: [] })
   );
+};
+
+export const serializeThresholdSlice = (slice: ThresholdSlice): SerializedStoreData => {
+  if (slice.thresholds.length === 0) {
+    return {};
+  }
+  return { [UrlParam.THRESHOLDS]: serializeThresholds(slice.thresholds) };
+};
+
+export const loadThresholdSliceFromParams = (slice: ThresholdSlice, params: URLSearchParams): void => {
+  const thresholds = deserializeThresholds(params.get(UrlParam.THRESHOLDS));
+  if (thresholds !== undefined) {
+    slice.setThresholds(thresholds);
+  }
 };

--- a/src/state/utils/store_io.ts
+++ b/src/state/utils/store_io.ts
@@ -1,4 +1,5 @@
 import {
+  loadBackdropSliceFromParams,
   loadColorRampSliceFromParams,
   loadConfigSliceFromParams,
   loadDatasetSliceFromParams,
@@ -26,7 +27,6 @@ export const serializeViewerStateStore = (store: Store<ViewerState>): Partial<Se
   // Ordered by approximate importance in the URL
   return {
     ...serializeCollectionSlice(store.getState()),
-    ...serializeVectorSlice(store.getState()),
     ...serializeDatasetSlice(store.getState()),
     ...serializeTimeSlice(store.getState()),
     ...serializeColorRampSlice(store.getState()),
@@ -49,23 +49,23 @@ export const serializedStoreDataToUrl = (data: SerializedStoreData): string => {
 // DESERIALIZATION ///////////////////////////////////////////////////////////////////////
 
 /**
- * Loads the viewer state from the given URL  parameters. Note that this MUST be
- * called after the dataset is loaded and set in the store.
+ * Loads the viewer state from the given URL parameters. Note that this MUST be
+ * called after the collection and dataset are loaded and set in the store.
  */
 export const loadViewerStateFromParams = async (store: Store<ViewerState>, params: URLSearchParams): Promise<void> => {
-  // NOTE: Ordering is important here, because of dependencies between slices.
   // 1. No dependencies:
   loadConfigSliceFromParams(store.getState(), params);
 
   // 2. Dependent on dataset object:
+  loadBackdropSliceFromParams(store.getState(), params);
   loadDatasetSliceFromParams(store.getState(), params);
-  loadThresholdSliceFromParams(store.getState(), params);
   loadScatterPlotSliceFromParams(store.getState(), params);
+  loadThresholdSliceFromParams(store.getState(), params);
   loadVectorSliceFromParams(store.getState(), params);
 
-  // 3. Dependent on dataset fields (track/backdrop/features):
+  // 3. Dependent on dataset slice (track/backdrop/features):
   loadTimeSliceFromParams(store.getState(), params);
 
-  // 4. Dependent on dataset + thresholds:
+  // 4. Dependent on dataset + threshold slices:
   loadColorRampSliceFromParams(store.getState(), params);
 };

--- a/src/state/utils/store_io.ts
+++ b/src/state/utils/store_io.ts
@@ -2,11 +2,17 @@ import {
   loadColorRampSliceFromParams,
   loadConfigSliceFromParams,
   loadDatasetSliceFromParams,
+  loadScatterPlotSliceFromParams,
+  loadThresholdSliceFromParams,
   loadTimeSliceFromParams,
   loadVectorSliceFromParams,
+  serializeBackdropSlice,
+  serializeCollectionSlice,
   serializeColorRampSlice,
   serializeConfigSlice,
   serializeDatasetSlice,
+  serializeScatterPlotSlice,
+  serializeThresholdSlice,
   serializeTimeSlice,
   serializeVectorSlice,
 } from "../slices";
@@ -19,10 +25,15 @@ import { ViewerState } from "../ViewerState";
 export const serializeViewerStateStore = (store: Store<ViewerState>): Partial<SerializedStoreData> => {
   // Ordered by approximate importance in the URL
   return {
+    ...serializeCollectionSlice(store.getState()),
+    ...serializeVectorSlice(store.getState()),
     ...serializeDatasetSlice(store.getState()),
     ...serializeTimeSlice(store.getState()),
     ...serializeColorRampSlice(store.getState()),
+    ...serializeThresholdSlice(store.getState()),
     ...serializeConfigSlice(store.getState()),
+    ...serializeScatterPlotSlice(store.getState()),
+    ...serializeBackdropSlice(store.getState()),
     ...serializeVectorSlice(store.getState()),
   };
 };
@@ -44,13 +55,17 @@ export const serializedStoreDataToUrl = (data: SerializedStoreData): string => {
 export const loadViewerStateFromParams = async (store: Store<ViewerState>, params: URLSearchParams): Promise<void> => {
   // NOTE: Ordering is important here, because of dependencies between slices.
   // 1. No dependencies:
-  loadDatasetSliceFromParams(store.getState(), params);
   loadConfigSliceFromParams(store.getState(), params);
 
-  // 2. Dependent on dataset fields:
-  loadTimeSliceFromParams(store.getState(), params);
+  // 2. Dependent on dataset object:
+  loadDatasetSliceFromParams(store.getState(), params);
+  loadThresholdSliceFromParams(store.getState(), params);
+  loadScatterPlotSliceFromParams(store.getState(), params);
   loadVectorSliceFromParams(store.getState(), params);
 
-  // 3. Dependent on dataset + thresholds:
+  // 3. Dependent on dataset fields (track/backdrop/features):
+  loadTimeSliceFromParams(store.getState(), params);
+
+  // 4. Dependent on dataset + thresholds:
   loadColorRampSliceFromParams(store.getState(), params);
 };

--- a/tests/math_utils.test.ts
+++ b/tests/math_utils.test.ts
@@ -38,7 +38,11 @@ describe("numberToStringDecimal", () => {
     expect(numberToStringDecimal(12345.6789, 3)).to.equal("12345.679");
   });
 
-  it("keeps precision for small values < 1", () => {
+  it("does not use precision for values over 1", () => {
+    expect(numberToStringDecimal(100.0000001234, 3)).to.equal("100.000");
+  });
+
+  it("uses precision for values less than 1", () => {
     const value = 0.0000001234;
     expect(numberToStringDecimal(value, 3)).to.equal("1.23e-7");
   });

--- a/tests/math_utils.test.ts
+++ b/tests/math_utils.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   convertCanvasOffsetPxToFrameCoords,
+  formatNumber,
   getFrameSizeInScreenPx,
   numberToSciNotation,
-  numberToStringDecimal,
   remap,
 } from "../src/colorizer/utils/math_utils";
 
@@ -13,38 +13,38 @@ const DEFAULT_ZOOM = 1;
 const DEFAULT_CANVAS_RESOLUTION = new Vector2(100, 100);
 const DEFAULT_FRAME_RESOLUTION = new Vector2(1, 1);
 
-describe("numberToStringDecimal", () => {
+describe("formatNumber", () => {
   it("handles undefined and null values", () => {
-    expect(numberToStringDecimal(undefined, 3)).to.equal("NaN");
-    expect(numberToStringDecimal(null, 3)).to.equal("NaN");
+    expect(formatNumber(undefined, 3)).to.equal("NaN");
+    expect(formatNumber(null, 3)).to.equal("NaN");
   });
 
   it("handles integers", () => {
-    expect(numberToStringDecimal(0, 3)).to.equal("0");
-    expect(numberToStringDecimal(1, 3)).to.equal("1");
-    expect(numberToStringDecimal(-1, 3)).to.equal("-1");
-    expect(numberToStringDecimal(123, 3)).to.equal("123");
+    expect(formatNumber(0, 3)).to.equal("0");
+    expect(formatNumber(1, 3)).to.equal("1");
+    expect(formatNumber(-1, 3)).to.equal("-1");
+    expect(formatNumber(123, 3)).to.equal("123");
   });
 
   it("truncates/rounds decimals to the specified max decimals", () => {
-    expect(numberToStringDecimal(10.123456, 3)).to.equal("10.123");
-    expect(numberToStringDecimal(10.123456, 2)).to.equal("10.12");
-    expect(numberToStringDecimal(10.123456, 1)).to.equal("10.1");
-    expect(numberToStringDecimal(10.123456, 0)).to.equal("10");
+    expect(formatNumber(10.123456, 3)).to.equal("10.123");
+    expect(formatNumber(10.123456, 2)).to.equal("10.12");
+    expect(formatNumber(10.123456, 1)).to.equal("10.1");
+    expect(formatNumber(10.123456, 0)).to.equal("10");
 
-    expect(numberToStringDecimal(-10.123456, 3)).to.equal("-10.123");
+    expect(formatNumber(-10.123456, 3)).to.equal("-10.123");
 
     // Applies rounding
-    expect(numberToStringDecimal(12345.6789, 3)).to.equal("12345.679");
+    expect(formatNumber(12345.6789, 3)).to.equal("12345.679");
   });
 
   it("does not use precision for values over 1", () => {
-    expect(numberToStringDecimal(100.0000001234, 3)).to.equal("100.000");
+    expect(formatNumber(100.0000001234, 3)).to.equal("100.000");
   });
 
   it("uses precision for values less than 1", () => {
     const value = 0.0000001234;
-    expect(numberToStringDecimal(value, 3)).to.equal("1.23e-7");
+    expect(formatNumber(value, 3)).to.equal("1.23e-7");
   });
 });
 

--- a/tests/math_utils.test.ts
+++ b/tests/math_utils.test.ts
@@ -5,12 +5,44 @@ import {
   convertCanvasOffsetPxToFrameCoords,
   getFrameSizeInScreenPx,
   numberToSciNotation,
+  numberToStringDecimal,
   remap,
 } from "../src/colorizer/utils/math_utils";
 
 const DEFAULT_ZOOM = 1;
 const DEFAULT_CANVAS_RESOLUTION = new Vector2(100, 100);
 const DEFAULT_FRAME_RESOLUTION = new Vector2(1, 1);
+
+describe("numberToStringDecimal", () => {
+  it("handles undefined and null values", () => {
+    expect(numberToStringDecimal(undefined, 3)).to.equal("NaN");
+    expect(numberToStringDecimal(null, 3)).to.equal("NaN");
+  });
+
+  it("handles integers", () => {
+    expect(numberToStringDecimal(0, 3)).to.equal("0");
+    expect(numberToStringDecimal(1, 3)).to.equal("1");
+    expect(numberToStringDecimal(-1, 3)).to.equal("-1");
+    expect(numberToStringDecimal(123, 3)).to.equal("123");
+  });
+
+  it("truncates/rounds decimals to the specified max decimals", () => {
+    expect(numberToStringDecimal(10.123456, 3)).to.equal("10.123");
+    expect(numberToStringDecimal(10.123456, 2)).to.equal("10.12");
+    expect(numberToStringDecimal(10.123456, 1)).to.equal("10.1");
+    expect(numberToStringDecimal(10.123456, 0)).to.equal("10");
+
+    expect(numberToStringDecimal(-10.123456, 3)).to.equal("-10.123");
+
+    // Applies rounding
+    expect(numberToStringDecimal(12345.6789, 3)).to.equal("12345.679");
+  });
+
+  it("keeps precision for small values < 1", () => {
+    const value = 0.0000001234;
+    expect(numberToStringDecimal(value, 3)).to.equal("1.23e-7");
+  });
+});
 
 describe("numberToSciNotation", () => {
   it("Handles zero", () => {

--- a/tests/state/ViewerState/scatterplot_slice.test.ts
+++ b/tests/state/ViewerState/scatterplot_slice.test.ts
@@ -3,8 +3,10 @@ import { act } from "react-dom/test-utils";
 import { describe, expect, it } from "vitest";
 
 import { PlotRangeType } from "../../../src/colorizer";
+import { UrlParam } from "../../../src/colorizer/utils/url_utils";
 import { SCATTERPLOT_TIME_FEATURE } from "../../../src/components/Tabs/scatter_plot_data_utils";
 import { useViewerStateStore } from "../../../src/state";
+import { loadScatterPlotSliceFromParams, serializeScatterPlotSlice } from "../../../src/state/slices";
 import { ANY_ERROR } from "../../test_utils";
 import { MOCK_DATASET, MockFeatureKeys } from "./constants";
 import { setDatasetAsync } from "./utils";
@@ -104,6 +106,72 @@ describe("ScatterplotSlice", () => {
       await setDatasetAsync(result, MOCK_DATASET);
       expect(result.current.scatterXAxis).toBe(null);
       expect(result.current.scatterYAxis).toBe(null);
+    });
+  });
+
+  describe("serializeScatterPlotSlice", () => {
+    it("serializes slice data", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      act(() => {
+        result.current.setScatterXAxis(null);
+        result.current.setScatterYAxis(null);
+        result.current.setScatterRangeType(PlotRangeType.ALL_TIME);
+      });
+      let serializedData = serializeScatterPlotSlice(result.current);
+      expect(serializedData[UrlParam.SCATTERPLOT_X_AXIS]).toBeUndefined();
+      expect(serializedData[UrlParam.SCATTERPLOT_Y_AXIS]).toBeUndefined();
+      expect(serializedData[UrlParam.SCATTERPLOT_RANGE_MODE]).toBe("all");
+
+      act(() => {
+        result.current.setScatterXAxis(MockFeatureKeys.FEATURE1);
+        result.current.setScatterYAxis(MockFeatureKeys.FEATURE2);
+        result.current.setScatterRangeType(PlotRangeType.CURRENT_FRAME);
+      });
+      serializedData = serializeScatterPlotSlice(result.current);
+      expect(serializedData[UrlParam.SCATTERPLOT_X_AXIS]).toBe(MockFeatureKeys.FEATURE1);
+      expect(serializedData[UrlParam.SCATTERPLOT_Y_AXIS]).toBe(MockFeatureKeys.FEATURE2);
+      expect(serializedData[UrlParam.SCATTERPLOT_RANGE_MODE]).toBe("frame");
+    });
+  });
+
+  describe("loadScatterPlotSliceFromParams", () => {
+    it("loads slice data", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      const params = new URLSearchParams();
+      params.set(UrlParam.SCATTERPLOT_X_AXIS, MockFeatureKeys.FEATURE1);
+      params.set(UrlParam.SCATTERPLOT_Y_AXIS, MockFeatureKeys.FEATURE2);
+      params.set(UrlParam.SCATTERPLOT_RANGE_MODE, "frame");
+
+      act(() => {
+        loadScatterPlotSliceFromParams(result.current, params);
+      });
+
+      expect(result.current.scatterXAxis).toBe(MockFeatureKeys.FEATURE1);
+      expect(result.current.scatterYAxis).toBe(MockFeatureKeys.FEATURE2);
+      expect(result.current.scatterRangeType).toBe(PlotRangeType.CURRENT_FRAME);
+    });
+
+    it("ignores missing axes", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      const initialXAxis = result.current.scatterXAxis;
+      const initialYAxis = result.current.scatterYAxis;
+      act(() => {
+        loadScatterPlotSliceFromParams(result.current, new URLSearchParams());
+      });
+      expect(result.current.scatterXAxis).toBe(initialXAxis);
+      expect(result.current.scatterYAxis).toBe(initialYAxis);
+    });
+
+    it("ignores invalid range types", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      const initialRangeType = result.current.scatterRangeType;
+
+      const params = new URLSearchParams();
+      params.set(UrlParam.SCATTERPLOT_RANGE_MODE, "invalid-range-type");
+      act(() => {
+        loadScatterPlotSliceFromParams(result.current, params);
+      });
+      expect(result.current.scatterRangeType).toBe(initialRangeType);
     });
   });
 });

--- a/tests/state/ViewerState/threshold_slice.test.ts
+++ b/tests/state/ViewerState/threshold_slice.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 
 import { FeatureThreshold, ThresholdType } from "../../../src/colorizer";
 import { validateThresholds } from "../../../src/colorizer/utils/data_utils";
+import { UrlParam } from "../../../src/colorizer/utils/url_utils";
+import { loadThresholdSliceFromParams, serializeThresholdSlice } from "../../../src/state/slices";
 import { MOCK_DATASET, MockFeatureKeys } from "./constants";
 import { setDatasetAsync } from "./utils";
 
@@ -25,6 +27,18 @@ const OUTDATED_THRESHOLDS: FeatureThreshold[] = [
 const VALIDATED_THRESHOLDS = validateThresholds(MOCK_DATASET, OUTDATED_THRESHOLDS);
 const EXPECTED_IN_RANGE_LUT = new Uint8Array([0, 0, 0, 1, 1, 1, 1, 0, 0]);
 const EXPECTED_IN_RANGE_LUT_NO_THRESHOLD = new Uint8Array([1, 1, 1, 1, 1, 1, 1, 1, 1]);
+
+const DEFAULT_THRESHOLDS: FeatureThreshold[] = [
+  { featureKey: MockFeatureKeys.FEATURE1, unit: "meters", type: ThresholdType.NUMERIC, min: 0, max: 1 },
+  { featureKey: MockFeatureKeys.FEATURE2, unit: "(m)", type: ThresholdType.NUMERIC, min: 24, max: 60 },
+  {
+    featureKey: MockFeatureKeys.FEATURE3,
+    unit: "",
+    type: ThresholdType.CATEGORICAL,
+    enabledCategories: [true, true, true, false, false, false, true, true, true, false, false, false],
+  },
+];
+const DEFAULT_THRESHOLDS_SERIALIZED = "feature1:meters:0:1,feature2:(m):24:60,feature3::1c7";
 
 describe("ThresholdSlice", () => {
   describe("setThresholds", () => {
@@ -97,6 +111,31 @@ describe("ThresholdSlice", () => {
       expect(result.current.inRangeLUT).to.deep.equal(new Uint8Array(0));
       await setDatasetAsync(result, MOCK_DATASET);
       expect(result.current.inRangeLUT).to.deep.equal(EXPECTED_IN_RANGE_LUT);
+    });
+  });
+
+  describe("serializeThresholdSlice", () => {
+    it("serializes thresholds", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      act(() => {
+        result.current.setThresholds(DEFAULT_THRESHOLDS);
+      });
+      expect(result.current.thresholds).to.deep.equal(DEFAULT_THRESHOLDS);
+      const serialized = serializeThresholdSlice(result.current);
+      expect(serialized).to.deep.equal({ [UrlParam.THRESHOLDS]: DEFAULT_THRESHOLDS_SERIALIZED });
+    });
+  });
+
+  describe("loadThresholdSliceFromParams", () => {
+    it("deserializes thresholds", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      const params = new URLSearchParams();
+      params.set(UrlParam.THRESHOLDS, DEFAULT_THRESHOLDS_SERIALIZED);
+      act(() => {
+        result.current.setThresholds([]);
+        loadThresholdSliceFromParams(result.current, params);
+      });
+      expect(result.current.thresholds).to.deep.equal(DEFAULT_THRESHOLDS);
     });
   });
 });

--- a/tests/state/ViewerState/threshold_slice.test.ts
+++ b/tests/state/ViewerState/threshold_slice.test.ts
@@ -137,5 +137,16 @@ describe("ThresholdSlice", () => {
       });
       expect(result.current.thresholds).to.deep.equal(DEFAULT_THRESHOLDS);
     });
+
+    it("ignores bad data", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      const params = new URLSearchParams();
+      params.set(UrlParam.THRESHOLDS, "bad-threshold");
+      act(() => {
+        result.current.setThresholds([]);
+        loadThresholdSliceFromParams(result.current, params);
+      });
+      expect(result.current.thresholds).to.deep.equal([]);
+    });
   });
 });


### PR DESCRIPTION
Problem
=======
Part 13 of ??? for #492, "refactor state management."

This change adds serialization for the remaining state slices. This means that all viewer settings are now being pulled from the URL and set in the state on initial load.

The next PR will focus on the inverse relationship, syncing state to the URL.

*Estimated review size: medium, 30-40 minutes* (it's mostly unit tests)

Solution
========
- Added serialization and deserialization for the collection, threshold, scatterplot, and backdrop slices.
- Added unit tests.
- Fix for very small values in `numberToStringDecimal`.
- Refactored unit tests in `url_utils.ts` for threshold serialization/deserialization.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link. You should see the same settings in the scatter plot, filters, and viewer settings as the screenshots below:  https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-594/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&feature=volume&t=15&filters=height%3A%25CE%25BCm%3A7.840%3A14.733%2Cvolume%3A%25CE%25BCm%25C2%25B3%3A43.818%3A977.818%2Cfamily_id%3A%3A164%3A273&range=43.818%2C977.818&color=matplotlib-cool&palette-key=adobe&bg-sat=49&bg-brightness=132&fg-alpha=43&outlier-color=c0c0c0&outlier-mode=1&filter-color=dddddd&filter-mode=1&outline-color=ff00ff&tab=settings&vc=0&vc-color=000000&vc-key=_motion_&vc-scale=4&vc-time-int=5&vc-tooltip=m&bg=1&scalebar=1&timestamp=1&path=1&keep-range=0&bg-key=max_intensity_zprojection_of_lamin_b1&scatter-range=frame&scatter-x=change_in_volume_in_25_minute_window&scatter-y=height

**Backdrop:**
![image](https://github.com/user-attachments/assets/1d2ddbe5-e17a-4d9b-8ff9-422b3fdf3e6f)

**Filters:**
![image](https://github.com/user-attachments/assets/509e6480-36e2-4ba4-9325-b427187e309c)

**Scatter plot:**
![image](https://github.com/user-attachments/assets/a849c23e-a670-4c76-b8ee-61aed2154ff5)
