### PR TITLE
refactor: `ColorizeCanvas` as module in `CanvasOverlay` (canvas pt. 4)

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -39,10 +39,11 @@ import { FlexRow, FlexRowAlignCenter } from "./styles/utils";
 import { LocationState } from "./types";
 import { loadInitialCollectionAndDataset } from "./utils/dataset_load_utils";
 
-import CanvasWithOverlay from "./colorizer/CanvasWithOverlay";
+import CanvasOverlay from "./colorizer/CanvasOverlay";
 import Collection from "./colorizer/Collection";
-import { BACKGROUND_ID } from "./colorizer/ColorizeCanvas";
+import ColorizeCanvas, { BACKGROUND_ID } from "./colorizer/ColorizeCanvas";
 import { FeatureType } from "./colorizer/Dataset";
+import { renderCanvasStateParamsSelector } from "./colorizer/IRenderCanvas";
 import UrlArrayLoader from "./colorizer/loaders/UrlArrayLoader";
 import { getSharedWorkerPool } from "./colorizer/workers/SharedWorkerPool";
 import { AppThemeContext } from "./components/AppStyle";
@@ -84,7 +85,8 @@ function Viewer(): ReactElement {
   const [, startTransition] = React.useTransition();
 
   const canv = useConstructor(() => {
-    const canvas = new CanvasWithOverlay();
+    const stateDeps = renderCanvasStateParamsSelector(useViewerStateStore.getState());
+    const canvas = new CanvasOverlay(new ColorizeCanvas(), stateDeps);
     canvas.domElement.className = styles.colorizeCanvas;
     // Report frame load results to the store
     canvas.setOnFrameLoadCallback(useViewerStateStore.getState().setFrameLoadResult);

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -41,7 +41,7 @@ import { loadInitialCollectionAndDataset } from "./utils/dataset_load_utils";
 
 import CanvasOverlay from "./colorizer/CanvasOverlay";
 import Collection from "./colorizer/Collection";
-import ColorizeCanvas, { BACKGROUND_ID } from "./colorizer/ColorizeCanvas";
+import ColorizeCanvas2D, { BACKGROUND_ID } from "./colorizer/ColorizeCanvas2D";
 import { FeatureType } from "./colorizer/Dataset";
 import { renderCanvasStateParamsSelector } from "./colorizer/IRenderCanvas";
 import UrlArrayLoader from "./colorizer/loaders/UrlArrayLoader";
@@ -86,7 +86,7 @@ function Viewer(): ReactElement {
 
   const canv = useConstructor(() => {
     const stateDeps = renderCanvasStateParamsSelector(useViewerStateStore.getState());
-    const canvas = new CanvasOverlay(new ColorizeCanvas(), stateDeps);
+    const canvas = new CanvasOverlay(new ColorizeCanvas2D(), stateDeps);
     canvas.domElement.className = styles.colorizeCanvas;
     // Report frame load results to the store
     canvas.setOnFrameLoadCallback(useViewerStateStore.getState().setFrameLoadResult);

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -138,8 +138,8 @@ export default class CanvasOverlay implements IRenderCanvas {
     return this.innerCanvasSize.clone();
   }
 
-  public getScaleInfo(): CanvasScaleInfo {
-    return this.innerCanvas.getScaleInfo();
+  public get scaleInfo(): CanvasScaleInfo {
+    return this.innerCanvas.scaleInfo;
   }
 
   get domElement(): HTMLCanvasElement {
@@ -147,7 +147,7 @@ export default class CanvasOverlay implements IRenderCanvas {
     return this.canvasElement;
   }
 
-  setOnFrameLoadCallback(callback: (result: FrameLoadResult) => void): void {
+  public setOnFrameLoadCallback(callback: (result: FrameLoadResult) => void): void {
     this.onFrameLoadCallback = callback;
     this.innerCanvas.setOnFrameLoadCallback(callback);
   }
@@ -259,7 +259,7 @@ export default class CanvasOverlay implements IRenderCanvas {
   }
 
   private getAnnotationRenderer(): RenderInfo {
-    const scaleInfo = this.innerCanvas.getScaleInfo();
+    const scaleInfo = this.innerCanvas.scaleInfo;
     const params: AnnotationParams = {
       ...this.getBaseRendererParams(),
       visible: this.isAnnotationVisible,
@@ -286,7 +286,7 @@ export default class CanvasOverlay implements IRenderCanvas {
   }
 
   private getFooterRenderer(visible: boolean): RenderInfo {
-    const scaleInfo = this.innerCanvas.getScaleInfo();
+    const scaleInfo = this.innerCanvas.scaleInfo;
     const baseParams = this.getBaseRendererParams();
     const params: FooterParams = {
       ...baseParams,

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -25,23 +25,28 @@ import {
 } from "./canvas/elements/annotations";
 import { BaseRenderParams, RenderInfo } from "./canvas/types";
 import { getPixelRatio } from "./canvas/utils";
+import { CanvasScaleInfo, CanvasType, FrameLoadResult } from "./types";
 
 import { LabelData } from "./AnnotationData";
-import Collection from "./Collection";
 import ColorizeCanvas from "./ColorizeCanvas";
-import ColorRamp from "./ColorRamp";
+import { IRenderCanvas, RenderCanvasStateParams } from "./IRenderCanvas";
 
 /**
- * Extends the ColorizeCanvas class by overlaying and compositing additional
- * dynamic elements (like a scale bar, timestamp, etc.) on top of the
+ * Wraps an IRenderCanvas class by overlaying and compositing additional
+ * dynamic elements (like a scale bar, timestamp, etc.) on top of a
  * base colorized image.
  */
-export default class CanvasWithOverlay extends ColorizeCanvas {
-  private canvas: HTMLCanvasElement;
+export default class CanvasOverlay implements IRenderCanvas {
+  private canvasElement: HTMLCanvasElement;
+  private canvas: IRenderCanvas;
   private ctx: CanvasRenderingContext2D;
 
-  private collection: Collection | null;
-  private datasetKey: string | null;
+  private currentFrame: number;
+  private params: RenderCanvasStateParams;
+  private onFrameLoadCallback: (result: FrameLoadResult) => void;
+
+  private zoomMultiplier: number;
+  private panOffset: Vector2;
 
   private labelData: LabelData[];
   private timeToLabelIds: Map<number, Record<number, number[]>>;
@@ -57,7 +62,7 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
   private annotationStyle: AnnotationStyle;
 
   /** Size of the inner colorized canvas, in pixels. */
-  private canvasSize: Vector2;
+  private canvasResolution: Vector2;
   // Size of the header and footer as of the current render.
   private headerSize: Vector2;
   private footerSize: Vector2;
@@ -73,21 +78,27 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
   public isTimestampVisible: boolean;
   public isAnnotationVisible: boolean;
 
-  constructor(styles?: {
-    scaleBar?: ScaleBarStyle;
-    timestamp?: TimestampStyle;
-    insetBox?: InsetBoxStyle;
-    legend?: LegendStyle;
-    header?: HeaderStyle;
-    footer?: FooterStyle;
-  }) {
-    super();
+  constructor(
+    canvas: IRenderCanvas,
+    params: RenderCanvasStateParams,
+    styles?: {
+      scaleBar?: ScaleBarStyle;
+      timestamp?: TimestampStyle;
+      insetBox?: InsetBoxStyle;
+      legend?: LegendStyle;
+      header?: HeaderStyle;
+      footer?: FooterStyle;
+    }
+  ) {
+    this.canvas = canvas;
+    this.canvasElement = document.createElement("canvas");
+    this.canvasElement.style.display = "block";
+    this.onFrameLoadCallback = () => {};
 
-    this.canvas = document.createElement("canvas");
-    this.canvas.style.display = "block";
-
-    this.collection = null;
-    this.datasetKey = null;
+    this.params = params;
+    this.currentFrame = 0;
+    this.zoomMultiplier = 1;
+    this.panOffset = new Vector2();
 
     this.labelData = [];
     this.timeToLabelIds = new Map();
@@ -101,7 +112,7 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
     this.headerStyle = styles?.header || defaultHeaderStyle;
     this.footerStyle = styles?.footer || defaultFooterStyle;
     this.annotationStyle = defaultAnnotationStyle;
-    this.canvasSize = new Vector2(1, 1);
+    this.canvasResolution = new Vector2(1, 1);
     this.headerSize = new Vector2(0, 0);
     this.footerSize = new Vector2(0, 0);
 
@@ -112,7 +123,7 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
     this.isTimestampVisible = true;
     this.isAnnotationVisible = true;
 
-    const canvasContext = this.canvas.getContext("2d") as CanvasRenderingContext2D;
+    const canvasContext = this.canvasElement.getContext("2d") as CanvasRenderingContext2D;
     if (canvasContext === null) {
       throw new Error("CanvasWithOverlay: Could not get canvas context; canvas.getContext('2d') returned null.");
     }
@@ -123,62 +134,107 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
 
   // Wrapped ColorizeCanvas functions ///////
 
+  public get resolution(): Vector2 {
+    return this.canvasResolution.clone();
+  }
+
+  public getScaleInfo(): CanvasScaleInfo {
+    return this.canvas.getScaleInfo();
+  }
+
   get domElement(): HTMLCanvasElement {
     // Override base ColorizeCanvas getter with the composited canvas.
-    return this.canvas;
+    return this.canvasElement;
+  }
+
+  setOnFrameLoadCallback(callback: (result: FrameLoadResult) => void): void {
+    this.onFrameLoadCallback = callback;
+    this.canvas.setOnFrameLoadCallback(callback);
+  }
+
+  dispose(): void {
+    this.canvas.dispose();
   }
 
   public setResolution(width: number, height: number): void {
-    this.canvasSize.x = width;
-    this.canvasSize.y = height;
-    super.setResolution(width, height);
+    this.canvasResolution.x = width;
+    this.canvasResolution.y = height;
+    this.canvas.setResolution(width, height);
     this.render();
   }
 
   public getIdAtPixel(x: number, y: number): number {
     const headerHeight = this.headerSize.y;
-    return super.getIdAtPixel(x, y - headerHeight);
+    return this.canvas.getIdAtPixel(x, y - headerHeight);
   }
 
   // Getters/Setters ////////////////////////////////
 
-  updateScaleBarStyle(style: Partial<ScaleBarStyle>): void {
+  public updateScaleBarStyle(style: Partial<ScaleBarStyle>): void {
     this.scaleBarStyle = { ...this.scaleBarStyle, ...style };
   }
 
-  updateTimestampStyle(style: Partial<TimestampStyle>): void {
+  public updateTimestampStyle(style: Partial<TimestampStyle>): void {
     this.timestampStyle = { ...this.timestampStyle, ...style };
   }
 
-  updateInsetBoxStyle(style: Partial<InsetBoxStyle>): void {
+  public updateInsetBoxStyle(style: Partial<InsetBoxStyle>): void {
     this.insetBoxStyle = { ...this.insetBoxStyle, ...style };
   }
 
-  updateLegendStyle(style: Partial<LegendStyle>): void {
+  public updateLegendStyle(style: Partial<LegendStyle>): void {
     this.legendStyle = { ...this.legendStyle, ...style };
   }
 
-  updateHeaderStyle(style: Partial<HeaderStyle>): void {
+  public updateHeaderStyle(style: Partial<HeaderStyle>): void {
     this.headerStyle = { ...this.headerStyle, ...style };
   }
 
-  updateFooterStyle(style: Partial<FooterStyle>): void {
+  public updateFooterStyle(style: Partial<FooterStyle>): void {
     this.footerStyle = { ...this.footerStyle, ...style };
   }
 
-  setIsExporting(isExporting: boolean): void {
+  // TODO: Move `isExporting` flag into state
+  public setIsExporting(isExporting: boolean): void {
     this.isExporting = isExporting;
   }
 
-  setCollection(collection: Collection | null): void {
-    this.collection = collection;
+  public setZoom(zoom: number): void {
+    this.zoomMultiplier = zoom;
+    if (this.canvas instanceof ColorizeCanvas) {
+      this.canvas.setZoom(zoom);
+    }
+    this.render();
   }
 
-  setDatasetKey(datasetKey: string | null): void {
-    this.datasetKey = datasetKey;
+  public setPan(x: number, y: number): void {
+    this.panOffset.set(x, y);
+    if (this.canvas instanceof ColorizeCanvas) {
+      this.canvas.setPan(x, y);
+    }
+    this.render();
   }
 
-  setAnnotationData(
+  public async setParams(params: RenderCanvasStateParams): Promise<void> {
+    this.params = params;
+    await this.canvas.setParams(params);
+    this.render(false);
+  }
+
+  public async setCanvas(canvas: IRenderCanvas): Promise<void> {
+    this.canvas = canvas;
+    this.canvas.setResolution(this.canvasResolution.x, this.canvasResolution.y);
+    this.canvas.setOnFrameLoadCallback(this.onFrameLoadCallback);
+    await this.canvas.setParams(this.params);
+    await this.canvas.setFrame(this.currentFrame);
+    if (this.canvas instanceof ColorizeCanvas) {
+      this.canvas.setZoom(this.zoomMultiplier);
+      this.canvas.setPan(this.panOffset.x, this.panOffset.y);
+    }
+    this.render(false);
+  }
+
+  public setAnnotationData(
     labelData: LabelData[],
     timeToLabelIds: Map<number, Record<number, number[]>>,
     selectedLabelIdx: number | null,
@@ -194,15 +250,16 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
 
   private getBaseRendererParams(): BaseRenderParams {
     return {
-      canvasSize: this.canvasSize,
-      collection: this.collection,
-      dataset: this.params?.dataset || null,
-      datasetKey: this.datasetKey,
-      featureKey: this.params?.featureKey || null,
+      canvasSize: this.canvasResolution,
+      collection: this.params.collection,
+      dataset: this.params.dataset,
+      datasetKey: this.params.datasetKey,
+      featureKey: this.params.featureKey,
     };
   }
 
   private getAnnotationRenderer(): RenderInfo {
+    const scaleInfo = this.canvas.getScaleInfo();
     const params: AnnotationParams = {
       ...this.getBaseRendererParams(),
       visible: this.isAnnotationVisible,
@@ -210,7 +267,10 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
       timeToLabelIds: this.timeToLabelIds,
       selectedLabelIdx: this.selectedLabelIdx,
       lastSelectedId: this.lastClickedId,
-      frameToCanvasCoordinates: this.frameToCanvasCoordinates,
+      // TODO: Make this into a matrix transformation from 3D centroid to 2D
+      // onscreen position.
+      frameToCanvasCoordinates:
+        scaleInfo.type === CanvasType.CANVAS_2D ? scaleInfo.frameToCanvasCoordinates : new Vector2(1, 1),
       frame: this.currentFrame,
       panOffset: this.panOffset,
     };
@@ -226,6 +286,7 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
   }
 
   private getFooterRenderer(visible: boolean): RenderInfo {
+    const scaleInfo = this.canvas.getScaleInfo();
     const baseParams = this.getBaseRendererParams();
     const params: FooterParams = {
       ...baseParams,
@@ -234,27 +295,38 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
       timestampStyle: this.timestampStyle,
       scaleBar: {
         ...baseParams,
-        frameSizeInCanvasCoordinates: this.frameSizeInCanvasCoordinates,
-        visible: this.isScaleBarVisible,
+        frameSizeInCanvasCoordinates:
+          scaleInfo.type === CanvasType.CANVAS_2D ? scaleInfo.frameSizeInCanvasCoordinates : new Vector2(),
+        // Hide scalebar for 3D canvas
+        visible: this.isScaleBarVisible && scaleInfo.type === CanvasType.CANVAS_2D,
       },
       scaleBarStyle: this.scaleBarStyle,
       insetBoxStyle: this.insetBoxStyle,
       legend: {
         ...baseParams,
-        colorRamp: this.params?.colorRamp || new ColorRamp(["white"]),
-        categoricalPalette: this.params?.categoricalPaletteRamp || new ColorRamp(["white"]),
-        colorMapRangeMin: this.params?.colorRampRange[0] || 0,
-        colorMapRangeMax: this.params?.colorRampRange[1] || 1,
+        colorRamp: this.params.colorRamp,
+        categoricalPalette: this.params.categoricalPaletteRamp,
+        colorMapRangeMin: this.params.colorRampRange[0] || 0,
+        colorMapRangeMax: this.params.colorRampRange[1] || 1,
       },
       legendStyle: this.legendStyle,
     };
     return getFooterRenderer(this.ctx, params, this.footerStyle);
   }
 
+  public async setFrame(requestedFrame: number): Promise<FrameLoadResult | null> {
+    const result = await this.canvas.setFrame(requestedFrame);
+    if (result !== null) {
+      this.currentFrame = requestedFrame;
+      this.render(false);
+    }
+    return result;
+  }
+
   /**
    * Render the viewport canvas with overlay elements composited on top of it.
    */
-  render(): void {
+  render(doesInnerCanvasNeedRender: boolean = true): void {
     // Expand size by header + footer, if rendering:
     const headerRenderer = this.getHeaderRenderer(this.isHeaderVisibleOnExport && this.isExporting);
     const footerRenderer = this.getFooterRenderer(this.isFooterVisibleOnExport && this.isExporting);
@@ -262,23 +334,27 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
     this.footerSize = footerRenderer.sizePx;
 
     const devicePixelRatio = getPixelRatio();
-    this.canvas.width = Math.round(this.canvasSize.x * devicePixelRatio);
-    this.canvas.height = Math.round((this.canvasSize.y + this.headerSize.y + this.footerSize.y) * devicePixelRatio);
+    this.canvasElement.width = Math.round(this.canvasResolution.x * devicePixelRatio);
+    this.canvasElement.height = Math.round(
+      (this.canvasResolution.y + this.headerSize.y + this.footerSize.y) * devicePixelRatio
+    );
 
     //Clear canvas
-    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    this.ctx.clearRect(0, 0, this.canvasElement.width, this.canvasElement.height);
 
     // Because CanvasWithOverlay is a child of ColorizeCanvas, this renders the base
     // colorized viewport image. It is then composited into the CanvasWithOverlay's canvas.
-    super.render();
+    if (doesInnerCanvasNeedRender) {
+      this.canvas.render();
+    }
     this.ctx.imageSmoothingEnabled = false;
-    this.ctx.drawImage(super.domElement, 0, Math.round(this.headerSize.y * devicePixelRatio));
+    this.ctx.drawImage(this.canvas.domElement, 0, Math.round(this.headerSize.y * devicePixelRatio));
 
     this.ctx.scale(devicePixelRatio, devicePixelRatio);
 
     headerRenderer.render(new Vector2(0, 0));
     this.getAnnotationRenderer().render(new Vector2(0, this.headerSize.y));
-    footerRenderer.render(new Vector2(0, this.canvasSize.y + this.headerSize.y));
+    footerRenderer.render(new Vector2(0, this.canvasResolution.y + this.headerSize.y));
   }
 
   /**
@@ -292,8 +368,10 @@ export default class CanvasWithOverlay extends ColorizeCanvas {
     this.footerSize = footerRenderer.sizePx;
 
     const devicePixelRatio = getPixelRatio();
-    const canvasWidth = Math.round(this.canvasSize.x * devicePixelRatio);
-    const canvasHeight = Math.round((this.canvasSize.y + this.headerSize.y + this.footerSize.y) * devicePixelRatio);
+    const canvasWidth = Math.round(this.canvasResolution.x * devicePixelRatio);
+    const canvasHeight = Math.round(
+      (this.canvasResolution.y + this.headerSize.y + this.footerSize.y) * devicePixelRatio
+    );
     return [canvasWidth, canvasHeight];
   }
 }

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -23,6 +23,7 @@ import {
 import { clamp } from "three/src/math/MathUtils";
 
 import { MAX_FEATURE_CATEGORIES } from "../constants";
+import { get2DCanvasScaling } from "./canvas/utils";
 import {
   CANVAS_BACKGROUND_COLOR_DEFAULT,
   FRAME_BACKGROUND_COLOR_DEFAULT,
@@ -30,7 +31,7 @@ import {
   OUTLIER_COLOR_DEFAULT,
   OUTLINE_COLOR_DEFAULT,
 } from "./constants";
-import { DrawMode, FeatureDataType, FrameLoadResult } from "./types";
+import { Canvas2DScaleInfo, CanvasType, DrawMode, FeatureDataType, FrameLoadResult } from "./types";
 import { hasPropertyChanged } from "./utils/data_utils";
 import { packDataTexture } from "./utils/texture_utils";
 
@@ -133,8 +134,7 @@ export default class ColorizeCanvas implements IRenderCanvas {
   private line: Line;
   private points: Float32Array;
 
-  protected frameSizeInCanvasCoordinates: Vector2;
-  protected frameToCanvasCoordinates: Vector2;
+  private scaleInfo: Canvas2DScaleInfo;
   private lastFrameLoadResult: FrameLoadResult | null;
 
   /**
@@ -226,9 +226,13 @@ export default class ColorizeCanvas implements IRenderCanvas {
     this.currentFrame = -1;
     this.pendingFrame = -1;
     this.lastFrameLoadResult = null;
+    this.scaleInfo = {
+      type: CanvasType.CANVAS_2D,
+      frameSizeInCanvasCoordinates: new Vector2(1, 1),
+      canvasToFrameCoordinates: new Vector2(1, 1),
+      frameToCanvasCoordinates: new Vector2(1, 1),
+    };
 
-    this.frameSizeInCanvasCoordinates = new Vector2(1, 1);
-    this.frameToCanvasCoordinates = new Vector2(1, 1);
     this.zoomMultiplier = 1;
     this.panOffset = new Vector2(0, 0);
 
@@ -245,7 +249,11 @@ export default class ColorizeCanvas implements IRenderCanvas {
   }
 
   public get resolution(): Vector2 {
-    return this.canvasResolution;
+    return this.canvasResolution.clone();
+  }
+
+  public getScaleInfo(): Canvas2DScaleInfo {
+    return this.scaleInfo;
   }
 
   public get domElement(): HTMLCanvasElement {
@@ -291,11 +299,11 @@ export default class ColorizeCanvas implements IRenderCanvas {
 
     // Adjust the line mesh position with scaling and panning
     this.line.position.set(
-      2 * this.panOffset.x * this.frameToCanvasCoordinates.x,
-      2 * this.panOffset.y * this.frameToCanvasCoordinates.y,
+      2 * this.panOffset.x * this.scaleInfo.frameToCanvasCoordinates.x,
+      2 * this.panOffset.y * this.scaleInfo.frameToCanvasCoordinates.y,
       0
     );
-    this.vectorField.setPosition(this.panOffset, this.frameToCanvasCoordinates);
+    this.vectorField.setPosition(this.panOffset, this.scaleInfo.frameToCanvasCoordinates);
     this.render();
   }
 
@@ -303,45 +311,21 @@ export default class ColorizeCanvas implements IRenderCanvas {
     if (!frameResolution || !canvasResolution) {
       return;
     }
+    this.scaleInfo = get2DCanvasScaling(frameResolution, canvasResolution, this.zoomMultiplier);
+    const { frameToCanvasCoordinates, canvasToFrameCoordinates } = this.scaleInfo;
+
     this.setUniform("canvasSizePx", canvasResolution);
-    // Both the frame and the canvas have coordinates in a range of [0, 1] in the x and y axis.
-    // However, the canvas may have a different aspect ratio than the frame, so we need to scale
-    // the frame to fit within the canvas while maintaining the aspect ratio.
-    const canvasAspect = canvasResolution.x / canvasResolution.y;
-    const frameAspect = frameResolution.x / frameResolution.y;
-    const unscaledFrameSizeInCanvasCoords: Vector2 = new Vector2(1, 1);
-    if (canvasAspect > frameAspect) {
-      // Canvas has a wider aspect ratio than the frame, so proportional height is 1
-      // and we scale width accordingly.
-      unscaledFrameSizeInCanvasCoords.x = canvasAspect / frameAspect;
-    } else {
-      unscaledFrameSizeInCanvasCoords.y = frameAspect / canvasAspect;
-    }
-
-    // Get final size by applying the current zoom level, where `zoomMultiplier=2` means the frame is 2x
-    // larger than its base size. Save this to use when calculating units with the scale bar.
-    this.frameSizeInCanvasCoordinates = unscaledFrameSizeInCanvasCoords.clone().multiplyScalar(this.zoomMultiplier);
-
-    // Transforms from [0, 1] space of the canvas to the [0, 1] space of the frame by dividing by the zoom level.
-    // ex: Let's say our frame has the same aspect ratio as the canvas, but our zoom is set to 2x.
-    // Assuming that the [0, 0] position of the frame and the canvas are in the same position,
-    // the position [1, 1] on the canvas should map to [0.5, 0.5] on the frame.
-    const canvasToFrameCoordinates = unscaledFrameSizeInCanvasCoords.clone().divideScalar(this.zoomMultiplier);
     this.setUniform("canvasToFrameScale", canvasToFrameCoordinates);
 
-    // Invert to get the frame to canvas coordinates. The line mesh is in frame coordinates, so transform it to
-    // canvas coordinates so it matches the zoomed frame.
-    this.frameToCanvasCoordinates = new Vector2(1 / canvasToFrameCoordinates.x, 1 / canvasToFrameCoordinates.y);
-
-    this.line.scale.set(this.frameToCanvasCoordinates.x, this.frameToCanvasCoordinates.y, 1);
+    this.line.scale.set(frameToCanvasCoordinates.x, frameToCanvasCoordinates.y, 1);
     // The line mesh is centered at [0,0]. Adjust the line mesh position with scaling and panning
     this.line.position.set(
-      2 * this.panOffset.x * this.frameToCanvasCoordinates.x,
-      2 * this.panOffset.y * this.frameToCanvasCoordinates.y,
+      2 * this.panOffset.x * frameToCanvasCoordinates.x,
+      2 * this.panOffset.y * frameToCanvasCoordinates.y,
       0
     );
-    this.vectorField.setPosition(this.panOffset, this.frameToCanvasCoordinates);
-    this.vectorField.setScale(this.frameToCanvasCoordinates, this.canvasResolution || new Vector2(1, 1));
+    this.vectorField.setPosition(this.panOffset, frameToCanvasCoordinates);
+    this.vectorField.setScale(frameToCanvasCoordinates, this.canvasResolution || new Vector2(1, 1));
   }
 
   /**
@@ -453,17 +437,18 @@ export default class ColorizeCanvas implements IRenderCanvas {
     this.onFrameLoadCallback = callback;
   }
 
-  public setParams(params: RenderCanvasStateParams): void {
+  public async setParams(params: RenderCanvasStateParams): Promise<void> {
     // TODO: What happens when `setParams` is called again while waiting for a Dataset to load?
     // May cause visual desync where the color ramp/feature data updates before frames load in fully
     if (this.params === params) {
       return;
     }
+    const promises: Promise<void>[] = [];
     const prevParams = this.params;
     this.params = params;
     // Update dataset and array data
     if (hasPropertyChanged(params, prevParams, ["dataset"])) {
-      this.handleNewDataset(params.dataset);
+      promises.push(this.handleNewDataset(params.dataset));
     }
     if (hasPropertyChanged(params, prevParams, ["dataset", "featureKey"])) {
       this.updateFeatureData(params.dataset, params.featureKey);
@@ -512,6 +497,7 @@ export default class ColorizeCanvas implements IRenderCanvas {
     this.setUniform("backdropSaturation", clamp(params.backdropSaturation, 0, 100) / 100);
     this.setUniform("backdropBrightness", clamp(params.backdropBrightness, 0, 200) / 100);
 
+    // Update color ramp + palette
     if (
       hasPropertyChanged(params, prevParams, [
         "dataset",
@@ -536,6 +522,8 @@ export default class ColorizeCanvas implements IRenderCanvas {
     }
 
     this.render();
+    await Promise.all(promises);
+    return;
   }
 
   public async setFrame(index: number, forceUpdate: boolean = false): Promise<FrameLoadResult | null> {

--- a/src/colorizer/ColorizeCanvas2D.ts
+++ b/src/colorizer/ColorizeCanvas2D.ts
@@ -134,7 +134,7 @@ export default class ColorizeCanvas2D implements IRenderCanvas {
   private line: Line;
   private points: Float32Array;
 
-  private scaleInfo: Canvas2DScaleInfo;
+  private savedScaleInfo: Canvas2DScaleInfo;
   private lastFrameLoadResult: FrameLoadResult | null;
 
   /**
@@ -226,7 +226,7 @@ export default class ColorizeCanvas2D implements IRenderCanvas {
     this.currentFrame = -1;
     this.pendingFrame = -1;
     this.lastFrameLoadResult = null;
-    this.scaleInfo = {
+    this.savedScaleInfo = {
       type: CanvasType.CANVAS_2D,
       frameSizeInCanvasCoordinates: new Vector2(1, 1),
       canvasToFrameCoordinates: new Vector2(1, 1),
@@ -252,8 +252,8 @@ export default class ColorizeCanvas2D implements IRenderCanvas {
     return this.canvasResolution.clone();
   }
 
-  public getScaleInfo(): Canvas2DScaleInfo {
-    return this.scaleInfo;
+  public get scaleInfo(): Canvas2DScaleInfo {
+    return this.savedScaleInfo;
   }
 
   public get domElement(): HTMLCanvasElement {
@@ -299,11 +299,11 @@ export default class ColorizeCanvas2D implements IRenderCanvas {
 
     // Adjust the line mesh position with scaling and panning
     this.line.position.set(
-      2 * this.panOffset.x * this.scaleInfo.frameToCanvasCoordinates.x,
-      2 * this.panOffset.y * this.scaleInfo.frameToCanvasCoordinates.y,
+      2 * this.panOffset.x * this.savedScaleInfo.frameToCanvasCoordinates.x,
+      2 * this.panOffset.y * this.savedScaleInfo.frameToCanvasCoordinates.y,
       0
     );
-    this.vectorField.setPosition(this.panOffset, this.scaleInfo.frameToCanvasCoordinates);
+    this.vectorField.setPosition(this.panOffset, this.savedScaleInfo.frameToCanvasCoordinates);
     this.render();
   }
 
@@ -311,8 +311,8 @@ export default class ColorizeCanvas2D implements IRenderCanvas {
     if (!frameResolution || !canvasResolution) {
       return;
     }
-    this.scaleInfo = get2DCanvasScaling(frameResolution, canvasResolution, this.zoomMultiplier);
-    const { frameToCanvasCoordinates, canvasToFrameCoordinates } = this.scaleInfo;
+    this.savedScaleInfo = get2DCanvasScaling(frameResolution, canvasResolution, this.zoomMultiplier);
+    const { frameToCanvasCoordinates, canvasToFrameCoordinates } = this.savedScaleInfo;
 
     this.setUniform("canvasSizePx", canvasResolution);
     this.setUniform("canvasToFrameScale", canvasToFrameCoordinates);

--- a/src/colorizer/ColorizeCanvas2D.ts
+++ b/src/colorizer/ColorizeCanvas2D.ts
@@ -122,7 +122,7 @@ const getDefaultUniforms = (): ColorizeUniforms => {
   };
 };
 
-export default class ColorizeCanvas implements IRenderCanvas {
+export default class ColorizeCanvas2D implements IRenderCanvas {
   private geometry: PlaneGeometry;
   private material: ShaderMaterial;
   private pickMaterial: ShaderMaterial;

--- a/src/colorizer/IRenderCanvas.ts
+++ b/src/colorizer/IRenderCanvas.ts
@@ -1,11 +1,13 @@
 import { Vector2 } from "three";
 
 import { ViewerStoreState } from "../state/slices";
-import { FrameLoadResult } from "./types";
+import { CanvasScaleInfo, FrameLoadResult } from "./types";
 
 export type RenderCanvasStateParams = Pick<
   ViewerStoreState,
   | "dataset"
+  | "collection"
+  | "datasetKey"
   | "featureKey"
   | "track"
   | "showTrackPath"
@@ -29,6 +31,8 @@ export type RenderCanvasStateParams = Pick<
 
 export const renderCanvasStateParamsSelector = (state: ViewerStoreState): RenderCanvasStateParams => ({
   dataset: state.dataset,
+  collection: state.collection,
+  datasetKey: state.datasetKey,
   featureKey: state.featureKey,
   track: state.track,
   showTrackPath: state.showTrackPath,
@@ -55,14 +59,21 @@ export const renderCanvasStateParamsSelector = (state: ViewerStoreState): Render
  */
 export interface IRenderCanvas {
   get domElement(): HTMLCanvasElement;
+
   /** (X,Y) resolution of the canvas, in pixels. */
   get resolution(): Vector2;
+
+  /** Gets information about canvas scaling. Switches types for 2D and 3D
+   * canvases. */
+  getScaleInfo(): CanvasScaleInfo;
+
   setResolution(width: number, height: number): void;
+
   /**
    * Updates the parameters used to configure the canvas view. See
    * `CanvasStateParams` for a complete list of parameters required.
    */
-  setParams(params: RenderCanvasStateParams): void;
+  setParams(params: RenderCanvasStateParams): Promise<void>;
   /**
    * Requests to load and render the image data for a specific frame.
    * @param requestedFrame The frame number to load and render.

--- a/src/colorizer/IRenderCanvas.ts
+++ b/src/colorizer/IRenderCanvas.ts
@@ -65,7 +65,7 @@ export interface IRenderCanvas {
 
   /** Gets information about canvas scaling. Switches types for 2D and 3D
    * canvases. */
-  getScaleInfo(): CanvasScaleInfo;
+  get scaleInfo(): CanvasScaleInfo;
 
   setResolution(width: number, height: number): void;
 

--- a/src/colorizer/canvas/utils.ts
+++ b/src/colorizer/canvas/utils.ts
@@ -86,31 +86,36 @@ export function get2DCanvasScaling(
   canvasResolution: Vector2,
   zoomMultiplier: number
 ): Canvas2DScaleInfo {
-  // Both the frame and the canvas have coordinates in a range of [0, 1] in the x and y axis.
-  // However, the canvas may have a different aspect ratio than the frame, so we need to scale
-  // the frame to fit within the canvas while maintaining the aspect ratio.
+  // Both the frame and the canvas have coordinates in a range of [0, 1] in the
+  // x and y axis. However, the canvas may have a different aspect ratio than
+  // the frame, so we need to scale the frame to fit within the canvas while
+  // maintaining the aspect ratio.
   const canvasAspect = canvasResolution.x / canvasResolution.y;
   const frameAspect = frameResolution.x / frameResolution.y;
   const unscaledFrameSizeInCanvasCoords: Vector2 = new Vector2(1, 1);
   if (canvasAspect > frameAspect) {
-    // Canvas has a wider aspect ratio than the frame, so proportional height is 1
-    // and we scale width accordingly.
+    // Canvas has a wider aspect ratio than the frame, so proportional height is
+    // 1 and we scale width accordingly.
     unscaledFrameSizeInCanvasCoords.x = canvasAspect / frameAspect;
   } else {
     unscaledFrameSizeInCanvasCoords.y = frameAspect / canvasAspect;
   }
 
-  // Get final size by applying the current zoom level, where `zoomMultiplier=2` means the frame is 2x
-  // larger than its base size. Save this to use when calculating units with the scale bar.
+  // Get final size by applying the current zoom level, where `zoomMultiplier=2`
+  // means the frame is 2x larger than its base size. Save this to use when
+  // calculating onscreen units (e.g. with the scale bar).
   const frameSizeInCanvasCoordinates = unscaledFrameSizeInCanvasCoords.clone().multiplyScalar(zoomMultiplier);
-  // Transforms from [0, 1] space of the canvas to the [0, 1] space of the frame by dividing by the zoom level.
-  // ex: Let's say our frame has the same aspect ratio as the canvas, but our zoom is set to 2x.
-  // Assuming that the [0, 0] position of the frame and the canvas are in the same position,
-  // the position [1, 1] on the canvas should map to [0.5, 0.5] on the frame.
+  // Transforms from [0, 1] space of the canvas to the [0, 1] space of the frame
+  // by dividing by the zoom level.
+  // ex: Let's say our frame has the same aspect ratio as the canvas, but our
+  // zoom is set to 2x. Assuming that the [0, 0] position of the frame and the
+  // canvas are in the same position, the position [1, 1] on the canvas should
+  // map to [0.5, 0.5] on the frame.
   const canvasToFrameCoordinates = unscaledFrameSizeInCanvasCoords.clone().divideScalar(zoomMultiplier);
 
-  // Invert to get the frame to canvas coordinates. The line mesh is in frame coordinates, so transform it to
-  // canvas coordinates so it matches the zoomed frame.
+  // Invert to get the frame to canvas coordinates. Useful for objects (e.g.
+  // line mesh vertices) that are in frame coordinates and need to be drawn on
+  // the canvas.
   const frameToCanvasCoordinates = new Vector2(1 / canvasToFrameCoordinates.x, 1 / canvasToFrameCoordinates.y);
 
   return {

--- a/src/colorizer/canvas/utils.ts
+++ b/src/colorizer/canvas/utils.ts
@@ -1,5 +1,6 @@
 import { Vector2 } from "three";
 
+import { Canvas2DScaleInfo, CanvasType } from "../types";
 import { FontStyle } from "./types";
 
 export function getTextDimensions(ctx: CanvasRenderingContext2D, text: string, style: FontStyle): Vector2 {
@@ -78,4 +79,44 @@ export function renderCanvasText(
   ctx.fillText(text, x, y);
 
   return new Vector2(textWidth, textHeight);
+}
+
+export function get2DCanvasScaling(
+  frameResolution: Vector2,
+  canvasResolution: Vector2,
+  zoomMultiplier: number
+): Canvas2DScaleInfo {
+  // Both the frame and the canvas have coordinates in a range of [0, 1] in the x and y axis.
+  // However, the canvas may have a different aspect ratio than the frame, so we need to scale
+  // the frame to fit within the canvas while maintaining the aspect ratio.
+  const canvasAspect = canvasResolution.x / canvasResolution.y;
+  const frameAspect = frameResolution.x / frameResolution.y;
+  const unscaledFrameSizeInCanvasCoords: Vector2 = new Vector2(1, 1);
+  if (canvasAspect > frameAspect) {
+    // Canvas has a wider aspect ratio than the frame, so proportional height is 1
+    // and we scale width accordingly.
+    unscaledFrameSizeInCanvasCoords.x = canvasAspect / frameAspect;
+  } else {
+    unscaledFrameSizeInCanvasCoords.y = frameAspect / canvasAspect;
+  }
+
+  // Get final size by applying the current zoom level, where `zoomMultiplier=2` means the frame is 2x
+  // larger than its base size. Save this to use when calculating units with the scale bar.
+  const frameSizeInCanvasCoordinates = unscaledFrameSizeInCanvasCoords.clone().multiplyScalar(zoomMultiplier);
+  // Transforms from [0, 1] space of the canvas to the [0, 1] space of the frame by dividing by the zoom level.
+  // ex: Let's say our frame has the same aspect ratio as the canvas, but our zoom is set to 2x.
+  // Assuming that the [0, 0] position of the frame and the canvas are in the same position,
+  // the position [1, 1] on the canvas should map to [0.5, 0.5] on the frame.
+  const canvasToFrameCoordinates = unscaledFrameSizeInCanvasCoords.clone().divideScalar(zoomMultiplier);
+
+  // Invert to get the frame to canvas coordinates. The line mesh is in frame coordinates, so transform it to
+  // canvas coordinates so it matches the zoomed frame.
+  const frameToCanvasCoordinates = new Vector2(1 / canvasToFrameCoordinates.x, 1 / canvasToFrameCoordinates.y);
+
+  return {
+    type: CanvasType.CANVAS_2D,
+    frameSizeInCanvasCoordinates,
+    canvasToFrameCoordinates,
+    frameToCanvasCoordinates,
+  };
 }

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -9,6 +9,7 @@ import {
   TextureDataType,
   UnsignedByteType,
   UnsignedIntType,
+  Vector2,
 } from "three";
 
 // This file provides a bit of type trickery to allow data loading code to be generic over multiple numeric types.
@@ -76,6 +77,8 @@ export const featureTypeSpecs: { [T in FeatureDataType]: FeatureTypeSpec<T> } = 
   },
 };
 
+// CANVAS //////////////////////////////////////
+
 export type FrameLoadResult = {
   frame: number;
   /** False if frame loading encountered an error. */
@@ -87,6 +90,40 @@ export type FrameLoadResult = {
    */
   isBackdropLoaded: boolean;
 };
+
+export enum CanvasType {
+  CANVAS_2D = "2D",
+  CANVAS_3D = "3D",
+}
+
+export type Canvas2DScaleInfo = {
+  type: CanvasType.CANVAS_2D;
+  /**
+   * Size of the frame in [0, 1] canvas coordinates, accounting for zoom.
+   */
+  frameSizeInCanvasCoordinates: Vector2;
+  /**
+   * Transforms from [0,1] space of the canvas to the [0,1] space of the frame,
+   * account for zoom.
+   *
+   * e.g. If frame has the same aspect ratio as the canvas and zoom is set to
+   * 2x, then, assuming that the [0, 0] position of the frame and the canvas are
+   * in the same position, the position [1, 1] on the canvas should map to [0.5,
+   * 0.5] on the frame.
+   */
+  canvasToFrameCoordinates: Vector2;
+  /**
+   * Inverse of `canvasToFrameCoordinates`. Transforms from [0,1] space of the
+   * frame to the [0,1] space of the canvas, accounting for zoom.
+   */
+  frameToCanvasCoordinates: Vector2;
+};
+
+export type Canvas3DScaleInfo = {
+  type: CanvasType.CANVAS_3D;
+};
+
+export type CanvasScaleInfo = Canvas3DScaleInfo | Canvas2DScaleInfo;
 
 // MUST be synchronized with the DRAW_MODE_* constants in `colorize_RGBA8U.frag`!
 // CHANGING THESE VALUES CAN POTENTIALLY BREAK URLs. See `url_utils.parseDrawSettings` for parsing logic.

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -12,7 +12,7 @@ import { AnnotationState } from "../colorizer/utils/react_utils";
 import { INTERNAL_BUILD } from "../constants";
 import { FlexColumn, FlexColumnAlignCenter, VisuallyHidden } from "../styles/utils";
 
-import CanvasUIOverlay from "../colorizer/CanvasWithOverlay";
+import CanvasUIOverlay from "../colorizer/CanvasOverlay";
 import { renderCanvasStateParamsSelector } from "../colorizer/IRenderCanvas";
 import { useViewerStateStore } from "../state/ViewerState";
 import { AppThemeContext } from "./AppStyle";
@@ -130,7 +130,6 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   const clearTrack = useViewerStateStore((state) => state.clearTrack);
   const collection = useViewerStateStore((state) => state.collection);
   const dataset = useViewerStateStore((state) => state.dataset);
-  const datasetKey = useViewerStateStore((state) => state.datasetKey);
   const setBackdropVisible = useViewerStateStore((state) => state.setBackdropVisible);
   const setOpenTab = useViewerStateStore((state) => state.setOpenTab);
   const setTrack = useViewerStateStore((state) => state.setTrack);
@@ -234,14 +233,6 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   useMemo(() => {
     canv.isTimestampVisible = showTimestamp;
   }, [showTimestamp]);
-
-  useMemo(() => {
-    canv.setCollection(collection);
-  }, [collection]);
-
-  useMemo(() => {
-    canv.setDatasetKey(datasetKey);
-  }, [datasetKey]);
 
   useMemo(() => {
     canv.setIsExporting(props.isRecording);


### PR DESCRIPTION
Problem
=======
CLOSES #560, "refactor CanvasOverlay to be its own class"! 

This change allows `ColorizeCanvas` to be a separate class from `CanvasOverlay`, which will let us make a new 3D canvas class for TFE 3D!

*Estimated review size: medium, 30 minutes*

Solution
========
- Moved some scaling calculations out of `ColorizeCanvas` and into a separate `utils` method, with a new `scaleInfo` property.
- Renamed `CanvasWithOverlay` to `CanvasOverlay`, and `ColorizeCanvas` to `ColorizeCanvas2D`.
- Changed `CanvasOverlay` to hold a reference to an `innerCanvas`, which it syncs parameters and rendering with.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open PR preview:
2. https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-608/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&tab=settings&bg=1
3. All canvas interactions should work like they did before! Try clicking objects, panning or zooming, toggling UI overlays on/off, etc.

Screenshots (optional):
-----------------------

**Video talk-through (🔊):**

https://github.com/user-attachments/assets/53ff9414-e5c6-4e68-b9b1-7577cf15f161


