### PR TITLE
fix: Sync Export settings with state

### DIFF
--- a/src/colorizer/constants.ts
+++ b/src/colorizer/constants.ts
@@ -1,14 +1,6 @@
 import { Color } from "three";
 
-import {
-  DrawMode,
-  PlotRangeType,
-  ScatterPlotConfig,
-  TabType,
-  VectorConfig,
-  VectorTooltipMode,
-  ViewerConfig,
-} from "./types";
+import { PlotRangeType, ScatterPlotConfig, VectorConfig, VectorTooltipMode } from "./types";
 
 export const BACKGROUND_COLOR_DEFAULT = 0xffffff;
 export const OUTLINE_COLOR_DEFAULT = 0xff00ff;
@@ -25,27 +17,6 @@ export const getDefaultVectorConfig = (): VectorConfig => ({
   scaleFactor: 4,
   tooltipMode: VectorTooltipMode.MAGNITUDE,
 });
-
-export const getDefaultViewerConfig = (): ViewerConfig => ({
-  showTrackPath: true,
-  showScaleBar: true,
-  showTimestamp: true,
-  showLegendDuringExport: true,
-  showHeaderDuringExport: true,
-  keepRangeBetweenDatasets: false,
-  backdropVisible: false,
-  /** Brightness, as an integer percentage. */
-  backdropBrightness: 100,
-  /** Saturation, as an integer percentage. */
-  backdropSaturation: 100,
-  /** Opacity when backdrops are visible, as an integer percentage. */
-  objectOpacity: 50,
-  outOfRangeDrawSettings: { mode: DrawMode.USE_COLOR, color: new Color(OUT_OF_RANGE_COLOR_DEFAULT) },
-  outlierDrawSettings: { mode: DrawMode.USE_COLOR, color: new Color(OUTLIER_COLOR_DEFAULT) },
-  outlineColor: new Color(OUTLINE_COLOR_DEFAULT),
-  openTab: TabType.TRACK_PLOT,
-  vectorConfig: getDefaultVectorConfig(),
-}); // Use a function instead of a constant to avoid sharing the same object reference.
 
 export const getDefaultScatterPlotConfig = (): ScatterPlotConfig => ({
   xAxis: null,

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -164,31 +164,6 @@ export const isTabType = (tab: string): tab is TabType => {
   return Object.values(TabType).includes(tab as TabType);
 };
 
-/**
- * Configuration for the viewer. These are high-level settings
- * that are not specific to a particular dataset.
- */
-export type ViewerConfig = {
-  showTrackPath: boolean;
-  showScaleBar: boolean;
-  showTimestamp: boolean;
-  showLegendDuringExport: boolean;
-  showHeaderDuringExport: boolean;
-  keepRangeBetweenDatasets: boolean;
-  backdropVisible: boolean;
-  /** Brightness, as an integer percentage. */
-  backdropBrightness: number;
-  /** Saturation, as an integer percentage. */
-  backdropSaturation: number;
-  /** Object opacity when backdrop is visible, as an integer percentage. */
-  objectOpacity: number;
-  outOfRangeDrawSettings: DrawSettings;
-  outlierDrawSettings: DrawSettings;
-  outlineColor: Color;
-  openTab: TabType;
-  vectorConfig: VectorConfig;
-};
-
 export enum PlotRangeType {
   ALL_TIME = "All time",
   CURRENT_TRACK = "Current track",

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -12,9 +12,7 @@ import {
   LoadErrorMessage,
   LoadTroubleshooting,
   PlotRangeType,
-  ScatterPlotConfig,
   ThresholdType,
-  ViewerConfig,
 } from "../types";
 import { nanToNull } from "./data_load_utils";
 import { AnyManifestFile } from "./dataset_utils";
@@ -67,23 +65,6 @@ const ALLEN_PREFIX_TO_HTTPS: Record<string, string> = {
   "/allen/aics/assay-dev": "https://dev-aics-dtp-001.int.allencell.org/assay-dev",
   // eslint-disable-next-line @typescript-eslint/naming-convention
   "/allen/aics/microscopy": "https://dev-aics-dtp-001.int.allencell.org/microscopy",
-};
-
-export type UrlParams = {
-  collection: string;
-  dataset: string;
-  /** Either feature key or feature name. */
-  feature: string;
-  track: number;
-  time: number;
-  thresholds: FeatureThreshold[];
-  range: [number, number];
-  colorRampKey: string | null;
-  colorRampReversed: boolean | null;
-  categoricalPalette: Color[];
-  config: Partial<ViewerConfig>;
-  selectedBackdropKey: string | null;
-  scatterPlotConfig: Partial<ScatterPlotConfig>;
 };
 
 export const DEFAULT_FETCH_TIMEOUT_MS = 2000;

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -17,9 +17,8 @@ import styled from "styled-components";
 import { clamp } from "three/src/math/MathUtils";
 
 import { ExportIconSVG } from "../assets";
-import { getDefaultViewerConfig } from "../colorizer/constants";
-import { ViewerConfig } from "../colorizer/types";
 import { AnalyticsEvent, triggerAnalyticsEvent } from "../colorizer/utils/analytics";
+import { useViewerStateStore } from "../state";
 import { StyledRadioGroup } from "../styles/components";
 import { FlexColumn, FlexColumnAlignCenter, FlexRow } from "../styles/utils";
 
@@ -35,17 +34,15 @@ import SpinBox from "./SpinBox";
 type ExportButtonProps = {
   totalFrames: number;
   setFrame: (frame: number) => Promise<void>;
-  getCanvasExportDimensions?: () => [number, number];
+  getCanvasExportDimensions: () => [number, number];
   getCanvas: () => HTMLCanvasElement;
   /** Callback, called whenever the button is clicked. Can be used to stop playback. */
-  onClick?: () => void;
+  onClick: () => void;
   currentFrame: number;
   /** Callback, called whenever the recording process starts or stops. */
-  setIsRecording?: (recording: boolean) => void;
-  defaultImagePrefix?: string;
-  disabled?: boolean;
-  config?: ViewerConfig;
-  updateConfig?: (settings: Partial<ViewerConfig>) => void;
+  setIsRecording: (recording: boolean) => void;
+  defaultImagePrefix: string;
+  disabled: boolean;
 };
 
 const FRAME_RANGE_RADIO_LABEL_ID = "export-modal-frame-range-label";
@@ -55,8 +52,6 @@ const defaultProps: Partial<ExportButtonProps> = {
   defaultImagePrefix: "image",
   disabled: false,
   onClick: () => {},
-  config: getDefaultViewerConfig(),
-  updateConfig: () => {},
 };
 
 const HorizontalDiv = styled.div`
@@ -141,6 +136,11 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
   // <body> tag, which causes some issues with styling.
   const { notification } = App.useApp();
   const modal = useStyledModal();
+
+  const showHeaderDuringExport = useViewerStateStore((state) => state.showHeaderDuringExport);
+  const setShowHeaderDuringExport = useViewerStateStore((state) => state.setShowHeaderDuringExport);
+  const showLegendDuringExport = useViewerStateStore((state) => state.showLegendDuringExport);
+  const setShowLegendDuringExport = useViewerStateStore((state) => state.setShowLegendDuringExport);
 
   const originalFrameRef = useRef(props.currentFrame);
   const [isModalOpen, _setIsModalOpen] = useState(false);
@@ -631,19 +631,15 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
             </SettingsItem>
             <SettingsItem label={"Show feature legend"}>
               <Checkbox
-                checked={props.config.showLegendDuringExport}
-                onChange={(e) => {
-                  props.updateConfig({ showLegendDuringExport: e.target.checked });
-                }}
+                checked={showLegendDuringExport}
+                onChange={(e) => setShowLegendDuringExport(e.target.checked)}
               />
             </SettingsItem>
             <SettingsItem label="Show dataset name">
               <div>
                 <Checkbox
-                  checked={props.config.showHeaderDuringExport}
-                  onChange={(e) => {
-                    props.updateConfig({ showHeaderDuringExport: e.target.checked });
-                  }}
+                  checked={showHeaderDuringExport}
+                  onChange={(e) => setShowHeaderDuringExport(e.target.checked)}
                 />
               </div>
             </SettingsItem>

--- a/tests/Export.test.tsx
+++ b/tests/Export.test.tsx
@@ -18,6 +18,9 @@ describe("ExportButton", () => {
           getCanvas={vi.fn()}
           getCanvasExportDimensions={vi.fn()}
           currentFrame={0}
+          onClick={vi.fn()}
+          setIsRecording={vi.fn()}
+          disabled={false}
         />
       );
     }


### PR DESCRIPTION
Problem
=======
Fixes a bug where two settings in the Export modal were not being synced to state and couldn't be changed.

*Estimated review size: small, 5 minutes*

Solution
========
- Changes `Export.tsx` to use the viewer state store.
- Updates unit tests.
- Removes unused `ViewerConfig` type.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open broken build (this link may break as PRs are merged). Open the Export modal and try to disable the checkboxes (nothing will happen): https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-596/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json
2. Open the fixed build and repeat the above steps: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-603/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json

Screenshots (optional):
-----------------------

https://github.com/user-attachments/assets/56409fd8-4cf4-494c-bde5-e6325dfea0d5

