### PR TITLE
refactor: Make Canvas interface, simplify ColorizeCanvas API (canvas pt. 1)

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -367,7 +367,6 @@ function Viewer(): ReactElement {
 
       // State updates
       setDataset(newDatasetKey, newDataset);
-      // await canv.setDataset(newDataset);
 
       setDatasetOpen(true);
       console.log("Dataset metadata:", newDataset.metadata);

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -367,7 +367,7 @@ function Viewer(): ReactElement {
 
       // State updates
       setDataset(newDatasetKey, newDataset);
-      await canv.setDataset(newDataset);
+      // await canv.setDataset(newDataset);
 
       setDatasetOpen(true);
       console.log("Dataset metadata:", newDataset.metadata);

--- a/src/colorizer/CanvasWithOverlay.ts
+++ b/src/colorizer/CanvasWithOverlay.ts
@@ -127,10 +127,10 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
     return this.canvas;
   }
 
-  public setSize(width: number, height: number): void {
+  public setResolution(width: number, height: number): void {
     this.canvasSize.x = width;
     this.canvasSize.y = height;
-    super.setSize(width, height);
+    super.setResolution(width, height);
   }
 
   public getIdAtPixel(x: number, y: number): number {

--- a/src/colorizer/CanvasWithOverlay.ts
+++ b/src/colorizer/CanvasWithOverlay.ts
@@ -29,6 +29,7 @@ import { getPixelRatio } from "./canvas/utils";
 import { LabelData } from "./AnnotationData";
 import Collection from "./Collection";
 import ColorizeCanvas from "./ColorizeCanvas";
+import ColorRamp from "./ColorRamp";
 
 /**
  * Extends the ColorizeCanvas class by overlaying and compositing additional
@@ -131,6 +132,7 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
     this.canvasSize.x = width;
     this.canvasSize.y = height;
     super.setResolution(width, height);
+    this.render();
   }
 
   public getIdAtPixel(x: number, y: number): number {
@@ -194,9 +196,9 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
     return {
       canvasSize: this.canvasSize,
       collection: this.collection,
-      dataset: this.dataset,
+      dataset: this.params?.dataset || null,
       datasetKey: this.datasetKey,
-      featureKey: this.featureKey,
+      featureKey: this.params?.featureKey || null,
     };
   }
 
@@ -209,7 +211,7 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
       selectedLabelIdx: this.selectedLabelIdx,
       lastSelectedId: this.lastClickedId,
       frameToCanvasCoordinates: this.frameToCanvasCoordinates,
-      frame: this.getCurrentFrame(),
+      frame: this.currentFrame,
       panOffset: this.panOffset,
     };
     return getAnnotationRenderer(this.ctx, params, this.annotationStyle);
@@ -228,7 +230,7 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
     const params: FooterParams = {
       ...baseParams,
       visible,
-      timestamp: { ...baseParams, currentFrame: this.getCurrentFrame(), visible: this.isTimestampVisible },
+      timestamp: { ...baseParams, currentFrame: this.currentFrame, visible: this.isTimestampVisible },
       timestampStyle: this.timestampStyle,
       scaleBar: {
         ...baseParams,
@@ -239,10 +241,10 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
       insetBoxStyle: this.insetBoxStyle,
       legend: {
         ...baseParams,
-        colorRamp: this.colorRamp,
+        colorRamp: this.params?.colorRamp || new ColorRamp(["white"]),
         categoricalPalette: this.categoricalPalette,
-        colorMapRangeMin: this.colorMapRangeMin,
-        colorMapRangeMax: this.colorMapRangeMax,
+        colorMapRangeMin: this.params?.colorRampRange[0] || 0,
+        colorMapRangeMax: this.params?.colorRampRange[1] || 1,
       },
       legendStyle: this.legendStyle,
     };

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -243,11 +243,11 @@ export default class ColorizeCanvas implements IRenderCanvas {
     this.pickMaterial.uniforms[name].value = value;
   }
 
-  get resolution(): Vector2 {
+  public get resolution(): Vector2 {
     return this.canvasResolution;
   }
 
-  get domElement(): HTMLCanvasElement {
+  public get domElement(): HTMLCanvasElement {
     return this.renderer.domElement;
   }
 
@@ -257,7 +257,7 @@ export default class ColorizeCanvas implements IRenderCanvas {
     }
   }
 
-  setResolution(width: number, height: number): void {
+  public setResolution(width: number, height: number): void {
     this.checkPixelRatio();
 
     this.renderer.setSize(width, height);
@@ -271,7 +271,7 @@ export default class ColorizeCanvas implements IRenderCanvas {
     }
   }
 
-  setZoom(zoom: number): void {
+  public setZoom(zoom: number): void {
     this.zoomMultiplier = zoom;
     if (this.params?.dataset) {
       this.updateScaling(this.params.dataset.frameResolution, this.canvasResolution);
@@ -284,7 +284,7 @@ export default class ColorizeCanvas implements IRenderCanvas {
    * Expects x and y in a range of [-0.5, 0.5], where [0, 0] means the frame will be centered
    * and [-0.5, -0.5] means the top right corner of the frame will be centered in the canvas view.
    */
-  setPan(x: number, y: number): void {
+  public setPan(x: number, y: number): void {
     this.panOffset = new Vector2(x, y);
     this.setUniform("panOffset", this.panOffset);
 
@@ -349,13 +349,11 @@ export default class ColorizeCanvas implements IRenderCanvas {
     if (dataset === null) {
       return;
     }
-
     if (dataset.outliers) {
       this.setUniform("outlierData", packDataTexture(Array.from(dataset.outliers), FeatureDataType.U8));
     } else {
       this.setUniform("outlierData", packDataTexture([0], FeatureDataType.U8));
     }
-
     this.vectorField.setDataset(dataset);
     await this.forceFrameReload();
     this.updateScaling(dataset.frameResolution, this.canvasResolution);
@@ -402,7 +400,7 @@ export default class ColorizeCanvas implements IRenderCanvas {
     }
   }
 
-  updateTrackData(dataset: Dataset | null, track: Track | null): void {
+  private updateTrackData(dataset: Dataset | null, track: Track | null): void {
     if (!track || !track.centroids || track.centroids.length === 0 || !dataset) {
       return;
     }
@@ -433,7 +431,7 @@ export default class ColorizeCanvas implements IRenderCanvas {
     this.line.geometry.getAttribute("position").needsUpdate = true;
   }
 
-  updateFeatureData(dataset: Dataset | null, featureKey: string | null): void {
+  private updateFeatureData(dataset: Dataset | null, featureKey: string | null): void {
     if (featureKey === null || dataset === null) {
       return;
     }
@@ -563,7 +561,7 @@ export default class ColorizeCanvas implements IRenderCanvas {
    * @param forceUpdate Force a reload of the frame data, even if the frame
    * is already loaded.
    */
-  async setFrame(index: number, forceUpdate: boolean = false): Promise<void> {
+  public async setFrame(index: number, forceUpdate: boolean = false): Promise<void> {
     const dataset = this.params?.dataset;
     // Ignore same or bad frame indices
     if (!dataset || (!forceUpdate && this.currentFrame === index) || !dataset.isValidFrameIndex(index)) {
@@ -641,7 +639,7 @@ export default class ColorizeCanvas implements IRenderCanvas {
    * Updates the range of the track path line so that it shows up the path up to the current
    * frame.
    */
-  syncTrackPathLine(): void {
+  private syncTrackPathLine(): void {
     // Show nothing if track doesn't exist or doesn't have centroid data
     const track = this.params?.track;
     if (!track || !track.centroids || !this.params?.showTrackPath) {
@@ -669,21 +667,21 @@ export default class ColorizeCanvas implements IRenderCanvas {
     this.setUniform("highlightedId", this.params?.track.getIdAtTime(this.currentFrame));
   }
 
-  render(): void {
+  public render(): void {
     this.syncHighlightedId();
     this.syncTrackPathLine();
 
     this.renderer.render(this.scene, this.camera);
   }
 
-  dispose(): void {
+  public dispose(): void {
     this.material.dispose();
     this.geometry.dispose();
     this.renderer.dispose();
     this.pickMaterial.dispose();
   }
 
-  getIdAtPixel(x: number, y: number): number {
+  public getIdAtPixel(x: number, y: number): number {
     const rt = this.renderer.getRenderTarget();
 
     this.renderer.setRenderTarget(this.pickRenderTarget);

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -29,7 +29,7 @@ import {
   OUTLIER_COLOR_DEFAULT,
   OUTLINE_COLOR_DEFAULT,
 } from "./constants";
-import { DrawMode, FeatureDataType, VectorConfig } from "./types";
+import { DrawMode, FeatureDataType } from "./types";
 import { hasPropertyChanged } from "./utils/data_utils";
 import { packDataTexture } from "./utils/texture_utils";
 
@@ -402,10 +402,6 @@ export default class ColorizeCanvas implements ICanvas {
     }
   }
 
-  setVectorFieldConfig(config: VectorConfig): void {
-    this.vectorField.setConfig(config);
-  }
-
   updateTrackData(dataset: Dataset | null, track: Track | null): void {
     if (!track || !track.centroids || track.centroids.length === 0 || !dataset) {
       return;
@@ -496,18 +492,14 @@ export default class ColorizeCanvas implements ICanvas {
       this.setOutOfRangeDrawMode(params.outOfRangeDrawSettings.mode, params.outOfRangeDrawSettings.color);
     }
     if (hasPropertyChanged(params, prevParams, ["inRangeLUT"])) {
-      console.log("Setting in range LUT");
       this.setInRangeLUT(params.inRangeLUT);
     }
-    if (
-      hasPropertyChanged(params, prevParams, [
-        "vectorMotionDeltas",
-        "vectorVisible",
-        "vectorColor",
-        "vectorScaleFactor",
-      ])
-    ) {
-      // TODO: Fix vectors
+    if (hasPropertyChanged(params, prevParams, ["vectorVisible", "vectorColor", "vectorScaleFactor"])) {
+      this.vectorField.setConfig({
+        color: params.vectorColor,
+        scaleFactor: params.vectorScaleFactor,
+        visible: params.vectorVisible,
+      });
     }
     if (hasPropertyChanged(params, prevParams, ["vectorMotionDeltas"])) {
       this.vectorField.setVectorData(params.vectorMotionDeltas);

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -35,7 +35,7 @@ import { packDataTexture } from "./utils/texture_utils";
 
 import ColorRamp from "./ColorRamp";
 import Dataset from "./Dataset";
-import { CanvasStateParams, ICanvas } from "./ICanvas";
+import { CanvasStateParams, IRenderCanvas } from "./IRenderCanvas";
 import Track from "./Track";
 import VectorField from "./VectorField";
 
@@ -120,7 +120,7 @@ const getDefaultUniforms = (): ColorizeUniforms => {
   };
 };
 
-export default class ColorizeCanvas implements ICanvas {
+export default class ColorizeCanvas implements IRenderCanvas {
   private geometry: PlaneGeometry;
   private material: ShaderMaterial;
   private pickMaterial: ShaderMaterial;
@@ -468,7 +468,7 @@ export default class ColorizeCanvas implements ICanvas {
     this.onFrameChangeCallback = callback;
   }
 
-  public async setParams(params: CanvasStateParams): Promise<void> {
+  public setParams(params: CanvasStateParams): void {
     // TODO: What happens when `setParams` is called again while waiting for a Dataset to load?
     // May cause visual desync where the color ramp/feature data updates before frames load in fully
     if (this.params === params) {

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -537,6 +537,14 @@ export default class Dataset {
     return this.times?.[index] || 0;
   }
 
+  public getTotalFrames(): number {
+    return this.frameFiles.length;
+  }
+
+  public isValidFrameIndex(index: number): boolean {
+    return index >= 0 && index < this.getTotalFrames();
+  }
+
   /** get track id of a given cell id */
   public getTrackId(index: number): number {
     return this.trackIds?.[index] || 0;

--- a/src/colorizer/ICanvas.ts
+++ b/src/colorizer/ICanvas.ts
@@ -1,0 +1,61 @@
+import { Vector2 } from "three";
+
+import { ViewerStoreState } from "../state/slices";
+
+export type CanvasStateParams = Pick<
+  ViewerStoreState,
+  | "dataset"
+  | "featureKey"
+  | "track"
+  | "showTrackPath"
+  | "colorRamp"
+  | "colorRampRange"
+  | "categoricalPalette"
+  | "outlineColor"
+  | "outlierDrawSettings"
+  | "outOfRangeDrawSettings"
+  | "inRangeLUT"
+  | "vectorMotionDeltas"
+  | "vectorVisible"
+  | "vectorColor"
+  | "vectorScaleFactor"
+  | "backdropKey"
+  | "backdropVisible"
+  | "objectOpacity"
+  | "backdropSaturation"
+  | "backdropBrightness"
+>;
+
+export const canvasStateParamsSelector = (state: ViewerStoreState): CanvasStateParams => ({
+  dataset: state.dataset,
+  featureKey: state.scatterXAxis,
+  track: state.track,
+  showTrackPath: state.showTrackPath,
+  colorRamp: state.colorRamp,
+  colorRampRange: state.colorRampRange,
+  categoricalPalette: state.categoricalPalette,
+  outlineColor: state.outlineColor,
+  outlierDrawSettings: state.outlierDrawSettings,
+  outOfRangeDrawSettings: state.outOfRangeDrawSettings,
+  inRangeLUT: state.inRangeLUT,
+  vectorMotionDeltas: state.vectorMotionDeltas,
+  vectorVisible: state.vectorVisible,
+  vectorColor: state.vectorColor,
+  vectorScaleFactor: state.vectorScaleFactor,
+  backdropKey: state.backdropKey,
+  backdropVisible: state.backdropVisible,
+  objectOpacity: state.objectOpacity,
+  backdropSaturation: state.backdropSaturation,
+  backdropBrightness: state.backdropBrightness,
+});
+
+export interface ICanvas {
+  get domElement(): HTMLCanvasElement;
+  get resolution(): Vector2;
+  setResolution(width: number, height: number): void;
+  setParams(params: CanvasStateParams): void;
+  setFrame(frame: number): Promise<void>;
+  render(): void;
+  dispose(): void;
+  getIdAtPixel(x: number, y: number): number;
+}

--- a/src/colorizer/ICanvas.ts
+++ b/src/colorizer/ICanvas.ts
@@ -2,52 +2,35 @@ import { Vector2 } from "three";
 
 import { ViewerStoreState } from "../state/slices";
 
-export type CanvasStateParams = Pick<
-  ViewerStoreState,
-  | "dataset"
-  | "featureKey"
-  | "track"
-  | "showTrackPath"
-  | "colorRamp"
-  | "colorRampRange"
-  | "categoricalPalette"
-  | "outlineColor"
-  | "outlierDrawSettings"
-  | "outOfRangeDrawSettings"
-  | "inRangeLUT"
-  | "vectorMotionDeltas"
-  | "vectorVisible"
-  | "vectorColor"
-  | "vectorScaleFactor"
-  | "backdropKey"
-  | "backdropVisible"
-  | "objectOpacity"
-  | "backdropSaturation"
-  | "backdropBrightness"
->;
+const canvasStateDeps = [
+  "dataset",
+  "featureKey",
+  "track",
+  "showTrackPath",
+  "colorRamp",
+  "colorRampRange",
+  "categoricalPalette",
+  "outlineColor",
+  "outlierDrawSettings",
+  "outOfRangeDrawSettings",
+  "inRangeLUT",
+  "vectorMotionDeltas",
+  "vectorVisible",
+  "vectorColor",
+  "vectorScaleFactor",
+  "backdropKey",
+  "backdropVisible",
+  "objectOpacity",
+  "backdropSaturation",
+  "backdropBrightness",
+] as const;
 
-export const canvasStateParamsSelector = (state: ViewerStoreState): CanvasStateParams => ({
-  dataset: state.dataset,
-  featureKey: state.featureKey,
-  track: state.track,
-  showTrackPath: state.showTrackPath,
-  colorRamp: state.colorRamp,
-  colorRampRange: state.colorRampRange,
-  categoricalPalette: state.categoricalPalette,
-  outlineColor: state.outlineColor,
-  outlierDrawSettings: state.outlierDrawSettings,
-  outOfRangeDrawSettings: state.outOfRangeDrawSettings,
-  inRangeLUT: state.inRangeLUT,
-  vectorMotionDeltas: state.vectorMotionDeltas,
-  vectorVisible: state.vectorVisible,
-  vectorColor: state.vectorColor,
-  vectorScaleFactor: state.vectorScaleFactor,
-  backdropKey: state.backdropKey,
-  backdropVisible: state.backdropVisible,
-  objectOpacity: state.objectOpacity,
-  backdropSaturation: state.backdropSaturation,
-  backdropBrightness: state.backdropBrightness,
-});
+export type CanvasStateParams = Pick<ViewerStoreState, (typeof canvasStateDeps)[number]>;
+
+export const canvasStateParamsSelector = (state: ViewerStoreState): CanvasStateParams => {
+  const entries = canvasStateDeps.map((key) => [key, state[key]]);
+  return Object.fromEntries(entries);
+};
 
 export interface ICanvas {
   get domElement(): HTMLCanvasElement;

--- a/src/colorizer/ICanvas.ts
+++ b/src/colorizer/ICanvas.ts
@@ -28,7 +28,7 @@ export type CanvasStateParams = Pick<
 
 export const canvasStateParamsSelector = (state: ViewerStoreState): CanvasStateParams => ({
   dataset: state.dataset,
-  featureKey: state.scatterXAxis,
+  featureKey: state.featureKey,
   track: state.track,
   showTrackPath: state.showTrackPath,
   colorRamp: state.colorRamp,

--- a/src/colorizer/IRenderCanvas.ts
+++ b/src/colorizer/IRenderCanvas.ts
@@ -25,9 +25,9 @@ const canvasStateDeps = [
   "backdropBrightness",
 ] as const;
 
-export type CanvasStateParams = Pick<ViewerStoreState, (typeof canvasStateDeps)[number]>;
+export type RenderCanvasStateParams = Pick<ViewerStoreState, (typeof canvasStateDeps)[number]>;
 
-export const canvasStateParamsSelector = (state: ViewerStoreState): CanvasStateParams => {
+export const renderCanvasStateParamsSelector = (state: ViewerStoreState): RenderCanvasStateParams => {
   const entries = canvasStateDeps.map((key) => [key, state[key]]);
   return Object.fromEntries(entries);
 };
@@ -44,7 +44,10 @@ export interface IRenderCanvas {
    * Updates the parameters used to configure the canvas view. See
    * `CanvasStateParams` for a complete list of parameters required.
    */
-  setParams(params: CanvasStateParams): void;
+  setParams(params: RenderCanvasStateParams): void;
+  // TODO: Have `setFrame` report additional information about the frame
+  // such as the frame number and whether the file was missing/load failed.
+  // This is currently handled through `loadFrameCallback`.
   /**
    * Loads and renders the data for a specific frame. Returns a Promise that
    * resolves when the data is loaded and rendered onscreen.

--- a/src/colorizer/IRenderCanvas.ts
+++ b/src/colorizer/IRenderCanvas.ts
@@ -32,12 +32,12 @@ export const canvasStateParamsSelector = (state: ViewerStoreState): CanvasStateP
   return Object.fromEntries(entries);
 };
 
-export interface ICanvas {
+export interface IRenderCanvas {
   get domElement(): HTMLCanvasElement;
   get resolution(): Vector2;
   setResolution(width: number, height: number): void;
   setParams(params: CanvasStateParams): void;
-  setFrame(frame: number): Promise<void>;
+  setFrame(frame: number): void;
   render(): void;
   dispose(): void;
   getIdAtPixel(x: number, y: number): number;

--- a/src/colorizer/IRenderCanvas.ts
+++ b/src/colorizer/IRenderCanvas.ts
@@ -32,13 +32,34 @@ export const canvasStateParamsSelector = (state: ViewerStoreState): CanvasStateP
   return Object.fromEntries(entries);
 };
 
+/**
+ * A canvas that renders timelapse data.
+ */
 export interface IRenderCanvas {
   get domElement(): HTMLCanvasElement;
+  /** (X,Y) resolution of the canvas, in pixels. */
   get resolution(): Vector2;
   setResolution(width: number, height: number): void;
+  /**
+   * Updates the parameters used to configure the canvas view. See
+   * `CanvasStateParams` for a complete list of parameters required.
+   */
   setParams(params: CanvasStateParams): void;
-  setFrame(frame: number): void;
+  /**
+   * Loads and renders the data for a specific frame. Returns a Promise that
+   * resolves when the data is loaded and rendered onscreen.
+   * @param frame The frame number to load and render. Ignores frames that are
+   * out of range of the current dataset or that are already loaded.
+   */
+  setFrame(frame: number): Promise<void>;
   render(): void;
+  /**
+   * Disposes of the canvas and its resources.
+   */
   dispose(): void;
+  /**
+   * Gets the ID of the segmentation at a pixel coordinate in the canvas, where
+   * `(0,0)` is the top left corner.
+   */
   getIdAtPixel(x: number, y: number): number;
 }

--- a/src/colorizer/VectorField.ts
+++ b/src/colorizer/VectorField.ts
@@ -24,6 +24,12 @@ const arrowStyle = {
 
 type ArrayVector3 = [number, number, number];
 
+export type VectorFieldConfig = {
+  visible: boolean;
+  scaleFactor: number;
+  color: Color;
+};
+
 /**
  * Renders vector arrows as a Three JS object.
  */
@@ -314,7 +320,7 @@ export default class VectorField {
     );
   }
 
-  public setConfig(config: { visible: boolean; scaleFactor: number; color: Color }): void {
+  public setConfig(config: VectorFieldConfig): void {
     // TODO: will not need update if scaling is controlled by vertex shader
     const needsUpdate = this.scaleFactor !== config.scaleFactor || this.visible !== config.visible;
 

--- a/src/colorizer/VectorField.ts
+++ b/src/colorizer/VectorField.ts
@@ -1,7 +1,15 @@
-import { BufferAttribute, BufferGeometry, Line, LineBasicMaterial, LineSegments, Material, Vector2 } from "three";
+import {
+  BufferAttribute,
+  BufferGeometry,
+  Color,
+  Line,
+  LineBasicMaterial,
+  LineSegments,
+  Material,
+  Vector2,
+} from "three";
 
-import { getDefaultVectorConfig } from "./constants";
-import { VectorConfig } from "./types";
+import { OUTLINE_COLOR_DEFAULT } from "./constants";
 
 import Dataset from "./Dataset";
 
@@ -35,8 +43,9 @@ export default class VectorField {
 
   ///// Stored parameters /////
   private dataset: Dataset | null;
-  private config: VectorConfig;
   private currentFrame: number;
+  private scaleFactor: number;
+  private visible: boolean;
   /** Resolution of the canvas in onscreen pixels. */
   private canvasResolution: Vector2;
   /**
@@ -57,7 +66,8 @@ export default class VectorField {
 
   constructor() {
     this.dataset = null;
-    this.config = getDefaultVectorConfig();
+    this.scaleFactor = 1;
+    this.visible = false;
     this.currentFrame = 0;
     this.canvasResolution = new Vector2();
     this.frameToCanvasCoordinates = new Vector2();
@@ -65,7 +75,7 @@ export default class VectorField {
 
     const lineGeometry = new BufferGeometry();
     const lineMaterial = new LineBasicMaterial({
-      color: this.config.color,
+      color: new Color(OUTLINE_COLOR_DEFAULT),
       // Note: setting line width to anything other than 1.0 is unreliable.
       // See https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/lineWidth
       linewidth: 1,
@@ -85,7 +95,7 @@ export default class VectorField {
 
     // Update vertex geometry range to render.
     const range = this.timeToVertexIndexRange.get(frame);
-    if (range && this.config.visible) {
+    if (range && this.visible) {
       this.line.geometry.setDrawRange(range[0], range[1] - range[0]);
     } else {
       this.line.geometry.setDrawRange(0, 0);
@@ -194,8 +204,8 @@ export default class VectorField {
 
     const vectorStart: ArrayVector3 = [centroid[0], centroid[1], 0];
     const vectorEnd: ArrayVector3 = [
-      centroid[0] + delta[0] * this.config.scaleFactor,
-      centroid[1] + delta[1] * this.config.scaleFactor,
+      centroid[0] + delta[0] * this.scaleFactor,
+      centroid[1] + delta[1] * this.scaleFactor,
       0,
     ];
     const normVectorEnd = this.framePixelsToRelativeFrameCoords(vectorEnd);
@@ -223,7 +233,7 @@ export default class VectorField {
    * a frame number to the range of vertices that should be drawn for that frame.
    */
   private updateLineVertices(): void {
-    if (!this.dataset || !this.vectorData || !this.config.visible) {
+    if (!this.dataset || !this.vectorData || !this.visible) {
       this.line.geometry.setDrawRange(0, 0);
       return;
     }
@@ -304,12 +314,13 @@ export default class VectorField {
     );
   }
 
-  public setConfig(config: VectorConfig): void {
+  public setConfig(config: { visible: boolean; scaleFactor: number; color: Color }): void {
     // TODO: will not need update if scaling is controlled by vertex shader
-    const needsUpdate = this.config.scaleFactor !== config.scaleFactor || this.config.visible !== config.visible;
+    const needsUpdate = this.scaleFactor !== config.scaleFactor || this.visible !== config.visible;
 
-    this.config = config;
-    (this.line.material as LineBasicMaterial).color = this.config.color;
+    this.visible = config.visible;
+    this.scaleFactor = config.scaleFactor;
+    (this.line.material as LineBasicMaterial).color = config.color;
 
     if (needsUpdate) {
       this.updateLineVertices();

--- a/src/colorizer/utils/data_utils.ts
+++ b/src/colorizer/utils/data_utils.ts
@@ -222,3 +222,21 @@ export function getIntervals(values: number[]): [number, number][] {
   }
   return intervals;
 }
+
+export function hasPropertyChanged<T extends Record<string, unknown>>(
+  curr: T | null,
+  prev: T | null,
+  properties: (keyof T)[]
+): boolean {
+  if (!curr && !prev) {
+    return false;
+  } else if (!curr || !prev) {
+    return true;
+  }
+  for (const property of properties) {
+    if (curr[property] !== prev[property]) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -13,7 +13,7 @@ import { INTERNAL_BUILD } from "../constants";
 import { FlexColumn, FlexColumnAlignCenter, VisuallyHidden } from "../styles/utils";
 
 import CanvasUIOverlay from "../colorizer/CanvasWithOverlay";
-import { canvasStateParamsSelector } from "../colorizer/IRenderCanvas";
+import { renderCanvasStateParamsSelector } from "../colorizer/IRenderCanvas";
 import { useViewerStateStore } from "../state/ViewerState";
 import { AppThemeContext } from "./AppStyle";
 import { AlertBannerProps } from "./Banner";
@@ -146,7 +146,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
 
   // Add subscriber so canvas parameters are updated when the state changes.
   useEffect(() => {
-    return useViewerStateStore.subscribe(canvasStateParamsSelector, (params) => {
+    return useViewerStateStore.subscribe(renderCanvasStateParamsSelector, (params) => {
       canv.setParams(params);
     });
   }, []);

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -15,6 +15,7 @@ import { selectVectorConfigFromState } from "../state/slices";
 import { FlexColumn, FlexColumnAlignCenter, VisuallyHidden } from "../styles/utils";
 
 import CanvasUIOverlay from "../colorizer/CanvasWithOverlay";
+import { canvasStateParamsSelector } from "../colorizer/ICanvas";
 import { useViewerStateStore } from "../state/ViewerState";
 import { AppThemeContext } from "./AppStyle";
 import { AlertBannerProps } from "./Banner";
@@ -125,23 +126,13 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   const props = { ...defaultProps, ...inputProps } as Required<CanvasWrapperProps>;
 
   // Access state properties
-  const backdropBrightness = useViewerStateStore((state) => state.backdropBrightness);
+  const currentFrame = useViewerStateStore((state) => state.currentFrame);
   const backdropKey = useViewerStateStore((state) => state.backdropKey);
-  const backdropSaturation = useViewerStateStore((state) => state.backdropSaturation);
   const backdropVisible = useViewerStateStore((state) => state.backdropVisible);
-  const categoricalPalette = useViewerStateStore((state) => state.categoricalPalette);
   const clearTrack = useViewerStateStore((state) => state.clearTrack);
   const collection = useViewerStateStore((state) => state.collection);
-  const colorRamp = useViewerStateStore((state) => state.colorRamp);
-  const colorRampRange = useViewerStateStore((state) => state.colorRampRange);
   const dataset = useViewerStateStore((state) => state.dataset);
   const datasetKey = useViewerStateStore((state) => state.datasetKey);
-  const featureKey = useViewerStateStore((state) => state.featureKey);
-  const inRangeLUT = useViewerStateStore((state) => state.inRangeLUT);
-  const objectOpacity = useViewerStateStore((state) => state.objectOpacity);
-  const outlierDrawSettings = useViewerStateStore((state) => state.outlierDrawSettings);
-  const outlineColor = useViewerStateStore((state) => state.outlineColor);
-  const outOfRangeDrawSettings = useViewerStateStore((state) => state.outOfRangeDrawSettings);
   const setBackdropVisible = useViewerStateStore((state) => state.setBackdropVisible);
   const setOpenTab = useViewerStateStore((state) => state.setOpenTab);
   const setTrack = useViewerStateStore((state) => state.setTrack);
@@ -149,15 +140,20 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   const showLegendDuringExport = useViewerStateStore((state) => state.showLegendDuringExport);
   const showScaleBar = useViewerStateStore((state) => state.showScaleBar);
   const showTimestamp = useViewerStateStore((state) => state.showTimestamp);
-  const showTrackPath = useViewerStateStore((state) => state.showTrackPath);
-  const track = useViewerStateStore((state) => state.track);
+
   const vectorConfig = useViewerStateStore(useShallow(selectVectorConfigFromState));
-  const vectorData = useViewerStateStore((state) => state.vectorMotionDeltas);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
   const canv = props.canv;
   const canvasPlaceholderRef = useRef<HTMLDivElement>(null);
+
+  // Add subscriber so canvas parameters are updated when the state changes.
+  useEffect(() => {
+    return useViewerStateStore.subscribe(canvasStateParamsSelector, (params) => {
+      canv.setParams(params);
+    });
+  }, []);
 
   /**
    * Canvas zoom level, stored as its inverse. This makes it so linear changes in zoom level
@@ -238,58 +234,6 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
     canv.setCanvasBackgroundColor(new Color(theme.color.viewport.background as ColorRepresentation));
   }, [theme]);
 
-  // Update canvas color ramp
-  useMemo(() => {
-    canv.setColorRamp(colorRamp);
-    canv.setColorMapRangeMin(colorRampRange[0]);
-    canv.setColorMapRangeMax(colorRampRange[1]);
-  }, [colorRamp, colorRampRange]);
-
-  useMemo(() => {
-    if (featureKey) {
-      canv.setFeatureKey(featureKey);
-    }
-  }, [featureKey]);
-
-  // Update backdrops
-  useMemo(() => {
-    if (backdropKey !== null && backdropVisible) {
-      canv.setBackdropKey(backdropKey);
-      canv.setBackdropBrightness(backdropBrightness);
-      canv.setBackdropSaturation(backdropSaturation);
-      canv.setObjectOpacity(objectOpacity);
-    } else {
-      canv.setBackdropKey(null);
-      canv.setObjectOpacity(100);
-    }
-  }, [backdropKey, backdropVisible, backdropBrightness, backdropSaturation, objectOpacity]);
-
-  // Update categorical colors
-  useMemo(() => {
-    canv.setCategoricalColors(categoricalPalette);
-  }, [categoricalPalette]);
-
-  // Update drawing modes for outliers + out of range values
-  useMemo(() => {
-    const settings = outOfRangeDrawSettings;
-    canv.setOutOfRangeDrawMode(settings.mode, settings.color);
-  }, [outOfRangeDrawSettings]);
-
-  useMemo(() => {
-    const settings = outlierDrawSettings;
-    canv.setOutlierDrawMode(settings.mode, settings.color);
-  }, [outlierDrawSettings]);
-
-  useMemo(() => {
-    canv.setInRangeLUT(inRangeLUT);
-  }, [inRangeLUT]);
-
-  // Updated track-related settings
-  useMemo(() => {
-    canv.setSelectedTrack(track);
-    canv.setShowTrackPath(showTrackPath);
-  }, [track, showTrackPath]);
-
   // Update overlay settings
   useMemo(() => {
     canv.isScaleBarVisible = showScaleBar;
@@ -316,14 +260,6 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   useMemo(() => {
     canv.setVectorFieldConfig(vectorConfig);
   }, [vectorConfig]);
-
-  useMemo(() => {
-    canv.setVectorData(vectorData);
-  }, [vectorData]);
-
-  useMemo(() => {
-    canv.setOutlineColor(outlineColor);
-  }, [outlineColor]);
 
   useMemo(() => {
     const annotationLabels = props.annotationState.data.getLabels();
@@ -362,13 +298,12 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   useEffect(() => {
     const updateCanvasDimensions = (): void => {
       const canvasSizePx = getCanvasSizePx();
-      canv.setSize(canvasSizePx.x, canvasSizePx.y);
+      canv.setResolution(canvasSizePx.x, canvasSizePx.y);
     };
     updateCanvasDimensions(); // Initial size setting
 
     const handleResize = (): void => {
       updateCanvasDimensions();
-      canv.render();
     };
 
     window.addEventListener("resize", handleResize);
@@ -621,7 +556,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
     if (isMouseOverCanvas.current) {
       reportHoveredIdAtPixel(lastMousePositionPx.current.x, lastMousePositionPx.current.y);
     }
-  }, [canv.getCurrentFrame()]);
+  }, [currentFrame]);
 
   useEffect(() => {
     const onMouseMove = (event: MouseEvent): void => {

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -13,7 +13,7 @@ import { INTERNAL_BUILD } from "../constants";
 import { FlexColumn, FlexColumnAlignCenter, VisuallyHidden } from "../styles/utils";
 
 import CanvasUIOverlay from "../colorizer/CanvasWithOverlay";
-import { canvasStateParamsSelector } from "../colorizer/ICanvas";
+import { canvasStateParamsSelector } from "../colorizer/IRenderCanvas";
 import { useViewerStateStore } from "../state/ViewerState";
 import { AppThemeContext } from "./AppStyle";
 import { AlertBannerProps } from "./Banner";

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -4,14 +4,12 @@ import React, { ReactElement, ReactNode, useCallback, useContext, useEffect, use
 import styled from "styled-components";
 import { Color, ColorRepresentation, Vector2 } from "three";
 import { clamp } from "three/src/math/MathUtils";
-import { useShallow } from "zustand/shallow";
 
 import { ImagesIconSVG, ImagesSlashIconSVG, NoImageSVG, TagIconSVG, TagSlashIconSVG } from "../assets";
 import { AnnotationSelectionMode, LoadTroubleshooting, TabType } from "../colorizer/types";
 import * as mathUtils from "../colorizer/utils/math_utils";
 import { AnnotationState } from "../colorizer/utils/react_utils";
 import { INTERNAL_BUILD } from "../constants";
-import { selectVectorConfigFromState } from "../state/slices";
 import { FlexColumn, FlexColumnAlignCenter, VisuallyHidden } from "../styles/utils";
 
 import CanvasUIOverlay from "../colorizer/CanvasWithOverlay";
@@ -141,8 +139,6 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   const showScaleBar = useViewerStateStore((state) => state.showScaleBar);
   const showTimestamp = useViewerStateStore((state) => state.showTimestamp);
 
-  const vectorConfig = useViewerStateStore(useShallow(selectVectorConfigFromState));
-
   const containerRef = useRef<HTMLDivElement>(null);
 
   const canv = props.canv;
@@ -256,10 +252,6 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
     canv.isHeaderVisibleOnExport = showHeaderDuringExport;
     canv.isFooterVisibleOnExport = showLegendDuringExport;
   }, [showLegendDuringExport, props.isRecording]);
-
-  useMemo(() => {
-    canv.setVectorFieldConfig(vectorConfig);
-  }, [vectorConfig]);
 
   useMemo(() => {
     const annotationLabels = props.annotationState.data.getLabels();


### PR DESCRIPTION
Problem
=======
Part 1 of 2ish for #560, "Refactor CanvasOverlay to be its own class, make generic Canvas."

This change makes the new `IRenderCanvas`, a new interface for the `ColorizeCanvas` class. Eventually, the plan is for the new 3D canvas renderer to also implement `IRenderCanvas`. This will also make it easier to refactor `CanvasWithOverlay` in the next PR.

*Estimated review size: large, 40 minutes*

Solution
========
- Creates the new `IRenderCanvas` interface.
- Refactors `ColorizeCanvas` with the new `setParams` method, which accepts a subset of the `ViewerStoreState`.
- Removes unused setters from `CanvasWrapper.tsx`.

Steps to Verify:
----------------
1. Open preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-601/
2. Change canvas settings like the currently selected track, color ramp, feature, time, etc. Everything should work as it did before.

Screenshots (optional):
-----------------------

**Video talk-through (🔊):**

https://github.com/user-attachments/assets/6c66c4d6-780f-4f40-a9e8-96bccd66e7b9

Second video with an overview of the changes:

https://github.com/user-attachments/assets/f7693882-e13d-4677-b03c-537bce3fb519


Keyfiles:
-----------------------
1. `IRenderCanvas.ts`
3. `ColorizeCanvas.ts`

