### PR TITLE
refactor: Reorganize slices, update serialization/deserialization (state pt. 14)

### DIFF
--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -328,6 +328,10 @@ export function encodeColor(value: Color): string {
   return value.getHexString();
 }
 
+export function encodeMaybeColor(value: Color | undefined): string | undefined {
+  return value ? encodeColor(value) : undefined;
+}
+
 export function isHexColor(value: string | null): value is HexColorString {
   const hexRegex = /^#([0-9a-f]{3}){1,2}$/;
   return value !== null && hexRegex.test(value);
@@ -340,6 +344,10 @@ export function decodeHexColor(value: string | null): Color | undefined {
 
 export function encodeNumber(value: number): string {
   return numberToStringDecimal(value, 3);
+}
+
+export function encodeMaybeNumber(value: number | undefined): string | undefined {
+  return value !== undefined ? encodeNumber(value) : undefined;
 }
 
 export function decodeFloat(value: string | null): number | undefined {
@@ -365,6 +373,10 @@ export function parseDrawSettings(
 
 export function encodeBoolean(value: boolean): string {
   return value ? "1" : "0";
+}
+
+export function encodeMaybeBoolean(value: boolean | undefined): string | undefined {
+  return value !== undefined ? encodeBoolean(value) : undefined;
 }
 
 export function decodeBoolean(value: string | null): boolean | undefined {

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -29,6 +29,7 @@ import { numberToStringDecimal } from "./math_utils";
 // TODO: This file needs to be split up for easier reading and unit testing.
 // This could also be a great opportunity to reconsider how we store and manage state.
 
+export const URL_COLOR_RAMP_REVERSED_SUFFIX = "!";
 export enum UrlParam {
   TRACK = "track",
   DATASET = "dataset",
@@ -38,7 +39,6 @@ export enum UrlParam {
   THRESHOLDS = "filters",
   RANGE = "range",
   COLOR_RAMP = "color",
-  COLOR_RAMP_REVERSED_SUFFIX = "!",
   PALETTE = "palette",
   PALETTE_KEY = "palette-key",
   SHOW_BACKDROP = "bg",
@@ -550,7 +550,7 @@ export function paramsToUrlQueryString(state: Partial<UrlParams>): string {
   if (state.colorRampKey) {
     if (state.colorRampReversed) {
       includedParameters.push(
-        `${UrlParam.COLOR_RAMP}=${encodeURIComponent(state.colorRampKey + UrlParam.COLOR_RAMP_REVERSED_SUFFIX)}`
+        `${UrlParam.COLOR_RAMP}=${encodeURIComponent(state.colorRampKey + URL_COLOR_RAMP_REVERSED_SUFFIX)}`
       );
     } else {
       includedParameters.push(`${UrlParam.COLOR_RAMP}=${encodeURIComponent(state.colorRampKey)}`);
@@ -703,10 +703,7 @@ export function loadFromUrlSearchParams(urlParams: URLSearchParams): Partial<Url
   let colorRampParam: string | undefined = colorRampRawParam || undefined;
   let colorRampReversedParam: boolean | undefined = undefined;
   //  Color ramps are marked as reversed by adding ! to the end of the key
-  if (
-    colorRampRawParam &&
-    colorRampRawParam.charAt(colorRampRawParam.length - 1) === UrlParam.COLOR_RAMP_REVERSED_SUFFIX
-  ) {
+  if (colorRampRawParam && colorRampRawParam.charAt(colorRampRawParam.length - 1) === URL_COLOR_RAMP_REVERSED_SUFFIX) {
     colorRampReversedParam = true;
     colorRampParam = colorRampRawParam.slice(0, -1);
   }

--- a/src/state/ViewerState.ts
+++ b/src/state/ViewerState.ts
@@ -1,50 +1,8 @@
 import { create } from "zustand";
-import { StateCreator } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 
-import { Spread } from "../colorizer/utils/type_utils";
-import { addBackdropDerivedStateSubscribers, BackdropSlice, createBackdropSlice } from "./slices/backdrop_slice";
-import { CollectionSlice, createCollectionSlice } from "./slices/collection_slice";
-import { addColorRampDerivedStateSubscribers, ColorRampSlice, createColorRampSlice } from "./slices/color_ramp_slice";
-import { ConfigSlice, createConfigSlice } from "./slices/config_slice";
-import { createDatasetSlice, DatasetSlice } from "./slices/dataset_slice";
-import {
-  addScatterPlotSliceDerivedStateSubscribers,
-  createScatterPlotSlice,
-  ScatterPlotSlice,
-} from "./slices/scatterplot_slice";
-import { addThresholdDerivedStateSubscribers, createThresholdSlice, ThresholdSlice } from "./slices/threshold_slice";
-import { addTimeDerivedStateSubscribers, createTimeSlice, TimeSlice } from "./slices/time_slice";
-import { addVectorDerivedStateSubscribers, createVectorSlice, VectorSlice } from "./slices/vector_slice";
+import { addStoreStateSubscribers, viewerStateStoreCreator, ViewerStore } from "./slices";
 import { SubscribableStore } from "./types";
-
-// The ViewerState is composed of many smaller slices, modules of related state,
-// actions, and selectors. See
-// https://github.com/pmndrs/zustand/blob/main/docs/guides/typescript.md#slices-pattern
-// for more details on the pattern.
-export type ViewerState = Spread<
-  BackdropSlice &
-    CollectionSlice &
-    ColorRampSlice &
-    ConfigSlice &
-    DatasetSlice &
-    ScatterPlotSlice &
-    ThresholdSlice &
-    TimeSlice &
-    VectorSlice
->;
-
-export const viewerStateStoreCreator: StateCreator<ViewerState> = (...a) => ({
-  ...createBackdropSlice(...a),
-  ...createCollectionSlice(...a),
-  ...createColorRampSlice(...a),
-  ...createConfigSlice(...a),
-  ...createDatasetSlice(...a),
-  ...createScatterPlotSlice(...a),
-  ...createThresholdSlice(...a),
-  ...createTimeSlice(...a),
-  ...createVectorSlice(...a),
-});
 
 /**
  * Hook for accessing the global viewer state store. If used with selectors,
@@ -87,22 +45,17 @@ export const viewerStateStoreCreator: StateCreator<ViewerState> = (...a) => ({
  * );
  * ```
  */
-export const useViewerStateStore: SubscribableStore<ViewerState> = create<ViewerState>()(
+export const useViewerStateStore: SubscribableStore<ViewerStore> = create<ViewerStore>()(
   subscribeWithSelector(viewerStateStoreCreator)
 );
 
-addBackdropDerivedStateSubscribers(useViewerStateStore);
-addColorRampDerivedStateSubscribers(useViewerStateStore);
-addScatterPlotSliceDerivedStateSubscribers(useViewerStateStore);
-addThresholdDerivedStateSubscribers(useViewerStateStore);
-addTimeDerivedStateSubscribers(useViewerStateStore);
-addVectorDerivedStateSubscribers(useViewerStateStore);
+addStoreStateSubscribers(useViewerStateStore);
 
 // Adds compatibility with hot module reloading.
 // Adapted from https://github.com/pmndrs/zustand/discussions/827#discussioncomment-9843290
 declare global {
   interface Window {
-    _store: ViewerState;
+    _store: ViewerStore;
   }
 }
 

--- a/src/state/slices/backdrop_slice.ts
+++ b/src/state/slices/backdrop_slice.ts
@@ -22,7 +22,7 @@ import { SerializedStoreData, SubscribableStore } from "../types";
 import { clampWithNanCheck } from "../utils/data_validation";
 import { DatasetSlice } from "./dataset_slice";
 
-type BackdropSliceState = {
+export type BackdropSliceState = {
   backdropVisible: boolean;
   /** Brightness, as a percentage in the `[0, 200]` range. 100 by default. */
   backdropBrightness: number;
@@ -33,7 +33,12 @@ type BackdropSliceState = {
   objectOpacity: number;
 };
 
-type BackdropSliceActions = {
+export type BackdropSliceSerializableState = Pick<
+  BackdropSliceState,
+  "backdropVisible" | "backdropBrightness" | "backdropSaturation" | "objectOpacity"
+>;
+
+export type BackdropSliceActions = {
   /**
    * Sets the visibility of the backdrop layer. The backdrop will be hidden if
    * the current backdrop key is `null`.
@@ -86,7 +91,7 @@ export const addBackdropDerivedStateSubscribers = (store: SubscribableStore<Back
   );
 };
 
-export const serializeBackdropSlice = (state: Partial<BackdropSlice>): SerializedStoreData => {
+export const serializeBackdropSlice = (state: Partial<BackdropSliceSerializableState>): SerializedStoreData => {
   const ret: SerializedStoreData = {};
   ret[UrlParam.SHOW_BACKDROP] = encodeMaybeBoolean(state.backdropVisible);
   ret[UrlParam.BACKDROP_BRIGHTNESS] = encodeMaybeNumber(state.backdropBrightness);
@@ -96,7 +101,7 @@ export const serializeBackdropSlice = (state: Partial<BackdropSlice>): Serialize
 };
 
 /** Selects state values that serialization depends on. */
-export const backdropSliceSerializationDependencies = (slice: BackdropSlice): Partial<BackdropSliceState> => ({
+export const backdropSliceSerializationDependencies = (slice: BackdropSlice): BackdropSliceSerializableState => ({
   backdropVisible: slice.backdropVisible,
   backdropBrightness: slice.backdropBrightness,
   backdropSaturation: slice.backdropSaturation,

--- a/src/state/slices/backdrop_slice.ts
+++ b/src/state/slices/backdrop_slice.ts
@@ -92,12 +92,12 @@ export const addBackdropDerivedStateSubscribers = (store: SubscribableStore<Back
 };
 
 export const serializeBackdropSlice = (state: Partial<BackdropSliceSerializableState>): SerializedStoreData => {
-  const ret: SerializedStoreData = {};
-  ret[UrlParam.SHOW_BACKDROP] = encodeMaybeBoolean(state.backdropVisible);
-  ret[UrlParam.BACKDROP_BRIGHTNESS] = encodeMaybeNumber(state.backdropBrightness);
-  ret[UrlParam.BACKDROP_SATURATION] = encodeMaybeNumber(state.backdropSaturation);
-  ret[UrlParam.OBJECT_OPACITY] = encodeMaybeNumber(state.objectOpacity);
-  return ret;
+  return {
+    [UrlParam.SHOW_BACKDROP]: encodeMaybeBoolean(state.backdropVisible),
+    [UrlParam.BACKDROP_BRIGHTNESS]: encodeMaybeNumber(state.backdropBrightness),
+    [UrlParam.BACKDROP_SATURATION]: encodeMaybeNumber(state.backdropSaturation),
+    [UrlParam.OBJECT_OPACITY]: encodeMaybeNumber(state.objectOpacity),
+  };
 };
 
 /** Selects state values that serialization depends on. */

--- a/src/state/slices/backdrop_slice.ts
+++ b/src/state/slices/backdrop_slice.ts
@@ -89,6 +89,14 @@ export const serializeBackdropSlice = (state: BackdropSlice): SerializedStoreDat
   return ret;
 };
 
+/** Selects state values that serialization depends on. */
+export const backdropSliceSerializationDependencies = (slice: BackdropSlice): Partial<BackdropSliceState> => ({
+  backdropVisible: slice.backdropVisible,
+  backdropBrightness: slice.backdropBrightness,
+  backdropSaturation: slice.backdropSaturation,
+  objectOpacity: slice.objectOpacity,
+});
+
 export const loadBackdropSliceFromParams = (slice: BackdropSlice, params: URLSearchParams): void => {
   const showBackdrop = decodeBoolean(params.get(UrlParam.SHOW_BACKDROP));
   if (showBackdrop !== undefined) {

--- a/src/state/slices/backdrop_slice.ts
+++ b/src/state/slices/backdrop_slice.ts
@@ -1,6 +1,12 @@
 import { StateCreator } from "zustand";
 
-import { decodeBoolean, decodeFloat, encodeBoolean, encodeNumber, UrlParam } from "../../colorizer/utils/url_utils";
+import {
+  decodeBoolean,
+  decodeFloat,
+  encodeMaybeBoolean,
+  encodeMaybeNumber,
+  UrlParam,
+} from "../../colorizer/utils/url_utils";
 import {
   BACKDROP_BRIGHTNESS_DEFAULT,
   BACKDROP_BRIGHTNESS_MAX,
@@ -80,12 +86,12 @@ export const addBackdropDerivedStateSubscribers = (store: SubscribableStore<Back
   );
 };
 
-export const serializeBackdropSlice = (state: BackdropSlice): SerializedStoreData => {
+export const serializeBackdropSlice = (state: Partial<BackdropSlice>): SerializedStoreData => {
   const ret: SerializedStoreData = {};
-  ret[UrlParam.SHOW_BACKDROP] = encodeBoolean(state.backdropVisible);
-  ret[UrlParam.BACKDROP_BRIGHTNESS] = encodeNumber(state.backdropBrightness);
-  ret[UrlParam.BACKDROP_SATURATION] = encodeNumber(state.backdropSaturation);
-  ret[UrlParam.OBJECT_OPACITY] = encodeNumber(state.objectOpacity);
+  ret[UrlParam.SHOW_BACKDROP] = encodeMaybeBoolean(state.backdropVisible);
+  ret[UrlParam.BACKDROP_BRIGHTNESS] = encodeMaybeNumber(state.backdropBrightness);
+  ret[UrlParam.BACKDROP_SATURATION] = encodeMaybeNumber(state.backdropSaturation);
+  ret[UrlParam.OBJECT_OPACITY] = encodeMaybeNumber(state.objectOpacity);
   return ret;
 };
 

--- a/src/state/slices/backdrop_slice.ts
+++ b/src/state/slices/backdrop_slice.ts
@@ -101,7 +101,7 @@ export const serializeBackdropSlice = (state: Partial<BackdropSliceSerializableS
 };
 
 /** Selects state values that serialization depends on. */
-export const backdropSliceSerializationDependencies = (slice: BackdropSlice): BackdropSliceSerializableState => ({
+export const selectBackdropSliceSerializationDeps = (slice: BackdropSlice): BackdropSliceSerializableState => ({
   backdropVisible: slice.backdropVisible,
   backdropBrightness: slice.backdropBrightness,
   backdropSaturation: slice.backdropSaturation,

--- a/src/state/slices/collection_slice.ts
+++ b/src/state/slices/collection_slice.ts
@@ -23,11 +23,11 @@ export const createCollectionSlice: StateCreator<CollectionSlice, [], [], Collec
   },
 });
 
-export const serializeCollectionSlice = (slice: CollectionSlice): SerializedStoreData => {
+export const serializeCollectionSlice = (slice: Partial<CollectionSlice>): SerializedStoreData => {
   const collection = slice.collection;
   // Collection URL is null if a single dataset was loaded directly.
   // In this case, the collection doesn't need to be included in the URL.
-  if (collection === null || collection.url === null) {
+  if (!collection || collection.url === null) {
     return {};
   }
   return {

--- a/src/state/slices/collection_slice.ts
+++ b/src/state/slices/collection_slice.ts
@@ -34,3 +34,8 @@ export const serializeCollectionSlice = (slice: CollectionSlice): SerializedStor
     [UrlParam.COLLECTION]: collection.url,
   };
 };
+
+/** Selects state values that serialization depends on. */
+export const collectionSliceSerializationDependencies = (slice: CollectionSlice): Partial<CollectionSliceState> => ({
+  collection: slice.collection,
+});

--- a/src/state/slices/collection_slice.ts
+++ b/src/state/slices/collection_slice.ts
@@ -5,11 +5,13 @@ import { SerializedStoreData } from "../types";
 
 import Collection from "../../colorizer/Collection";
 
-type CollectionSliceState = {
+export type CollectionSliceState = {
   collection: Collection | null;
 };
 
-type CollectionSliceActions = {
+export type CollectionSliceSerializableState = Pick<CollectionSliceState, "collection">;
+
+export type CollectionSliceActions = {
   setCollection: (collection: Collection) => void;
 };
 
@@ -23,7 +25,7 @@ export const createCollectionSlice: StateCreator<CollectionSlice, [], [], Collec
   },
 });
 
-export const serializeCollectionSlice = (slice: Partial<CollectionSlice>): SerializedStoreData => {
+export const serializeCollectionSlice = (slice: Partial<CollectionSliceSerializableState>): SerializedStoreData => {
   const collection = slice.collection;
   // Collection URL is null if a single dataset was loaded directly.
   // In this case, the collection doesn't need to be included in the URL.
@@ -36,6 +38,6 @@ export const serializeCollectionSlice = (slice: Partial<CollectionSlice>): Seria
 };
 
 /** Selects state values that serialization depends on. */
-export const collectionSliceSerializationDependencies = (slice: CollectionSlice): Partial<CollectionSliceState> => ({
+export const collectionSliceSerializationDependencies = (slice: CollectionSlice): CollectionSliceSerializableState => ({
   collection: slice.collection,
 });

--- a/src/state/slices/collection_slice.ts
+++ b/src/state/slices/collection_slice.ts
@@ -38,6 +38,6 @@ export const serializeCollectionSlice = (slice: Partial<CollectionSliceSerializa
 };
 
 /** Selects state values that serialization depends on. */
-export const collectionSliceSerializationDependencies = (slice: CollectionSlice): CollectionSliceSerializableState => ({
+export const selectCollectionSliceSerializationDeps = (slice: CollectionSlice): CollectionSliceSerializableState => ({
   collection: slice.collection,
 });

--- a/src/state/slices/color_ramp_slice.ts
+++ b/src/state/slices/color_ramp_slice.ts
@@ -237,6 +237,15 @@ export const serializeColorRampSlice = (slice: ColorRampSlice): SerializedStoreD
   return ret;
 };
 
+/** Selects state values that serialization depends on. */
+export const colorRampSliceSerializationDependencies = (slice: ColorRampSlice): Partial<ColorRampSliceState> => ({
+  colorRampKey: slice.colorRampKey,
+  isColorRampReversed: slice.isColorRampReversed,
+  keepColorRampRange: slice.keepColorRampRange,
+  colorRampRange: slice.colorRampRange,
+  categoricalPalette: slice.categoricalPalette,
+});
+
 export const loadColorRampSliceFromParams = (slice: ColorRampSlice, params: URLSearchParams): void => {
   const colorRampParam = params.get(UrlParam.COLOR_RAMP);
   if (colorRampParam) {

--- a/src/state/slices/color_ramp_slice.ts
+++ b/src/state/slices/color_ramp_slice.ts
@@ -14,6 +14,7 @@ import {
   encodeColor,
   encodeMaybeBoolean,
   encodeNumber,
+  URL_COLOR_RAMP_REVERSED_SUFFIX,
   UrlParam,
 } from "../../colorizer/utils/url_utils";
 import { COLOR_RAMP_RANGE_DEFAULT, MAX_FEATURE_CATEGORIES } from "../../constants";
@@ -230,8 +231,7 @@ export const serializeColorRampSlice = (slice: Partial<ColorRampSliceSerializabl
 
   // Ramp + reversed
   if (slice.colorRampKey !== undefined) {
-    ret[UrlParam.COLOR_RAMP] =
-      slice.colorRampKey + (slice.isColorRampReversed ? UrlParam.COLOR_RAMP_REVERSED_SUFFIX : "");
+    ret[UrlParam.COLOR_RAMP] = slice.colorRampKey + (slice.isColorRampReversed ? URL_COLOR_RAMP_REVERSED_SUFFIX : "");
   }
 
   ret[UrlParam.KEEP_RANGE] = encodeMaybeBoolean(slice.keepColorRampRange);
@@ -264,7 +264,7 @@ export const colorRampSliceSerializationDependencies = (slice: ColorRampSlice): 
 export const loadColorRampSliceFromParams = (slice: ColorRampSlice, params: URLSearchParams): void => {
   const colorRampParam = params.get(UrlParam.COLOR_RAMP);
   if (colorRampParam) {
-    const [key, reversed] = colorRampParam.split(UrlParam.COLOR_RAMP_REVERSED_SUFFIX);
+    const [key, reversed] = colorRampParam.split(URL_COLOR_RAMP_REVERSED_SUFFIX);
     if (KNOWN_COLOR_RAMPS.has(key)) {
       slice.setColorRampKey(key);
       slice.setColorRampReversed(reversed !== undefined);

--- a/src/state/slices/color_ramp_slice.ts
+++ b/src/state/slices/color_ramp_slice.ts
@@ -51,6 +51,16 @@ export type ColorRampSliceState = {
   categoricalPaletteKey: string | null;
 };
 
+export type ColorRampSliceSerializableState = Pick<
+  ColorRampSliceState,
+  | "colorRampKey"
+  | "isColorRampReversed"
+  | "keepColorRampRange"
+  | "colorRampRange"
+  | "categoricalPalette"
+  | "categoricalPaletteKey"
+>;
+
 export type ColorRampSliceActions = {
   /**
    * Changes the key of the current color ramp to one in `KNOWN_COLOR_RAMPS`.
@@ -215,7 +225,7 @@ export const addColorRampDerivedStateSubscribers = (
   );
 };
 
-export const serializeColorRampSlice = (slice: Partial<ColorRampSlice>): SerializedStoreData => {
+export const serializeColorRampSlice = (slice: Partial<ColorRampSliceSerializableState>): SerializedStoreData => {
   const ret: SerializedStoreData = {};
 
   // Ramp + reversed
@@ -242,12 +252,13 @@ export const serializeColorRampSlice = (slice: Partial<ColorRampSlice>): Seriali
 };
 
 /** Selects state values that serialization depends on. */
-export const colorRampSliceSerializationDependencies = (slice: ColorRampSlice): Partial<ColorRampSliceState> => ({
+export const colorRampSliceSerializationDependencies = (slice: ColorRampSlice): ColorRampSliceSerializableState => ({
   colorRampKey: slice.colorRampKey,
   isColorRampReversed: slice.isColorRampReversed,
   keepColorRampRange: slice.keepColorRampRange,
   colorRampRange: slice.colorRampRange,
   categoricalPalette: slice.categoricalPalette,
+  categoricalPaletteKey: slice.categoricalPaletteKey,
 });
 
 export const loadColorRampSliceFromParams = (slice: ColorRampSlice, params: URLSearchParams): void => {

--- a/src/state/slices/color_ramp_slice.ts
+++ b/src/state/slices/color_ramp_slice.ts
@@ -11,8 +11,8 @@ import { arrayElementsAreEqual, getColorMap, thresholdMatchFinder } from "../../
 import {
   decodeBoolean,
   decodeString,
-  encodeBoolean,
   encodeColor,
+  encodeMaybeBoolean,
   encodeNumber,
   UrlParam,
 } from "../../colorizer/utils/url_utils";
@@ -215,22 +215,26 @@ export const addColorRampDerivedStateSubscribers = (
   );
 };
 
-export const serializeColorRampSlice = (slice: ColorRampSlice): SerializedStoreData => {
+export const serializeColorRampSlice = (slice: Partial<ColorRampSlice>): SerializedStoreData => {
   const ret: SerializedStoreData = {};
 
   // Ramp + reversed
-  ret[UrlParam.COLOR_RAMP] =
-    slice.colorRampKey + (slice.isColorRampReversed ? UrlParam.COLOR_RAMP_REVERSED_SUFFIX : "");
+  if (slice.colorRampKey !== undefined) {
+    ret[UrlParam.COLOR_RAMP] =
+      slice.colorRampKey + (slice.isColorRampReversed ? UrlParam.COLOR_RAMP_REVERSED_SUFFIX : "");
+  }
 
-  ret[UrlParam.KEEP_RANGE] = encodeBoolean(slice.keepColorRampRange);
+  ret[UrlParam.KEEP_RANGE] = encodeMaybeBoolean(slice.keepColorRampRange);
 
-  const range = slice.colorRampRange;
-  ret[UrlParam.RANGE] = range.map(encodeNumber).join(",");
+  if (slice.colorRampRange !== undefined) {
+    const range = slice.colorRampRange;
+    ret[UrlParam.RANGE] = range.map(encodeNumber).join(",");
+  }
 
   // Palette key takes precedence over palette
   if (slice.categoricalPaletteKey !== null) {
     ret[UrlParam.PALETTE_KEY] = slice.categoricalPaletteKey;
-  } else {
+  } else if (slice.categoricalPalette !== undefined) {
     ret[UrlParam.PALETTE] = slice.categoricalPalette.map(encodeColor).join("-");
   }
 

--- a/src/state/slices/color_ramp_slice.ts
+++ b/src/state/slices/color_ramp_slice.ts
@@ -242,7 +242,7 @@ export const serializeColorRampSlice = (slice: Partial<ColorRampSliceSerializabl
   }
 
   // Palette key takes precedence over palette
-  if (slice.categoricalPaletteKey !== null) {
+  if (slice.categoricalPaletteKey !== undefined && slice.categoricalPaletteKey !== null) {
     ret[UrlParam.PALETTE_KEY] = slice.categoricalPaletteKey;
   } else if (slice.categoricalPalette !== undefined) {
     ret[UrlParam.PALETTE] = slice.categoricalPalette.map(encodeColor).join("-");
@@ -252,7 +252,7 @@ export const serializeColorRampSlice = (slice: Partial<ColorRampSliceSerializabl
 };
 
 /** Selects state values that serialization depends on. */
-export const colorRampSliceSerializationDependencies = (slice: ColorRampSlice): ColorRampSliceSerializableState => ({
+export const selectColorRampSliceSerializationDeps = (slice: ColorRampSlice): ColorRampSliceSerializableState => ({
   colorRampKey: slice.colorRampKey,
   isColorRampReversed: slice.isColorRampReversed,
   keepColorRampRange: slice.keepColorRampRange,

--- a/src/state/slices/config_slice.ts
+++ b/src/state/slices/config_slice.ts
@@ -107,7 +107,7 @@ export const serializeConfigSlice = (slice: Partial<ConfigSliceSerializableState
 };
 
 /** Selects state values that serialization depends on. */
-export const configSliceSerializationDependencies = (slice: ConfigSlice): ConfigSliceSerializableState => ({
+export const selectConfigSliceSerializationDeps = (slice: ConfigSlice): ConfigSliceSerializableState => ({
   showTrackPath: slice.showTrackPath,
   showScaleBar: slice.showScaleBar,
   showTimestamp: slice.showTimestamp,

--- a/src/state/slices/config_slice.ts
+++ b/src/state/slices/config_slice.ts
@@ -95,6 +95,17 @@ export const serializeConfigSlice = (slice: ConfigSlice): SerializedStoreData =>
   return ret;
 };
 
+/** Selects state values that serialization depends on. */
+export const configSliceSerializationDependencies = (slice: ConfigSlice): Partial<ConfigSliceState> => ({
+  showTrackPath: slice.showTrackPath,
+  showScaleBar: slice.showScaleBar,
+  showTimestamp: slice.showTimestamp,
+  outOfRangeDrawSettings: slice.outOfRangeDrawSettings,
+  outlierDrawSettings: slice.outlierDrawSettings,
+  outlineColor: slice.outlineColor,
+  openTab: slice.openTab,
+});
+
 export const loadConfigSliceFromParams = (slice: ConfigSlice, params: URLSearchParams): void => {
   const showPathParam = decodeBoolean(params.get(UrlParam.SHOW_PATH));
   if (showPathParam !== undefined) {

--- a/src/state/slices/config_slice.ts
+++ b/src/state/slices/config_slice.ts
@@ -13,8 +13,8 @@ import {
 import {
   decodeBoolean,
   decodeHexColor,
-  encodeBoolean,
-  encodeColor,
+  encodeMaybeBoolean,
+  encodeMaybeColor,
   parseDrawSettings,
   UrlParam,
 } from "../../colorizer/utils/url_utils";
@@ -79,17 +79,17 @@ export const createConfigSlice: StateCreator<ConfigSlice, [], [], ConfigSlice> =
   setOpenTab: (openTab) => set({ openTab }),
 });
 
-export const serializeConfigSlice = (slice: ConfigSlice): SerializedStoreData => {
+export const serializeConfigSlice = (slice: Partial<ConfigSlice>): SerializedStoreData => {
   const ret: SerializedStoreData = {};
-  ret[UrlParam.SHOW_PATH] = encodeBoolean(slice.showTrackPath);
-  ret[UrlParam.SHOW_SCALEBAR] = encodeBoolean(slice.showScaleBar);
-  ret[UrlParam.SHOW_TIMESTAMP] = encodeBoolean(slice.showTimestamp);
+  ret[UrlParam.SHOW_PATH] = encodeMaybeBoolean(slice.showTrackPath);
+  ret[UrlParam.SHOW_SCALEBAR] = encodeMaybeBoolean(slice.showScaleBar);
+  ret[UrlParam.SHOW_TIMESTAMP] = encodeMaybeBoolean(slice.showTimestamp);
   // Export settings are currently not serialized.
-  ret[UrlParam.FILTERED_COLOR] = encodeColor(slice.outOfRangeDrawSettings.color);
-  ret[UrlParam.FILTERED_MODE] = slice.outOfRangeDrawSettings.mode.toString();
-  ret[UrlParam.OUTLIER_COLOR] = encodeColor(slice.outlierDrawSettings.color);
-  ret[UrlParam.OUTLIER_MODE] = slice.outlierDrawSettings.mode.toString();
-  ret[UrlParam.OUTLINE_COLOR] = encodeColor(slice.outlineColor);
+  ret[UrlParam.FILTERED_COLOR] = encodeMaybeColor(slice.outOfRangeDrawSettings?.color);
+  ret[UrlParam.FILTERED_MODE] = slice.outOfRangeDrawSettings?.mode.toString();
+  ret[UrlParam.OUTLIER_COLOR] = encodeMaybeColor(slice.outlierDrawSettings?.color);
+  ret[UrlParam.OUTLIER_MODE] = slice.outlierDrawSettings?.mode.toString();
+  ret[UrlParam.OUTLINE_COLOR] = encodeMaybeColor(slice.outlineColor);
 
   ret[UrlParam.OPEN_TAB] = slice.openTab;
   return ret;

--- a/src/state/slices/config_slice.ts
+++ b/src/state/slices/config_slice.ts
@@ -29,7 +29,7 @@ const OUTLIER_DRAW_SETTINGS_DEFAULT: DrawSettings = {
   mode: DrawMode.USE_COLOR,
 };
 
-type ConfigSliceState = {
+export type ConfigSliceState = {
   showTrackPath: boolean;
   showScaleBar: boolean;
   showTimestamp: boolean;
@@ -41,7 +41,18 @@ type ConfigSliceState = {
   openTab: TabType;
 };
 
-type ConfigSliceActions = {
+export type ConfigSliceSerializableState = Pick<
+  ConfigSliceState,
+  | "showTrackPath"
+  | "showScaleBar"
+  | "showTimestamp"
+  | "outOfRangeDrawSettings"
+  | "outlierDrawSettings"
+  | "outlineColor"
+  | "openTab"
+>;
+
+export type ConfigSliceActions = {
   setShowTrackPath: (showTrackPath: boolean) => void;
   setShowScaleBar: (showScaleBar: boolean) => void;
   setShowTimestamp: (showTimestamp: boolean) => void;
@@ -79,7 +90,7 @@ export const createConfigSlice: StateCreator<ConfigSlice, [], [], ConfigSlice> =
   setOpenTab: (openTab) => set({ openTab }),
 });
 
-export const serializeConfigSlice = (slice: Partial<ConfigSlice>): SerializedStoreData => {
+export const serializeConfigSlice = (slice: Partial<ConfigSliceSerializableState>): SerializedStoreData => {
   const ret: SerializedStoreData = {};
   ret[UrlParam.SHOW_PATH] = encodeMaybeBoolean(slice.showTrackPath);
   ret[UrlParam.SHOW_SCALEBAR] = encodeMaybeBoolean(slice.showScaleBar);
@@ -96,7 +107,7 @@ export const serializeConfigSlice = (slice: Partial<ConfigSlice>): SerializedSto
 };
 
 /** Selects state values that serialization depends on. */
-export const configSliceSerializationDependencies = (slice: ConfigSlice): Partial<ConfigSliceState> => ({
+export const configSliceSerializationDependencies = (slice: ConfigSlice): ConfigSliceSerializableState => ({
   showTrackPath: slice.showTrackPath,
   showScaleBar: slice.showScaleBar,
   showTimestamp: slice.showTimestamp,

--- a/src/state/slices/dataset_slice.ts
+++ b/src/state/slices/dataset_slice.ts
@@ -110,18 +110,18 @@ export const createDatasetSlice: StateCreator<CollectionSlice & DatasetSlice, []
   clearDataset: () => set({ datasetKey: null, dataset: null, track: null, featureKey: null, backdropKey: null }),
 });
 
-export const serializeDatasetSlice = (slice: DatasetSlice): SerializedStoreData => {
+export const serializeDatasetSlice = (slice: Partial<DatasetSlice>): SerializedStoreData => {
   const ret: SerializedStoreData = {};
-  if (slice.dataset !== null) {
+  if (slice.dataset) {
     ret[UrlParam.DATASET] = slice.datasetKey;
   }
-  if (slice.featureKey !== null) {
+  if (slice.featureKey !== undefined && slice.featureKey !== null) {
     ret[UrlParam.FEATURE] = slice.featureKey;
   }
-  if (slice.track !== null) {
+  if (slice.track) {
     ret[UrlParam.TRACK] = slice.track.trackId.toString();
   }
-  if (slice.backdropKey !== null) {
+  if (slice.backdropKey !== undefined && slice.backdropKey !== null) {
     ret[UrlParam.BACKDROP_KEY] = slice.backdropKey;
   }
   return ret;

--- a/src/state/slices/dataset_slice.ts
+++ b/src/state/slices/dataset_slice.ts
@@ -123,7 +123,7 @@ export const serializeDatasetSlice = (slice: Partial<DatasetSliceSerializableSta
 };
 
 /** Selects state values that serialization depends on. */
-export const datasetSliceSerializationDependencies = (slice: DatasetSlice): DatasetSliceSerializableState => ({
+export const selectDatasetSliceSerializationDeps = (slice: DatasetSlice): DatasetSliceSerializableState => ({
   datasetKey: slice.datasetKey,
   featureKey: slice.featureKey,
   track: slice.track,

--- a/src/state/slices/dataset_slice.ts
+++ b/src/state/slices/dataset_slice.ts
@@ -7,27 +7,22 @@ import { CollectionSlice } from "./collection_slice";
 
 import Dataset from "../../colorizer/Dataset";
 
-type DatasetSliceState =
-  | {
-      datasetKey: null;
-      dataset: null;
-      featureKey: null;
-      track: null;
-      /** The key of the backdrop image set in the current dataset. `null` if there
-       * is no Dataset loaded or if the dataset does not have backdrops. */
-      backdropKey: null;
-    }
-  | {
-      datasetKey: string;
-      dataset: Dataset;
-      featureKey: string;
-      track: Track | null;
-      /** The key of the backdrop image set in the current dataset. `null` if there
-       * is no Dataset loaded or if the dataset does not have backdrops. */
-      backdropKey: string | null;
-    };
+export type DatasetSliceState = {
+  datasetKey: string | null;
+  dataset: Dataset | null;
+  featureKey: string | null;
+  track: Track | null;
+  /** The key of the backdrop image set in the current dataset. `null` if there
+   * is no Dataset loaded or if the dataset does not have backdrops. */
+  backdropKey: string | null;
+};
 
-type DatasetSliceActions = {
+export type DatasetSliceSerializableState = Pick<
+  DatasetSliceState,
+  "datasetKey" | "featureKey" | "track" | "backdropKey"
+>;
+
+export type DatasetSliceActions = {
   setDataset: (key: string, dataset: Dataset) => void;
   clearDataset: () => void;
   /** Sets the current feature key.
@@ -110,9 +105,9 @@ export const createDatasetSlice: StateCreator<CollectionSlice & DatasetSlice, []
   clearDataset: () => set({ datasetKey: null, dataset: null, track: null, featureKey: null, backdropKey: null }),
 });
 
-export const serializeDatasetSlice = (slice: Partial<DatasetSlice>): SerializedStoreData => {
+export const serializeDatasetSlice = (slice: Partial<DatasetSliceSerializableState>): SerializedStoreData => {
   const ret: SerializedStoreData = {};
-  if (slice.dataset) {
+  if (slice.datasetKey !== undefined && slice.datasetKey !== null) {
     ret[UrlParam.DATASET] = slice.datasetKey;
   }
   if (slice.featureKey !== undefined && slice.featureKey !== null) {
@@ -128,14 +123,12 @@ export const serializeDatasetSlice = (slice: Partial<DatasetSlice>): SerializedS
 };
 
 /** Selects state values that serialization depends on. */
-export const datasetSliceSerializationDependencies = (slice: DatasetSlice): Partial<DatasetSliceState> =>
-  ({
-    dataset: slice.dataset,
-    datasetKey: slice.datasetKey,
-    featureKey: slice.featureKey,
-    track: slice.track,
-    backdropKey: slice.backdropKey,
-  } as DatasetSliceState);
+export const datasetSliceSerializationDependencies = (slice: DatasetSlice): DatasetSliceSerializableState => ({
+  datasetKey: slice.datasetKey,
+  featureKey: slice.featureKey,
+  track: slice.track,
+  backdropKey: slice.backdropKey,
+});
 
 export const loadDatasetSliceFromParams = (slice: DatasetSlice, params: URLSearchParams): void => {
   const dataset = slice.dataset;

--- a/src/state/slices/dataset_slice.ts
+++ b/src/state/slices/dataset_slice.ts
@@ -127,6 +127,16 @@ export const serializeDatasetSlice = (slice: DatasetSlice): SerializedStoreData 
   return ret;
 };
 
+/** Selects state values that serialization depends on. */
+export const datasetSliceSerializationDependencies = (slice: DatasetSlice): Partial<DatasetSliceState> =>
+  ({
+    dataset: slice.dataset,
+    datasetKey: slice.datasetKey,
+    featureKey: slice.featureKey,
+    track: slice.track,
+    backdropKey: slice.backdropKey,
+  } as DatasetSliceState);
+
 export const loadDatasetSliceFromParams = (slice: DatasetSlice, params: URLSearchParams): void => {
   const dataset = slice.dataset;
   if (!dataset) {

--- a/src/state/slices/index.ts
+++ b/src/state/slices/index.ts
@@ -1,3 +1,62 @@
+import { StateCreator } from "zustand";
+
+import { SubscribableStore } from "../types";
+import {
+  addBackdropDerivedStateSubscribers,
+  BackdropSliceActions,
+  BackdropSliceSerializableState,
+  BackdropSliceState,
+  createBackdropSlice,
+} from "./backdrop_slice";
+import {
+  CollectionSliceActions,
+  CollectionSliceSerializableState,
+  CollectionSliceState,
+  createCollectionSlice,
+} from "./collection_slice";
+import {
+  addColorRampDerivedStateSubscribers,
+  ColorRampSliceActions,
+  ColorRampSliceSerializableState,
+  ColorRampSliceState,
+  createColorRampSlice,
+} from "./color_ramp_slice";
+import { ConfigSliceActions, ConfigSliceSerializableState, ConfigSliceState, createConfigSlice } from "./config_slice";
+import {
+  createDatasetSlice,
+  DatasetSliceActions,
+  DatasetSliceSerializableState,
+  DatasetSliceState,
+} from "./dataset_slice";
+import {
+  addScatterPlotSliceDerivedStateSubscribers,
+  createScatterPlotSlice,
+  ScatterPlotSliceActions,
+  ScatterPlotSliceSerializableState,
+  ScatterPlotSliceState,
+} from "./scatterplot_slice";
+import {
+  addThresholdDerivedStateSubscribers,
+  createThresholdSlice,
+  ThresholdSliceActions,
+  ThresholdSliceSerializableState,
+  ThresholdSliceState,
+} from "./threshold_slice";
+import {
+  addTimeDerivedStateSubscribers,
+  createTimeSlice,
+  TimeSliceActions,
+  TimeSliceSerializableState,
+  TimeSliceState,
+} from "./time_slice";
+import {
+  addVectorDerivedStateSubscribers,
+  createVectorSlice,
+  VectorSliceActions,
+  VectorSliceSerializableState,
+  VectorSliceState,
+} from "./vector_slice";
+
 export * from "./backdrop_slice";
 export * from "./collection_slice";
 export * from "./color_ramp_slice";
@@ -7,3 +66,72 @@ export * from "./scatterplot_slice";
 export * from "./threshold_slice";
 export * from "./time_slice";
 export * from "./vector_slice";
+
+export type ViewerStoreState = BackdropSliceState &
+  CollectionSliceState &
+  ColorRampSliceState &
+  ConfigSliceState &
+  DatasetSliceState &
+  ScatterPlotSliceState &
+  ThresholdSliceState &
+  TimeSliceState &
+  VectorSliceState;
+
+export type ViewerStoreActions = BackdropSliceActions &
+  CollectionSliceActions &
+  ColorRampSliceActions &
+  ConfigSliceActions &
+  DatasetSliceActions &
+  ScatterPlotSliceActions &
+  ThresholdSliceActions &
+  TimeSliceActions &
+  VectorSliceActions;
+
+/**
+ * State values in ViewerStore that can be serialized. Subset of
+ * ViewerStoreState.
+ */
+export type ViewerStoreSerializableState = BackdropSliceSerializableState &
+  CollectionSliceSerializableState &
+  ColorRampSliceSerializableState &
+  ConfigSliceSerializableState &
+  DatasetSliceSerializableState &
+  ScatterPlotSliceSerializableState &
+  ThresholdSliceSerializableState &
+  TimeSliceSerializableState &
+  VectorSliceSerializableState;
+
+/**
+ * Combined state for the React app. The ViewerState is composed of many smaller
+ * **slices**, modules of related state, actions, and selectors. See
+ * https://github.com/pmndrs/zustand/blob/main/docs/guides/typescript.md#slices-pattern
+ * for more details on the pattern.
+ */
+export type ViewerStore = ViewerStoreState & ViewerStoreActions;
+
+export const viewerStateStoreCreator: StateCreator<ViewerStore> = (...a) => ({
+  // TODO: Move this into slices/index.ts
+  ...createBackdropSlice(...a),
+  ...createCollectionSlice(...a),
+  ...createColorRampSlice(...a),
+  ...createConfigSlice(...a),
+  ...createDatasetSlice(...a),
+  ...createScatterPlotSlice(...a),
+  ...createThresholdSlice(...a),
+  ...createTimeSlice(...a),
+  ...createVectorSlice(...a),
+});
+
+/**
+ * Adds subscribers to the store that update derived state values when their
+ * dependencies change. MUST be called after creating any store with the
+ * `viewerStateStoreCreator`.
+ */
+export const addStoreStateSubscribers = (store: SubscribableStore<ViewerStore>): void => {
+  addBackdropDerivedStateSubscribers(store);
+  addColorRampDerivedStateSubscribers(store);
+  addScatterPlotSliceDerivedStateSubscribers(store);
+  addThresholdDerivedStateSubscribers(store);
+  addTimeDerivedStateSubscribers(store);
+  addVectorDerivedStateSubscribers(store);
+};

--- a/src/state/slices/index.ts
+++ b/src/state/slices/index.ts
@@ -110,7 +110,6 @@ export type ViewerStoreSerializableState = BackdropSliceSerializableState &
 export type ViewerStore = ViewerStoreState & ViewerStoreActions;
 
 export const viewerStateStoreCreator: StateCreator<ViewerStore> = (...a) => ({
-  // TODO: Move this into slices/index.ts
   ...createBackdropSlice(...a),
   ...createCollectionSlice(...a),
   ...createColorRampSlice(...a),

--- a/src/state/slices/scatterplot_slice.ts
+++ b/src/state/slices/scatterplot_slice.ts
@@ -90,6 +90,13 @@ export const serializeScatterPlotSlice = (slice: ScatterPlotSlice): SerializedSt
   return ret;
 };
 
+/** Selects state values that serialization depends on. */
+export const scatterPlotSliceSerializationDependencies = (slice: ScatterPlotSlice): Partial<ScatterPlotSliceState> => ({
+  scatterXAxis: slice.scatterXAxis,
+  scatterYAxis: slice.scatterYAxis,
+  scatterRangeType: slice.scatterRangeType,
+});
+
 export const loadScatterPlotSliceFromParams = (slice: ScatterPlotSlice, params: URLSearchParams): void => {
   const scatterXAxis = params.get(UrlParam.SCATTERPLOT_X_AXIS);
   if (scatterXAxis !== null) {

--- a/src/state/slices/scatterplot_slice.ts
+++ b/src/state/slices/scatterplot_slice.ts
@@ -102,14 +102,19 @@ export const scatterPlotSliceSerializationDependencies = (
   scatterRangeType: slice.scatterRangeType,
 });
 
-export const loadScatterPlotSliceFromParams = (slice: ScatterPlotSlice, params: URLSearchParams): void => {
+export const loadScatterPlotSliceFromParams = (
+  slice: ScatterPlotSlice & DatasetSlice,
+  params: URLSearchParams
+): void => {
+  const dataset = slice.dataset;
+
   const scatterXAxis = params.get(UrlParam.SCATTERPLOT_X_AXIS);
-  if (scatterXAxis !== null) {
+  if (scatterXAxis !== null && scatterXAxis !== undefined && isAxisKeyValid(dataset, scatterXAxis)) {
     slice.setScatterXAxis(scatterXAxis);
   }
 
   const scatterYAxis = params.get(UrlParam.SCATTERPLOT_Y_AXIS);
-  if (scatterYAxis !== null) {
+  if (scatterYAxis !== null && scatterYAxis !== undefined && isAxisKeyValid(dataset, scatterYAxis)) {
     slice.setScatterYAxis(scatterYAxis);
   }
 

--- a/src/state/slices/scatterplot_slice.ts
+++ b/src/state/slices/scatterplot_slice.ts
@@ -85,8 +85,12 @@ export const addScatterPlotSliceDerivedStateSubscribers = (
 
 export const serializeScatterPlotSlice = (slice: Partial<ScatterPlotSliceSerializableState>): SerializedStoreData => {
   const ret: SerializedStoreData = {};
-  ret[UrlParam.SCATTERPLOT_X_AXIS] = slice.scatterXAxis ?? undefined;
-  ret[UrlParam.SCATTERPLOT_Y_AXIS] = slice.scatterYAxis ?? undefined;
+  if (slice.scatterXAxis !== null && slice.scatterXAxis !== undefined) {
+    ret[UrlParam.SCATTERPLOT_X_AXIS] = slice.scatterXAxis;
+  }
+  if (slice.scatterYAxis !== null && slice.scatterYAxis !== undefined) {
+    ret[UrlParam.SCATTERPLOT_Y_AXIS] = slice.scatterYAxis;
+  }
   if (slice.scatterRangeType !== undefined) {
     ret[UrlParam.SCATTERPLOT_RANGE_MODE] = encodeScatterPlotRangeType(slice.scatterRangeType);
   }
@@ -94,7 +98,7 @@ export const serializeScatterPlotSlice = (slice: Partial<ScatterPlotSliceSeriali
 };
 
 /** Selects state values that serialization depends on. */
-export const scatterPlotSliceSerializationDependencies = (
+export const selectScatterPlotSliceSerializationDeps = (
   slice: ScatterPlotSlice
 ): ScatterPlotSliceSerializableState => ({
   scatterXAxis: slice.scatterXAxis,

--- a/src/state/slices/scatterplot_slice.ts
+++ b/src/state/slices/scatterplot_slice.ts
@@ -8,13 +8,18 @@ import { SerializedStoreData, SubscribableStore } from "../types";
 import { addDerivedStateSubscriber } from "../utils/store_utils";
 import { DatasetSlice } from "./dataset_slice";
 
-type ScatterPlotSliceState = {
+export type ScatterPlotSliceState = {
   scatterXAxis: string | null;
   scatterYAxis: string | null;
   scatterRangeType: PlotRangeType;
 };
 
-type ScatterPlotSliceActions = {
+export type ScatterPlotSliceSerializableState = Pick<
+  ScatterPlotSliceState,
+  "scatterXAxis" | "scatterYAxis" | "scatterRangeType"
+>;
+
+export type ScatterPlotSliceActions = {
   setScatterXAxis: (xAxis: string | null) => void;
   setScatterYAxis: (yAxis: string | null) => void;
   setScatterRangeType: (rangeType: PlotRangeType) => void;
@@ -78,7 +83,7 @@ export const addScatterPlotSliceDerivedStateSubscribers = (
   );
 };
 
-export const serializeScatterPlotSlice = (slice: Partial<ScatterPlotSlice>): SerializedStoreData => {
+export const serializeScatterPlotSlice = (slice: Partial<ScatterPlotSliceSerializableState>): SerializedStoreData => {
   const ret: SerializedStoreData = {};
   ret[UrlParam.SCATTERPLOT_X_AXIS] = slice.scatterXAxis ?? undefined;
   ret[UrlParam.SCATTERPLOT_Y_AXIS] = slice.scatterYAxis ?? undefined;
@@ -89,7 +94,9 @@ export const serializeScatterPlotSlice = (slice: Partial<ScatterPlotSlice>): Ser
 };
 
 /** Selects state values that serialization depends on. */
-export const scatterPlotSliceSerializationDependencies = (slice: ScatterPlotSlice): Partial<ScatterPlotSliceState> => ({
+export const scatterPlotSliceSerializationDependencies = (
+  slice: ScatterPlotSlice
+): ScatterPlotSliceSerializableState => ({
   scatterXAxis: slice.scatterXAxis,
   scatterYAxis: slice.scatterYAxis,
   scatterRangeType: slice.scatterRangeType,

--- a/src/state/slices/scatterplot_slice.ts
+++ b/src/state/slices/scatterplot_slice.ts
@@ -78,15 +78,13 @@ export const addScatterPlotSliceDerivedStateSubscribers = (
   );
 };
 
-export const serializeScatterPlotSlice = (slice: ScatterPlotSlice): SerializedStoreData => {
+export const serializeScatterPlotSlice = (slice: Partial<ScatterPlotSlice>): SerializedStoreData => {
   const ret: SerializedStoreData = {};
-  if (slice.scatterXAxis !== null) {
-    ret[UrlParam.SCATTERPLOT_X_AXIS] = slice.scatterXAxis;
+  ret[UrlParam.SCATTERPLOT_X_AXIS] = slice.scatterXAxis ?? undefined;
+  ret[UrlParam.SCATTERPLOT_Y_AXIS] = slice.scatterYAxis ?? undefined;
+  if (slice.scatterRangeType !== undefined) {
+    ret[UrlParam.SCATTERPLOT_RANGE_MODE] = encodeScatterPlotRangeType(slice.scatterRangeType);
   }
-  if (slice.scatterYAxis !== null) {
-    ret[UrlParam.SCATTERPLOT_Y_AXIS] = slice.scatterYAxis;
-  }
-  ret[UrlParam.SCATTERPLOT_RANGE_MODE] = encodeScatterPlotRangeType(slice.scatterRangeType);
   return ret;
 };
 

--- a/src/state/slices/threshold_slice.ts
+++ b/src/state/slices/threshold_slice.ts
@@ -79,6 +79,11 @@ export const serializeThresholdSlice = (slice: ThresholdSlice): SerializedStoreD
   return { [UrlParam.THRESHOLDS]: serializeThresholds(slice.thresholds) };
 };
 
+/* Selects state values that serialization depends on. */
+export const thresholdSliceSerializationDependencies = (slice: ThresholdSlice): Partial<ThresholdSliceState> => ({
+  thresholds: slice.thresholds,
+});
+
 export const loadThresholdSliceFromParams = (slice: ThresholdSlice, params: URLSearchParams): void => {
   const thresholds = deserializeThresholds(params.get(UrlParam.THRESHOLDS));
   if (thresholds !== undefined) {

--- a/src/state/slices/threshold_slice.ts
+++ b/src/state/slices/threshold_slice.ts
@@ -82,7 +82,7 @@ export const serializeThresholdSlice = (slice: Partial<ThresholdSliceSerializabl
 };
 
 /* Selects state values that serialization depends on. */
-export const thresholdSliceSerializationDependencies = (slice: ThresholdSlice): ThresholdSliceSerializableState => ({
+export const selectThresholdSliceSerializationDeps = (slice: ThresholdSlice): ThresholdSliceSerializableState => ({
   thresholds: slice.thresholds,
 });
 

--- a/src/state/slices/threshold_slice.ts
+++ b/src/state/slices/threshold_slice.ts
@@ -8,7 +8,7 @@ import { addDerivedStateSubscriber } from "../utils/store_utils";
 import { CollectionSlice } from "./collection_slice";
 import { DatasetSlice } from "./dataset_slice";
 
-type ThresholdSliceState = {
+export type ThresholdSliceState = {
   thresholds: FeatureThreshold[];
 
   // Derived state
@@ -16,7 +16,9 @@ type ThresholdSliceState = {
   inRangeLUT: Uint8Array;
 };
 
-type ThresholdSliceActions = {
+export type ThresholdSliceSerializableState = Pick<ThresholdSliceState, "thresholds">;
+
+export type ThresholdSliceActions = {
   setThresholds: (thresholds: FeatureThreshold[]) => void;
 };
 
@@ -72,7 +74,7 @@ export const addThresholdDerivedStateSubscribers = (
   );
 };
 
-export const serializeThresholdSlice = (slice: Partial<ThresholdSlice>): SerializedStoreData => {
+export const serializeThresholdSlice = (slice: Partial<ThresholdSliceSerializableState>): SerializedStoreData => {
   if (!slice.thresholds || slice.thresholds.length === 0) {
     return {};
   }
@@ -80,7 +82,7 @@ export const serializeThresholdSlice = (slice: Partial<ThresholdSlice>): Seriali
 };
 
 /* Selects state values that serialization depends on. */
-export const thresholdSliceSerializationDependencies = (slice: ThresholdSlice): Partial<ThresholdSliceState> => ({
+export const thresholdSliceSerializationDependencies = (slice: ThresholdSlice): ThresholdSliceSerializableState => ({
   thresholds: slice.thresholds,
 });
 

--- a/src/state/slices/threshold_slice.ts
+++ b/src/state/slices/threshold_slice.ts
@@ -72,8 +72,8 @@ export const addThresholdDerivedStateSubscribers = (
   );
 };
 
-export const serializeThresholdSlice = (slice: ThresholdSlice): SerializedStoreData => {
-  if (slice.thresholds.length === 0) {
+export const serializeThresholdSlice = (slice: Partial<ThresholdSlice>): SerializedStoreData => {
+  if (!slice.thresholds || slice.thresholds.length === 0) {
     return {};
   }
   return { [UrlParam.THRESHOLDS]: serializeThresholds(slice.thresholds) };

--- a/src/state/slices/time_slice.ts
+++ b/src/state/slices/time_slice.ts
@@ -101,9 +101,9 @@ export const addTimeDerivedStateSubscribers = (store: SubscribableStore<DatasetS
   );
 };
 
-export const serializeTimeSlice = (state: TimeSlice): SerializedStoreData => {
+export const serializeTimeSlice = (state: Partial<TimeSlice>): SerializedStoreData => {
   return {
-    [UrlParam.TIME]: state.currentFrame.toString(),
+    [UrlParam.TIME]: state.currentFrame?.toString(),
   };
 };
 

--- a/src/state/slices/time_slice.ts
+++ b/src/state/slices/time_slice.ts
@@ -110,7 +110,7 @@ export const serializeTimeSlice = (state: Partial<TimeSliceSerializableState>): 
 };
 
 /** Selects state values that serialization depends on. */
-export const timeSliceSerializationDependencies = (slice: TimeSlice): TimeSliceSerializableState => ({
+export const selectTimeSliceSerializationDeps = (slice: TimeSlice): TimeSliceSerializableState => ({
   currentFrame: slice.currentFrame,
 });
 

--- a/src/state/slices/time_slice.ts
+++ b/src/state/slices/time_slice.ts
@@ -107,6 +107,11 @@ export const serializeTimeSlice = (state: TimeSlice): SerializedStoreData => {
   };
 };
 
+/** Selects state values that serialization depends on. */
+export const timeSliceSerializationDependencies = (slice: TimeSlice): Partial<TimeSliceState> => ({
+  currentFrame: slice.currentFrame,
+});
+
 export const loadTimeSliceFromParams = (state: TimeSlice & DatasetSlice, params: URLSearchParams): void => {
   // Load time from URL. If no time is set but a track is, set the time to the
   // start of the track.

--- a/src/state/slices/time_slice.ts
+++ b/src/state/slices/time_slice.ts
@@ -9,7 +9,7 @@ import { DatasetSlice } from "./dataset_slice";
 
 import TimeControls from "../../colorizer/TimeControls";
 
-type TimeSliceState = {
+export type TimeSliceState = {
   /** The frame that is currently being loaded. If no load is happening,
    * `pendingFrame === currentFrame`.
    */
@@ -21,7 +21,9 @@ type TimeSliceState = {
   loadFrameCallback: (frame: number) => Promise<void>;
 };
 
-type TimeSliceActions = {
+export type TimeSliceSerializableState = Pick<TimeSliceState, "currentFrame">;
+
+export type TimeSliceActions = {
   /**
    * Attempts to set and load the given frame number, using the callback
    * provided by `setLoadCallback`.
@@ -101,14 +103,14 @@ export const addTimeDerivedStateSubscribers = (store: SubscribableStore<DatasetS
   );
 };
 
-export const serializeTimeSlice = (state: Partial<TimeSlice>): SerializedStoreData => {
+export const serializeTimeSlice = (state: Partial<TimeSliceSerializableState>): SerializedStoreData => {
   return {
     [UrlParam.TIME]: state.currentFrame?.toString(),
   };
 };
 
 /** Selects state values that serialization depends on. */
-export const timeSliceSerializationDependencies = (slice: TimeSlice): Partial<TimeSliceState> => ({
+export const timeSliceSerializationDependencies = (slice: TimeSlice): TimeSliceSerializableState => ({
   currentFrame: slice.currentFrame,
 });
 

--- a/src/state/slices/vector_slice.ts
+++ b/src/state/slices/vector_slice.ts
@@ -144,6 +144,16 @@ export const serializeVectorSlice = (slice: VectorSlice): SerializedStoreData =>
   return ret;
 };
 
+/** Selects state values that serialization depends on. */
+export const vectorSliceSerializationDependencies = (slice: VectorSlice): Partial<VectorSliceState> => ({
+  vectorVisible: slice.vectorVisible,
+  vectorKey: slice.vectorKey,
+  vectorColor: slice.vectorColor,
+  vectorScaleFactor: slice.vectorScaleFactor,
+  vectorTooltipMode: slice.vectorTooltipMode,
+  vectorMotionTimeIntervals: slice.vectorMotionTimeIntervals,
+});
+
 export function loadVectorSliceFromParams(slice: VectorSlice, params: URLSearchParams): void {
   const vectorVisible = decodeBoolean(params.get(UrlParam.SHOW_VECTOR));
   if (vectorVisible !== undefined) {

--- a/src/state/slices/vector_slice.ts
+++ b/src/state/slices/vector_slice.ts
@@ -13,9 +13,9 @@ import {
   decodeFloat,
   decodeHexColor,
   decodeInt,
-  encodeBoolean,
-  encodeColor,
-  encodeNumber,
+  encodeMaybeBoolean,
+  encodeMaybeColor,
+  encodeMaybeNumber,
   UrlParam,
 } from "../../colorizer/utils/url_utils";
 import { SerializedStoreData, SubscribableStore } from "../types";
@@ -133,14 +133,14 @@ export const selectVectorConfigFromState = (state: VectorSlice): VectorConfig =>
   tooltipMode: state.vectorTooltipMode,
 });
 
-export const serializeVectorSlice = (slice: VectorSlice): SerializedStoreData => {
+export const serializeVectorSlice = (slice: Partial<VectorSlice>): SerializedStoreData => {
   const ret: SerializedStoreData = {};
-  ret[UrlParam.SHOW_VECTOR] = encodeBoolean(slice.vectorVisible);
+  ret[UrlParam.SHOW_VECTOR] = encodeMaybeBoolean(slice.vectorVisible);
   ret[UrlParam.VECTOR_KEY] = slice.vectorKey;
-  ret[UrlParam.VECTOR_COLOR] = encodeColor(slice.vectorColor);
-  ret[UrlParam.VECTOR_SCALE] = encodeNumber(slice.vectorScaleFactor);
-  ret[UrlParam.VECTOR_TOOLTIP_MODE] = slice.vectorTooltipMode.toString();
-  ret[UrlParam.VECTOR_TIME_INTERVALS] = encodeNumber(slice.vectorMotionTimeIntervals);
+  ret[UrlParam.VECTOR_COLOR] = encodeMaybeColor(slice.vectorColor);
+  ret[UrlParam.VECTOR_SCALE] = encodeMaybeNumber(slice.vectorScaleFactor);
+  ret[UrlParam.VECTOR_TOOLTIP_MODE] = slice.vectorTooltipMode?.toString();
+  ret[UrlParam.VECTOR_TIME_INTERVALS] = encodeMaybeNumber(slice.vectorMotionTimeIntervals);
   return ret;
 };
 

--- a/src/state/slices/vector_slice.ts
+++ b/src/state/slices/vector_slice.ts
@@ -155,7 +155,7 @@ export const serializeVectorSlice = (slice: Partial<VectorSlice>): SerializedSto
 };
 
 /** Selects state values that serialization depends on. */
-export const vectorSliceSerializationDependencies = (slice: VectorSlice): Partial<VectorSliceState> => ({
+export const selectVectorSliceSerializationDeps = (slice: VectorSlice): Partial<VectorSliceState> => ({
   vectorVisible: slice.vectorVisible,
   vectorKey: slice.vectorKey,
   vectorColor: slice.vectorColor,

--- a/src/state/slices/vector_slice.ts
+++ b/src/state/slices/vector_slice.ts
@@ -25,7 +25,7 @@ import { DatasetSlice } from "./dataset_slice";
 
 import { getSharedWorkerPool } from "../../colorizer/workers/SharedWorkerPool";
 
-type VectorSliceState = {
+export type VectorSliceState = {
   vectorVisible: boolean;
   vectorKey: string;
   vectorColor: Color;
@@ -49,7 +49,17 @@ type VectorSliceState = {
   vectorMotionDeltas: Float32Array | null;
 };
 
-type VectorSliceActions = {
+export type VectorSliceSerializableState = Pick<
+  VectorSliceState,
+  | "vectorVisible"
+  | "vectorKey"
+  | "vectorColor"
+  | "vectorScaleFactor"
+  | "vectorTooltipMode"
+  | "vectorMotionTimeIntervals"
+>;
+
+export type VectorSliceActions = {
   setVectorVisible: (visible: boolean) => void;
   setVectorKey: (key: string) => void;
   setVectorColor: (color: Color) => void;

--- a/src/state/utils/data_validation.ts
+++ b/src/state/utils/data_validation.ts
@@ -21,3 +21,31 @@ export const validateFiniteValue = (value: number, source: string): number => {
   }
   return value;
 };
+
+/**
+ * Returns a copy of an object where any properties with a value of `undefined`
+ * are not included.
+ */
+export function removeUndefinedProperties<T>(object: T): Partial<T> {
+  const ret: Partial<T> = {};
+  for (const key in object) {
+    if (object[key] !== undefined) {
+      ret[key] = object[key];
+    }
+  }
+  return ret;
+}
+
+/**
+ * Returns the set of keys that have differing values between two objects.
+ */
+export const getDifferingProperties = <T extends Record<string, any>>(a: Partial<T>, b: Partial<T>): Set<keyof T> => {
+  const differingKeys = new Set<keyof T>();
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const key in keys) {
+    if (a[key] !== b[key]) {
+      differingKeys.add(key);
+    }
+  }
+  return differingKeys;
+};

--- a/src/state/utils/store_io.ts
+++ b/src/state/utils/store_io.ts
@@ -91,25 +91,37 @@ export const serializeViewerState = (state: Partial<ViewerStoreSerializableState
   };
 };
 
-export type ViewerParams = Partial<ViewerStoreSerializableState> & {
-  /** URL of the collection resource to load. */
+export type ViewerParams = {
+  /** Optional URL of the collection resource to load. Overwrites the URL of the
+   * `collection` field in the serialized store data if defined.
+   */
   collectionParam?: string;
-};
+  /** Optional URL of the dataset or dataset key. Overwrites the
+   * `dataset` field in the serialized store data if defined.
+   */
+  datasetParam?: string;
+} & Partial<ViewerStoreSerializableState>;
 
 /**
  * Serializes parameters for the viewer into a `SerializedStoreData` object,
  * which can be used to generate a URL query string using `serializedDataToUrl`.
- * @param params Object containing serializable viewer state parameters.
- * Also includes a `collectionParam` field for the collection URL.
+ * @param params Object containing serializable viewer state parameters; see
+ * `ViewerStoreSerializableState` for a list of possible fields.
  */
 export const serializeViewerParams = (params: ViewerParams): SerializedStoreData => {
   const ret: SerializedStoreData = {};
   if (params.collectionParam) {
     ret[UrlParam.COLLECTION] = params.collectionParam;
   }
+  if (params.datasetParam) {
+    ret[UrlParam.DATASET] = params.datasetParam;
+  }
   return {
+    // Order collection + dataset first in params, but override the default
+    // serialized collection fields by destructuring a second time.
     ...ret,
-    ...serializeViewerState(params),
+    ...serializeViewerState({ ...params }),
+    ...ret,
   };
 };
 

--- a/src/state/utils/store_io.ts
+++ b/src/state/utils/store_io.ts
@@ -1,4 +1,9 @@
 import {
+  backdropSliceSerializationDependencies,
+  collectionSliceSerializationDependencies,
+  colorRampSliceSerializationDependencies,
+  configSliceSerializationDependencies,
+  datasetSliceSerializationDependencies,
   loadBackdropSliceFromParams,
   loadColorRampSliceFromParams,
   loadConfigSliceFromParams,
@@ -7,6 +12,7 @@ import {
   loadThresholdSliceFromParams,
   loadTimeSliceFromParams,
   loadVectorSliceFromParams,
+  scatterPlotSliceSerializationDependencies,
   serializeBackdropSlice,
   serializeCollectionSlice,
   serializeColorRampSlice,
@@ -16,12 +22,39 @@ import {
   serializeThresholdSlice,
   serializeTimeSlice,
   serializeVectorSlice,
+  thresholdSliceSerializationDependencies,
+  timeSliceSerializationDependencies,
+  vectorSliceSerializationDependencies,
 } from "../slices";
 import { SerializedStoreData, Store } from "../types";
 
 import { ViewerState } from "../ViewerState";
 
 // SERIALIZATION /////////////////////////////////////////////////////////////////////////
+
+export const selectSerializationDependencies = (state: ViewerState): Partial<ViewerState> => ({
+  ...collectionSliceSerializationDependencies(state),
+  ...datasetSliceSerializationDependencies(state),
+  // Time slice should only allow updates when paused.
+  ...timeSliceSerializationDependencies(state),
+  ...colorRampSliceSerializationDependencies(state),
+  ...thresholdSliceSerializationDependencies(state),
+  ...configSliceSerializationDependencies(state),
+  ...scatterPlotSliceSerializationDependencies(state),
+  ...backdropSliceSerializationDependencies(state),
+  ...vectorSliceSerializationDependencies(state),
+});
+
+export const getDifferingKeys = (a: Partial<ViewerState>, b: Partial<ViewerState>): Set<keyof ViewerState> => {
+  const differingKeys = new Set<keyof ViewerState>();
+  for (const key in a) {
+    const typedKey = key as keyof ViewerState;
+    if (a[typedKey] !== b[typedKey]) {
+      differingKeys.add(typedKey);
+    }
+  }
+  return differingKeys;
+};
 
 export const serializeViewerStateStore = (store: Store<ViewerState>): Partial<SerializedStoreData> => {
   // Ordered by approximate importance in the URL

--- a/src/state/utils/store_io.ts
+++ b/src/state/utils/store_io.ts
@@ -98,7 +98,7 @@ export const serializeViewerParams = (params: ViewerParams): SerializedStoreData
     // Order collection + dataset first in params, but override the default
     // serialized collection fields by destructuring a second time.
     ...ret,
-    ...serializeViewerState({ ...params }),
+    ...serializeViewerState(params),
     ...ret,
   });
 };

--- a/src/state/utils/store_utils.ts
+++ b/src/state/utils/store_utils.ts
@@ -40,7 +40,7 @@ export const addDerivedStateSubscriber = <T, const U>(
  * @param debounceMs The number of milliseconds to wait before calling the
  * debounced callback. Defaults to 250ms.
  */
-export const makeDebouncedCallback = <T, U, CallbackFn extends (state: T) => Partial<U> | undefined | void>(
+export const makeDebouncedCallback = <T, U, CallbackFn extends (args: T) => Partial<U> | undefined | void>(
   callback: CallbackFn,
   debounceMs: number = 250
 ): ((args: T) => void) => {
@@ -49,8 +49,8 @@ export const makeDebouncedCallback = <T, U, CallbackFn extends (state: T) => Par
   let timeout: ReturnType<typeof setTimeout> | null = null;
   let lastArgs: T | null = null;
 
-  return (state: T) => {
-    lastArgs = state;
+  return (args: T): void => {
+    lastArgs = args;
     if (timeout) {
       clearTimeout(timeout);
     }

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -1,13 +1,13 @@
 import { ReactNode } from "react";
 
-import { UrlParams } from "../colorizer/utils/url_utils";
+import { ViewerStateParams } from "../state/utils/store_io";
 
 import Collection from "../colorizer/Collection";
 
 export type DatasetEntry = {
   name: string;
   description: ReactNode;
-  loadParams: Partial<UrlParams>;
+  loadParams: ViewerStateParams;
 };
 
 export type ProjectEntry = {
@@ -15,7 +15,7 @@ export type ProjectEntry = {
   description: ReactNode;
   publicationLink?: URL;
   publicationName?: string;
-  loadParams?: Partial<UrlParams>;
+  loadParams?: ViewerStateParams;
   datasets?: DatasetEntry[];
   inReview?: boolean;
 };

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -1,13 +1,13 @@
 import { ReactNode } from "react";
 
-import { ViewerStateParams } from "../state/utils/store_io";
+import { UrlParams } from "../colorizer/utils/url_utils";
 
 import Collection from "../colorizer/Collection";
 
 export type DatasetEntry = {
   name: string;
   description: ReactNode;
-  loadParams: ViewerStateParams;
+  loadParams: Partial<UrlParams>;
 };
 
 export type ProjectEntry = {
@@ -15,7 +15,7 @@ export type ProjectEntry = {
   description: ReactNode;
   publicationLink?: URL;
   publicationName?: string;
-  loadParams?: ViewerStateParams;
+  loadParams?: Partial<UrlParams>;
   datasets?: DatasetEntry[];
   inReview?: boolean;
 };

--- a/tests/state/ViewerState/scatterplot_slice.test.ts
+++ b/tests/state/ViewerState/scatterplot_slice.test.ts
@@ -151,6 +151,19 @@ describe("ScatterplotSlice", () => {
       expect(result.current.scatterRangeType).toBe(PlotRangeType.CURRENT_FRAME);
     });
 
+    it("ignores axes that are not in the dataset when dataset is loaded", async () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      const params = new URLSearchParams();
+      params.set(UrlParam.SCATTERPLOT_X_AXIS, "invalid-feature-x");
+      params.set(UrlParam.SCATTERPLOT_Y_AXIS, "invalid-feature-y");
+      await setDatasetAsync(result, MOCK_DATASET);
+      act(() => {
+        loadScatterPlotSliceFromParams(result.current, params);
+      });
+      expect(result.current.scatterXAxis).toBe(null);
+      expect(result.current.scatterYAxis).toBe(null);
+    });
+
     it("ignores missing axes", () => {
       const { result } = renderHook(() => useViewerStateStore());
       const initialXAxis = result.current.scatterXAxis;

--- a/tests/state/ViewerState/utils.ts
+++ b/tests/state/ViewerState/utils.ts
@@ -4,7 +4,7 @@ import { expect } from "vitest";
 
 import { Dataset } from "../../../src/colorizer";
 import { UrlParam } from "../../../src/colorizer/utils/url_utils";
-import { ViewerState } from "../../../src/state";
+import { ViewerStore } from "../../../src/state/slices";
 import { SerializedStoreData } from "../../../src/state/types";
 
 /**
@@ -13,7 +13,7 @@ import { SerializedStoreData } from "../../../src/state/types";
  */
 
 export const setDatasetAsync = async (
-  result: { current: ViewerState },
+  result: { current: ViewerStore },
   dataset: Dataset,
   datasetKey: string = "some-dataset"
 ): Promise<void> => {
@@ -23,7 +23,7 @@ export const setDatasetAsync = async (
   await waitFor(() => {});
 };
 
-export const clearDatasetAsync = async (result: { current: ViewerState }): Promise<void> => {
+export const clearDatasetAsync = async (result: { current: ViewerStore }): Promise<void> => {
   act(() => {
     result.current.clearDataset();
   });
@@ -35,9 +35,9 @@ export const clearDatasetAsync = async (result: { current: ViewerState }): Promi
  * Note that `actual` may contain additional key-value pairs not present in
  * `expected` and still pass this check.
  */
-export const compareSlice = (actual: Partial<ViewerState>, expected: Partial<ViewerState>): void => {
+export const compareSlice = (actual: Partial<ViewerStore>, expected: Partial<ViewerStore>): void => {
   for (const key in expected) {
-    expect(actual[key as keyof ViewerState]).toEqual(expected[key as keyof ViewerState]);
+    expect(actual[key as keyof ViewerStore]).toEqual(expected[key as keyof ViewerStore]);
   }
 };
 


### PR DESCRIPTION
Problem
=======
Part 14 of 15(???) for #492, "refactor state management."

OKAY WE'RE ALMOST DONE! This change does some cleanup in the organization of the slice files-- now, there's only one file that needs to be updated when new slices are added or removed!

I also added a bunch of new types to help scope what parts of the state can be serialized. This allows for the other use case of the state serialization/deserialization, where we want to take some parameters for the app and turn it into a URL, like we do on the landing page.

*Estimated review size: medium, 30-40 minutes*

Solution
========
- Added versions of `encode{}` methods in `url_utils` that handle `undefined` values.
- Renamed `ViewerState` to `ViewerStore`.
- Moved imports from slices out of `ViewerState.tes` and into `state/slices/index.ts`.
- In all slice files:
  - Added a type (`{...}SliceSerializableState`) that defines what parts of the state can be serialized or deserialized.
    - This prevents users from trying to pass in params to the app that can't be loaded, and will also trigger useful linting errors if changes to serialized values aren't updated in the right places.
  - Added a selector for state that is serialized, for use with `subscribe`.
  - Changed all serialization logic to handle `Partial` types, so partial params can be turned into URLs.
