### PR TITLE
fix: Fixes bug where AlertBanners would allow duplicate messages

### DIFF
--- a/src/components/Banner/hooks.tsx
+++ b/src/components/Banner/hooks.tsx
@@ -56,7 +56,15 @@ export const useAlertBanner = (
         return;
       }
       ignoredBannerMessages.current.add(props.message);
-      setBannerProps((previousBannerProps) => [...previousBannerProps, props]);
+      setBannerProps((previousBannerProps) => {
+        // TODO: Needed to add a check here  to prevent duplicate error messages
+        // possibly due to batched state updates. Fix by changing banner props
+        // to a ref or other datastructure?
+        if (previousBannerProps.some((banner) => banner.message === props.message)) {
+          return previousBannerProps;
+        }
+        return [...previousBannerProps, props];
+      });
     },
     [bannerProps, ignoredBannerMessages.current]
   );

--- a/src/utils/formatting.tsx
+++ b/src/utils/formatting.tsx
@@ -29,7 +29,7 @@ export function renderStringArrayAsJsx(items: string[] | string | undefined): Re
   if (typeof items === "string") {
     return (
       <RenderedStringContainer>
-        <p>{items}</p>;
+        <p>{items}</p>
       </RenderedStringContainer>
     );
   }


### PR DESCRIPTION
Problem
=======
Two super-quick fixes for AlertBanners!

*Estimated review size: tiny, <5 minutes*

Solution
========
- Removes an erroneous semicolon in AlertBanner messages.
- Fixes a bug where duplicate AlertBanners could be emitted, causing React to throw error messages about duplicate keys.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
Before:
![image](https://github.com/user-attachments/assets/cc6eb6ce-7dc8-4dde-ba40-eee58d843a65)

After:
![image](https://github.com/user-attachments/assets/4c805309-373e-44bf-adee-ef1fb5b54e14)

