### PR TITLE
fix: Added input validation for time slice

### DIFF
--- a/src/state/slices/time_slice.ts
+++ b/src/state/slices/time_slice.ts
@@ -26,8 +26,8 @@ export type TimeSliceSerializableState = Pick<TimeSliceState, "currentFrame">;
 export type TimeSliceActions = {
   /**
    * Attempts to set and load the given frame number, using the callback
-   * provided by `setLoadCallback`. The frame number will be clamped to the
-   * number of frames in the dataset if one is loaded.
+   * provided by `setLoadCallback`. The frame number will be clamped between 0
+   * and the number of frames in the dataset, if one is loaded.
    *
    * Note that `pendingFrame` will be set to the frame that is being loaded,
    * while `currentFrame` will not update until the promise returned by the
@@ -66,6 +66,8 @@ export const createTimeSlice: StateCreator<TimeSlice & DatasetSlice, [], [], Tim
     const dataset = get().dataset;
     if (dataset !== null) {
       frame = clampWithNanCheck(frame, 0, dataset.numberOfFrames - 1);
+    } else {
+      frame = Math.max(frame, 0);
     }
 
     const isPlaying = get().timeControls.isPlaying();

--- a/src/state/slices/time_slice.ts
+++ b/src/state/slices/time_slice.ts
@@ -26,7 +26,8 @@ export type TimeSliceSerializableState = Pick<TimeSliceState, "currentFrame">;
 export type TimeSliceActions = {
   /**
    * Attempts to set and load the given frame number, using the callback
-   * provided by `setLoadCallback`.
+   * provided by `setLoadCallback`. The frame number will be clamped to the
+   * number of frames in the dataset if one is loaded.
    *
    * Note that `pendingFrame` will be set to the frame that is being loaded,
    * while `currentFrame` will not update until the promise returned by the
@@ -39,7 +40,7 @@ export type TimeSliceActions = {
 
 export type TimeSlice = TimeSliceState & TimeSliceActions;
 
-export const createTimeSlice: StateCreator<TimeSlice, [], [], TimeSlice> = (set, get) => ({
+export const createTimeSlice: StateCreator<TimeSlice & DatasetSlice, [], [], TimeSlice> = (set, get) => ({
   pendingFrame: 0,
   currentFrame: 0,
   playbackFps: DEFAULT_PLAYBACK_FPS,
@@ -59,16 +60,33 @@ export const createTimeSlice: StateCreator<TimeSlice, [], [], TimeSlice> = (set,
     set({ loadFrameCallback: callback });
   },
   setFrame: async (frame: number) => {
+    if (!Number.isFinite(frame)) {
+      throw new Error(`TimeSlice.setFrame: Invalid frame number: ${frame}`);
+    }
+    const dataset = get().dataset;
+    if (dataset !== null) {
+      frame = clampWithNanCheck(frame, 0, dataset.numberOfFrames - 1);
+    }
+
     const isPlaying = get().timeControls.isPlaying();
     if (isPlaying) {
       get().timeControls.pause();
     }
     set({ pendingFrame: frame });
-    await get().loadFrameCallback(frame);
-    set({ currentFrame: frame });
-    if (isPlaying) {
-      get().timeControls.play();
-    }
+    await get()
+      .loadFrameCallback(frame)
+      .then(() => {
+        set({ currentFrame: frame });
+      })
+      .catch((error) => {
+        console.error(`TimeSlice.setFrame: Failed to load frame ${frame}:`, error);
+        set({ pendingFrame: get().currentFrame });
+      })
+      .finally(() => {
+        if (isPlaying) {
+          get().timeControls.play();
+        }
+      });
   },
   setPlaybackFps: (fps: number) => {
     set({ playbackFps: clampWithNanCheck(fps, 0, Number.MAX_SAFE_INTEGER) });
@@ -118,7 +136,7 @@ export const loadTimeSliceFromParams = (state: TimeSlice & DatasetSlice, params:
   // Load time from URL. If no time is set but a track is, set the time to the
   // start of the track.
   const time = decodeInt(params.get(UrlParam.TIME));
-  if (time !== undefined) {
+  if (time !== undefined && Number.isFinite(time)) {
     state.setFrame(time);
   } else if (state.track !== null) {
     state.setFrame(state.track.startTime());

--- a/tests/state/ViewerState/time_slice.test.ts
+++ b/tests/state/ViewerState/time_slice.test.ts
@@ -188,7 +188,17 @@ describe("useViewerStateStore: TimeSlice", () => {
       expect(result.current.pendingFrame).toBe(3);
     });
 
-    it("clamps frame number if dataset is provided", async () => {
+    it("clamps min frame number to 0", () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      const params = new URLSearchParams();
+      params.set(UrlParam.TIME, "-100");
+      act(() => {
+        loadTimeSliceFromParams(result.current, params);
+      });
+      expect(result.current.pendingFrame).toBe(0);
+    });
+
+    it("clamps max frame number if dataset is provided", async () => {
       const { result } = renderHook(() => useViewerStateStore());
       const params = new URLSearchParams();
       params.set(UrlParam.TIME, "100");


### PR DESCRIPTION
Problem
=======
Fixes a bug where the frame could be set to `NaN`, `Infinity`, or invalid timesteps.

*Estimated review size: small, 5 minutes*

## Validation:
Min clamp:
1. Open the bugged build, where I've set the time to `-15`. You'll see the incorrect value appear on the UI. https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-596/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&t=-15
2. Open the fixed build. The time will be clamped to 0. https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-597/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&t=-15

Max clamp:
1. Open the bugged build, where I've set the time to `1000`. You'll see the incorrect value appear on the UI. https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-596/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&t=1000
2. Open the fixed build. The time will be clamped to the max frame number. https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-597/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&t=1000