### PR TITLE
refactor: Store frame load result in store (canvas pt. 2)

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -86,11 +86,7 @@ function Viewer(): ReactElement {
   const canv = useConstructor(() => {
     const canvas = new CanvasWithOverlay();
     canvas.domElement.className = styles.colorizeCanvas;
-    useViewerStateStore.getState().setLoadFrameCallback(async (frame) => {
-      const result = await canvas.setFrame(frame);
-      canvas.render();
-      return result;
-    });
+    useViewerStateStore.getState().setFrameLoadCallback(async (frame) => await canvas.setFrame(frame));
     return canvas;
   });
 
@@ -806,7 +802,7 @@ function Viewer(): ReactElement {
                     }
                   }}
                   onMouseLeave={() => setShowObjectHoverInfo(false)}
-                  showAlert={showAlert}
+                  showAlert={isInitialDatasetLoaded ? showAlert : undefined}
                   annotationState={annotationState}
                 />
               </CanvasHoverTooltip>

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -87,8 +87,9 @@ function Viewer(): ReactElement {
     const canvas = new CanvasWithOverlay();
     canvas.domElement.className = styles.colorizeCanvas;
     useViewerStateStore.getState().setLoadFrameCallback(async (frame) => {
-      await canvas.setFrame(frame);
+      const result = await canvas.setFrame(frame);
       canvas.render();
+      return result;
     });
     return canvas;
   });
@@ -805,7 +806,7 @@ function Viewer(): ReactElement {
                     }
                   }}
                   onMouseLeave={() => setShowObjectHoverInfo(false)}
-                  showAlert={isInitialDatasetLoaded ? showAlert : undefined}
+                  showAlert={showAlert}
                   annotationState={annotationState}
                 />
               </CanvasHoverTooltip>

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -25,6 +25,7 @@ import { clamp } from "three/src/math/MathUtils";
 import { MAX_FEATURE_CATEGORIES } from "../constants";
 import {
   BACKGROUND_COLOR_DEFAULT,
+  getDefaultFrameLoadResult,
   OUT_OF_RANGE_COLOR_DEFAULT,
   OUTLIER_COLOR_DEFAULT,
   OUTLINE_COLOR_DEFAULT,
@@ -134,7 +135,7 @@ export default class ColorizeCanvas implements IRenderCanvas {
 
   protected frameSizeInCanvasCoordinates: Vector2;
   protected frameToCanvasCoordinates: Vector2;
-  private lastFrameLoadResult: FrameLoadResult = { frame: -1, frameLoaded: false, backdropLoaded: false };
+  private lastFrameLoadResult: FrameLoadResult;
 
   /**
    * The zoom level of the frame in the canvas. At default zoom level 1, the frame will be
@@ -226,6 +227,7 @@ export default class ColorizeCanvas implements IRenderCanvas {
     this.categoricalPalette = new ColorRamp(["black"]);
     this.currentFrame = 0;
     this.pendingFrame = -1;
+    this.lastFrameLoadResult = getDefaultFrameLoadResult();
 
     this.frameSizeInCanvasCoordinates = new Vector2(1, 1);
     this.frameToCanvasCoordinates = new Vector2(1, 1);
@@ -546,13 +548,6 @@ export default class ColorizeCanvas implements IRenderCanvas {
     this.render();
   }
 
-  /**
-   * Sets the current frame of the canvas, loading the new frame data if the
-   * frame number changes.
-   * @param index Index of the new frame.
-   * @param forceUpdate Force a reload of the frame data, even if the frame
-   * is already loaded.
-   */
   public async setFrame(index: number, forceUpdate: boolean = false): Promise<FrameLoadResult> {
     const dataset = this.params?.dataset;
     // Ignore same or bad frame indices

--- a/src/colorizer/IRenderCanvas.ts
+++ b/src/colorizer/IRenderCanvas.ts
@@ -47,13 +47,18 @@ export interface IRenderCanvas {
    */
   setParams(params: RenderCanvasStateParams): void;
   /**
-   * Loads and renders the data for a specific frame. Returns a Promise that
-   * resolves when the data is loaded and rendered onscreen.
-   * @param frame The frame number to load and render. Ignores frames that are
-   * out of range of the current dataset or that are already loaded.
-   * @returns A `FrameLoadResult` object of the loaded frame.
-   * Note that, if the frame is out of bounds, the `FrameLoadResult`'s `frame`
-   * property will be whatever frame is currently loaded.
+   * Requests to load and render the image data for a specific frame. Returns a
+   * Promise that resolves when the frame is loaded and rendered, or if the
+   * request was ignored (e.g. if the frame is out of bounds).
+   * @param requestedFrame The frame number to load and render.
+   * @returns A `FrameLoadResult`, containing:
+   * - `frame`: the currently loaded and visible frame number. Note that this
+   *   may not be the same as `requestedFrame` if the frame was out of bounds or
+   *   otherwise ignored.
+   * - `frameLoaded`: Whether the frame was loaded successfully. If `false`, the
+   *   frame loading failed due to an error.
+   * - `backdropLoaded`: Whether the backdrop was loaded successfully for
+   *   `frame`. If `false`, the backdrop loading failed due to an error.
    */
   setFrame: FrameLoadCallback;
   render(): void;

--- a/src/colorizer/IRenderCanvas.ts
+++ b/src/colorizer/IRenderCanvas.ts
@@ -1,6 +1,7 @@
 import { Vector2 } from "three";
 
 import { ViewerStoreState } from "../state/slices";
+import { FrameLoadCallback } from "./types";
 
 const canvasStateDeps = [
   "dataset",
@@ -45,16 +46,16 @@ export interface IRenderCanvas {
    * `CanvasStateParams` for a complete list of parameters required.
    */
   setParams(params: RenderCanvasStateParams): void;
-  // TODO: Have `setFrame` report additional information about the frame
-  // such as the frame number and whether the file was missing/load failed.
-  // This is currently handled through `loadFrameCallback`.
   /**
    * Loads and renders the data for a specific frame. Returns a Promise that
    * resolves when the data is loaded and rendered onscreen.
    * @param frame The frame number to load and render. Ignores frames that are
    * out of range of the current dataset or that are already loaded.
+   * @returns A `FrameLoadResult` object of the loaded frame.
+   * Note that, if the frame is out of bounds, the `FrameLoadResult`'s `frame`
+   * property will be whatever frame is currently loaded.
    */
-  setFrame(frame: number): Promise<void>;
+  setFrame: FrameLoadCallback;
   render(): void;
   /**
    * Disposes of the canvas and its resources.

--- a/src/colorizer/constants.ts
+++ b/src/colorizer/constants.ts
@@ -2,6 +2,7 @@ import { Color } from "three";
 
 import {
   DrawMode,
+  FrameLoadResult,
   PlotRangeType,
   ScatterPlotConfig,
   TabType,
@@ -16,6 +17,12 @@ export const OUTLIER_COLOR_DEFAULT = 0xc0c0c0;
 export const OUT_OF_RANGE_COLOR_DEFAULT = 0xdddddd;
 
 export const VECTOR_KEY_MOTION_DELTA = "_motion_";
+
+export const getDefaultFrameLoadResult = (): FrameLoadResult => ({
+  frame: 0,
+  frameLoaded: false,
+  backdropLoaded: false,
+});
 
 export const getDefaultVectorConfig = (): VectorConfig => ({
   visible: false,

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -78,17 +78,16 @@ export const featureTypeSpecs: { [T in FeatureDataType]: FeatureTypeSpec<T> } = 
 
 export type FrameLoadResult = {
   frame: number;
+  /** False if frame loading encountered an error. */
   frameLoaded: boolean;
+  /**
+   * False if backdrop loading encountered an error. Note that this will be
+   * true if the backdrop is not visible.
+   */
   backdropLoaded: boolean;
 };
 
-export const DEFAULT_FRAME_LOAD_RESULT = {
-  frame: -1,
-  frameLoaded: false,
-  backdropLoaded: false,
-};
-
-export type FrameLoadCallback = (frame: number) => Promise<FrameLoadResult>;
+export type FrameLoadCallback = (requestedFrame: number) => Promise<FrameLoadResult>;
 
 // MUST be synchronized with the DRAW_MODE_* constants in `colorize_RGBA8U.frag`!
 // CHANGING THESE VALUES CAN POTENTIALLY BREAK URLs. See `url_utils.parseDrawSettings` for parsing logic.

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -76,6 +76,20 @@ export const featureTypeSpecs: { [T in FeatureDataType]: FeatureTypeSpec<T> } = 
   },
 };
 
+export type FrameLoadResult = {
+  frame: number;
+  frameLoaded: boolean;
+  backdropLoaded: boolean;
+};
+
+export const DEFAULT_FRAME_LOAD_RESULT = {
+  frame: -1,
+  frameLoaded: false,
+  backdropLoaded: false,
+};
+
+export type FrameLoadCallback = (frame: number) => Promise<FrameLoadResult>;
+
 // MUST be synchronized with the DRAW_MODE_* constants in `colorize_RGBA8U.frag`!
 // CHANGING THESE VALUES CAN POTENTIALLY BREAK URLs. See `url_utils.parseDrawSettings` for parsing logic.
 /** Draw options for object types. */

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -138,7 +138,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   const showLegendDuringExport = useViewerStateStore((state) => state.showLegendDuringExport);
   const showScaleBar = useViewerStateStore((state) => state.showScaleBar);
   const showTimestamp = useViewerStateStore((state) => state.showTimestamp);
-  const loadFrameResult = useViewerStateStore((state) => state.loadFrameResult);
+  const frameLoadResult = useViewerStateStore((state) => state.frameLoadResult);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -179,25 +179,22 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   const lastMousePositionPx = useRef(new Vector2(0, 0));
   const theme = useContext(AppThemeContext);
 
-  const isMissingFile = !loadFrameResult.frameLoaded || !loadFrameResult.backdropLoaded;
+  const isMissingFile = !frameLoadResult.frameLoaded || !frameLoadResult.backdropLoaded;
 
   // CANVAS PROPERTIES /////////////////////////////////////////////////
 
-  const showMissingFrameWarning = useCallback(() => {
-    props.showAlert({
-      type: "warning",
-      message: "Warning: One or more frames or backdrops failed to load.",
-      description: LoadTroubleshooting.CHECK_FILE_OR_NETWORK,
-      showDoNotShowAgainCheckbox: true,
-      closable: true,
-    });
-  }, [props.showAlert, canv]);
-
+  // Show warning if files are missing
   useMemo(() => {
-    if (isMissingFile) {
-      showMissingFrameWarning();
+    if (isMissingFile && props.showAlert) {
+      props.showAlert({
+        type: "warning",
+        message: "Warning: One or more frames or backdrops failed to load.",
+        description: LoadTroubleshooting.CHECK_FILE_OR_NETWORK,
+        showDoNotShowAgainCheckbox: true,
+        closable: true,
+      });
     }
-  }, [loadFrameResult, isMissingFile]);
+  }, [frameLoadResult, isMissingFile, props.showAlert]);
 
   // Mount the canvas to the placeholder's location in the document.
   useEffect(() => {

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -1,6 +1,6 @@
 import { HomeOutlined, ZoomInOutlined, ZoomOutOutlined } from "@ant-design/icons";
 import { Tooltip } from "antd";
-import React, { ReactElement, ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import React, { ReactElement, ReactNode, useCallback, useContext, useEffect, useMemo, useRef } from "react";
 import styled from "styled-components";
 import { Color, ColorRepresentation, Vector2 } from "three";
 import { clamp } from "three/src/math/MathUtils";
@@ -138,6 +138,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   const showLegendDuringExport = useViewerStateStore((state) => state.showLegendDuringExport);
   const showScaleBar = useViewerStateStore((state) => state.showScaleBar);
   const showTimestamp = useViewerStateStore((state) => state.showTimestamp);
+  const loadFrameResult = useViewerStateStore((state) => state.loadFrameResult);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -178,27 +179,25 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   const lastMousePositionPx = useRef(new Vector2(0, 0));
   const theme = useContext(AppThemeContext);
 
-  const [showMissingFileIcon, setShowMissingFileIcon] = useState(false);
+  const isMissingFile = !loadFrameResult.frameLoaded || !loadFrameResult.backdropLoaded;
 
   // CANVAS PROPERTIES /////////////////////////////////////////////////
 
-  const onFrameChangedCallback = useCallback(
-    (isMissing: boolean) => {
-      setShowMissingFileIcon(isMissing);
-      if (props.showAlert && isMissing) {
-        props.showAlert({
-          type: "warning",
-          message: "Warning: One or more frames failed to load.",
-          description: LoadTroubleshooting.CHECK_FILE_OR_NETWORK,
-          showDoNotShowAgainCheckbox: true,
-          closable: true,
-        });
-      }
-    },
-    [props.showAlert, setShowMissingFileIcon, canv]
-  );
+  const showMissingFrameWarning = useCallback(() => {
+    props.showAlert({
+      type: "warning",
+      message: "Warning: One or more frames or backdrops failed to load.",
+      description: LoadTroubleshooting.CHECK_FILE_OR_NETWORK,
+      showDoNotShowAgainCheckbox: true,
+      closable: true,
+    });
+  }, [props.showAlert, canv]);
 
-  canv.setOnFrameChangeCallback(onFrameChangedCallback);
+  useMemo(() => {
+    if (isMissingFile) {
+      showMissingFrameWarning();
+    }
+  }, [loadFrameResult, isMissingFile]);
 
   // Mount the canvas to the placeholder's location in the document.
   useEffect(() => {
@@ -632,7 +631,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       <LoadingSpinner loading={props.loading} progress={props.loadingProgress}>
         <div ref={canvasPlaceholderRef}></div>
       </LoadingSpinner>
-      <MissingFileIconContainer style={{ visibility: showMissingFileIcon ? "visible" : "hidden" }}>
+      <MissingFileIconContainer style={{ visibility: isMissingFile ? "visible" : "hidden" }}>
         <NoImageSVG aria-labelledby="no-image" style={{ width: "50px" }} />
         <p id="no-image">
           <b>Missing image data</b>

--- a/tests/state/ViewerState/time_slice.test.ts
+++ b/tests/state/ViewerState/time_slice.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it, Mock, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { Track } from "../../../src/colorizer";
+import { FrameLoadResult, Track } from "../../../src/colorizer";
 import { UrlParam } from "../../../src/colorizer/utils/url_utils";
 import { useViewerStateStore } from "../../../src/state";
 import { loadTimeSliceFromParams, serializeTimeSlice } from "../../../src/state/slices";
@@ -9,8 +9,11 @@ import { ANY_ERROR, sleep } from "../../test_utils";
 import { MOCK_DATASET, MOCK_DATASET_WITH_TWO_FRAMES } from "./constants";
 import { clearDatasetAsync, setDatasetAsync } from "./utils";
 
-const TIMEOUT_DURATION_MS = 10;
-const getMockLoadCallback = (): Mock<[], Promise<void>> => vi.fn((): Promise<void> => sleep(TIMEOUT_DURATION_MS));
+const TIMEOUT_DURATION_MS = 5;
+const MOCK_LOAD_CALLBACK = async (frame: number): Promise<FrameLoadResult> => {
+  await sleep(TIMEOUT_DURATION_MS);
+  return Promise.resolve({ frame, frameLoaded: true, backdropLoaded: true });
+};
 
 describe("useViewerStateStore: TimeSlice", () => {
   describe("setFrame", () => {
@@ -30,10 +33,10 @@ describe("useViewerStateStore: TimeSlice", () => {
 
     it("calls loadFrameCallback", async () => {
       const { result } = renderHook(() => useViewerStateStore());
-      const mockLoadCallback = getMockLoadCallback();
       setDatasetAsync(result, MOCK_DATASET);
+      const mockLoadCallback = vi.fn(MOCK_LOAD_CALLBACK);
       await act(async () => {
-        result.current.setLoadFrameCallback(mockLoadCallback);
+        result.current.setFrameLoadCallback(mockLoadCallback);
         await result.current.setFrame(1);
       });
       expect(mockLoadCallback).toHaveBeenCalled();
@@ -41,11 +44,10 @@ describe("useViewerStateStore: TimeSlice", () => {
 
     it("sets pendingFrame and currentFrame", async () => {
       const { result } = renderHook(() => useViewerStateStore());
-      const mockLoadCallback = getMockLoadCallback();
       setDatasetAsync(result, MOCK_DATASET);
       let setFramePromise;
       await act(async () => {
-        result.current.setLoadFrameCallback(mockLoadCallback);
+        result.current.setFrameLoadCallback(MOCK_LOAD_CALLBACK);
         setFramePromise = result.current.setFrame(1);
       });
       expect(result.current.pendingFrame).toBe(1);
@@ -60,10 +62,10 @@ describe("useViewerStateStore: TimeSlice", () => {
   describe("timeControls", () => {
     it("calls loadFrameCallback", async () => {
       const { result } = renderHook(() => useViewerStateStore());
-      const mockLoadCallback = getMockLoadCallback();
       setDatasetAsync(result, MOCK_DATASET);
+      const mockLoadCallback = vi.fn(MOCK_LOAD_CALLBACK);
       await act(async () => {
-        result.current.setLoadFrameCallback(mockLoadCallback);
+        result.current.setFrameLoadCallback(mockLoadCallback);
         result.current.setPlaybackFps(1000 / TIMEOUT_DURATION_MS);
         result.current.timeControls.play();
       });
@@ -74,10 +76,9 @@ describe("useViewerStateStore: TimeSlice", () => {
 
     it("sets pendingFrame and currentFrame", async () => {
       const { result } = renderHook(() => useViewerStateStore());
-      const mockLoadCallback = getMockLoadCallback();
       setDatasetAsync(result, MOCK_DATASET);
       await act(async () => {
-        result.current.setLoadFrameCallback(mockLoadCallback);
+        result.current.setFrameLoadCallback(MOCK_LOAD_CALLBACK);
         result.current.setPlaybackFps(1000 / TIMEOUT_DURATION_MS);
         result.current.timeControls.play();
       });


### PR DESCRIPTION
Problem
=======
Part 2 of 3 for #601, refactoring the Canvas to make them modular.

This change removes a callback in ColorizeCanvas for when frames are set, which was used to warn the user when missing frames were detected. The frame load result is now saved in state instead, which:
- Helps to remove the dependency of `CanvasWrapper` on specific implementations of `ColorizeCanvas`
- Potentially allows other parts of the UI to respond to missing frame data.

Solution
========
What I/we did to solve this problem

with @pairperson1

Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
2. other important file

Thanks for contributing!
