### PR TITLE
feat: Show Vol-E Viewer in TFE, sync time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "timelapse-colorizer",
       "version": "1.2.1",
       "dependencies": {
+        "@aics/vole-core": "^3.13.0",
         "@ant-design/icons": "^5.2.5",
         "@fortawesome/fontawesome-svg-core": "^6.5.1",
         "@fortawesome/free-solid-svg-icons": "^6.5.1",
@@ -68,6 +69,25 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.2.tgz",
       "integrity": "sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==",
       "dev": true
+    },
+    "node_modules/@aics/vole-core": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-3.13.0.tgz",
+      "integrity": "sha512-M/306mv0TKT0r9AzEedc1zp/ixTHZUixj0o5qxKmTc2w7phBO6k75+Tm5LhA5QZuGrs385j5hFmzLSJToJxd5w==",
+      "dependencies": {
+        "@babel/runtime": "^7.25.6",
+        "geotiff": "^2.0.5",
+        "serialize-error": "^11.0.3",
+        "three": "^0.171.0",
+        "throttled-queue": "^2.1.4",
+        "tweakpane": "^3.1.9",
+        "zarrita": "^0.3.2"
+      }
+    },
+    "node_modules/@aics/vole-core/node_modules/three": {
+      "version": "0.171.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.171.0.tgz",
+      "integrity": "sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -701,23 +721,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dependencies": {
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2058,9 +2078,9 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2069,13 +2089,13 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2110,9 +2130,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -3025,6 +3045,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@petamoriken/float16": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.2.tgz",
+      "integrity": "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -4811,6 +4836,40 @@
       "engines": {
         "node": ">=18.20.0"
       }
+    },
+    "node_modules/@zarrita/core": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@zarrita/core/-/core-0.0.3.tgz",
+      "integrity": "sha512-fWv51b+xbYnws1pkNDPwJQoDa76aojxplHyMup82u11UAiet3gURMsrrkhM6YbeTgSY1A8oGxDOrvar3SiZpLA==",
+      "dependencies": {
+        "@zarrita/storage": "^0.0.2",
+        "@zarrita/typedarray": "^0.0.1",
+        "numcodecs": "^0.2.2"
+      }
+    },
+    "node_modules/@zarrita/indexing": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@zarrita/indexing/-/indexing-0.0.3.tgz",
+      "integrity": "sha512-Q61d9MYX6dsK1DLltEpwx4mJWCZHj0TXiaEN4QpxNDtToa/EoyytP/pYHPypO4GXBscZooJ6eZkKT5FMx9PVfg==",
+      "dependencies": {
+        "@zarrita/core": "^0.0.3",
+        "@zarrita/storage": "^0.0.2",
+        "@zarrita/typedarray": "^0.0.1"
+      }
+    },
+    "node_modules/@zarrita/storage": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.0.2.tgz",
+      "integrity": "sha512-uFt4abAoiOYLroalNDAnVaQxA17zGKrQ0waYKmTVm+bNonz8ggKZP+0FqMhgUZITGChqoANHuYTazbuU5AFXWA==",
+      "dependencies": {
+        "reference-spec-reader": "^0.2.0",
+        "unzipit": "^1.3.6"
+      }
+    },
+    "node_modules/@zarrita/typedarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@zarrita/typedarray/-/typedarray-0.0.1.tgz",
+      "integrity": "sha512-ZdvNjYP1bEuQXoSTVkemV99w42jHYrJ3nh9golCLd4MVBlrVbfZo4wWgBslU4JZUaDikhFSH+GWMDgAq/rI32g=="
     },
     "node_modules/@zip.js/zip.js": {
       "version": "2.7.57",
@@ -8515,6 +8574,29 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/geotiff": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
+      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
+      "dependencies": {
+        "@petamoriken/float16": "^3.4.7",
+        "lerc": "^3.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "quick-lru": "^6.1.1",
+        "web-worker": "^1.2.0",
+        "xml-utils": "^1.0.2",
+        "zstddec": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10.19"
+      }
+    },
+    "node_modules/geotiff/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -9883,6 +9965,11 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -10455,6 +10542,14 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/numcodecs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.2.tgz",
+      "integrity": "sha512-Y5K8mv80yb4MgVpcElBkUeMZqeE4TrovxRit/dTZvoRl6YkB6WEjY+fiUjGCblITnt3T3fmrDg8yRWu0gOLjhQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
@@ -10757,6 +10852,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A=="
     },
     "node_modules/parse5": {
       "version": "7.1.2",
@@ -11295,6 +11395,17 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/rc-cascader": {
       "version": "3.17.0",
@@ -12052,6 +12163,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/reference-spec-reader": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
+      "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ=="
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
@@ -12422,9 +12538,6 @@
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-11.0.3.tgz",
       "integrity": "sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "type-fest": "^2.12.2"
       },
@@ -12439,9 +12552,6 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -13168,6 +13278,11 @@
         "node": ">=12.22"
       }
     },
+    "node_modules/throttled-queue": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/throttled-queue/-/throttled-queue-2.1.4.tgz",
+      "integrity": "sha512-YGdk8sdmr4ge3g+doFj/7RLF5kLM+Mi7DEciu9PHxnMJZMeVuZeTj31g4VE7ekUffx/IdbvrtOCiz62afg0mkg=="
+    },
     "node_modules/tinybench": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.0.tgz",
@@ -13305,6 +13420,14 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tweakpane": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/tweakpane/-/tweakpane-3.1.10.tgz",
+      "integrity": "sha512-rqwnl/pUa7+inhI2E9ayGTqqP0EPOOn/wVvSWjZsRbZUItzNShny7pzwL3hVlaN4m9t/aZhsP0aFQ9U5VVR2VQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/cocopon"
       }
     },
     "node_modules/type-check": {
@@ -13500,6 +13623,17 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/unzipit": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
+      "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
+      "dependencies": {
+        "uzip-module": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
@@ -13601,6 +13735,11 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/uzip-module": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
+      "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA=="
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
@@ -13616,9 +13755,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.9.tgz",
-      "integrity": "sha512-qK9W4xjgD3gXbC0NmdNFFnVFLMWSNiR3swj957yutwzzN16xF/E7nmtAyp1rT9hviDroQANjE4HK3H4WqWdFtw==",
+      "version": "4.5.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.10.tgz",
+      "integrity": "sha512-f2ueoukYTMI/5kMMT7wW+ol3zL6z6PjN28zYrGKAjnbzXhRXWXPThD3uN6muCp+TbfXaDgGvRuPsg6mwVLaWwQ==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -13917,6 +14056,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="
     },
     "node_modules/webdriver": {
       "version": "9.9.1",
@@ -14237,6 +14381,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/xml-utils": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.1.tgz",
+      "integrity": "sha512-Dn6vJ1Z9v1tepSjvnCpwk5QqwIPcEFKdgnjqfYOABv1ngSofuAhtlugcUC3ehS1OHdgDWSG6C5mvj+Qm15udTQ=="
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -14328,6 +14477,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zarrita": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.3.2.tgz",
+      "integrity": "sha512-Zx9nS28C2tXZhF1BmQkgQGi0M/Z5JiM/KCMa+fEYtr/MnIzyizR4sKRA/sXjDP1iuylILWTJAWWBJD//0ONXCA==",
+      "dependencies": {
+        "@zarrita/core": "^0.0.3",
+        "@zarrita/indexing": "^0.0.3",
+        "@zarrita/storage": "^0.0.2"
+      }
+    },
     "node_modules/zip-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
@@ -14343,6 +14502,11 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/zstddec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="
     },
     "node_modules/zustand": {
       "version": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "vitest-canvas-mock": "^0.3.3"
   },
   "dependencies": {
+    "@aics/vole-core": "^3.13.0",
     "@ant-design/icons": "^5.2.5",
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -42,6 +42,7 @@ import { loadInitialCollectionAndDataset } from "./utils/dataset_load_utils";
 import CanvasOverlay from "./colorizer/CanvasOverlay";
 import Collection from "./colorizer/Collection";
 import ColorizeCanvas2D, { BACKGROUND_ID } from "./colorizer/ColorizeCanvas2D";
+import { ColorizeCanvas3D } from "./colorizer/ColorizeCanvas3D";
 import { FeatureType } from "./colorizer/Dataset";
 import { renderCanvasStateParamsSelector } from "./colorizer/IRenderCanvas";
 import UrlArrayLoader from "./colorizer/loaders/UrlArrayLoader";
@@ -84,9 +85,12 @@ function Viewer(): ReactElement {
 
   const [, startTransition] = React.useTransition();
 
+  // TODO: Make `canv` an IRenderCanvas type? Don't wrap `ColorizeCanvas3D` in `CanvasOverlay`...?
   const canv = useConstructor(() => {
     const stateDeps = renderCanvasStateParamsSelector(useViewerStateStore.getState());
-    const canvas = new CanvasOverlay(new ColorizeCanvas2D(), stateDeps);
+    // const innerCanvas = new ColorizeCanvas2D();
+    const innerCanvas = new ColorizeCanvas3D(stateDeps);
+    const canvas = new CanvasOverlay(innerCanvas, stateDeps);
     canvas.domElement.className = styles.colorizeCanvas;
     // Report frame load results to the store
     canvas.setOnFrameLoadCallback(useViewerStateStore.getState().setFrameLoadResult);

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -39,9 +39,8 @@ import { FlexRow, FlexRowAlignCenter } from "./styles/utils";
 import { LocationState } from "./types";
 import { loadInitialCollectionAndDataset } from "./utils/dataset_load_utils";
 
-import CanvasOverlay from "./colorizer/CanvasOverlay";
 import Collection from "./colorizer/Collection";
-import ColorizeCanvas2D, { BACKGROUND_ID } from "./colorizer/ColorizeCanvas2D";
+import { BACKGROUND_ID } from "./colorizer/ColorizeCanvas2D";
 import { ColorizeCanvas3D } from "./colorizer/ColorizeCanvas3D";
 import { FeatureType } from "./colorizer/Dataset";
 import { IRenderCanvas, renderCanvasStateParamsSelector } from "./colorizer/IRenderCanvas";

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -44,7 +44,7 @@ import Collection from "./colorizer/Collection";
 import ColorizeCanvas2D, { BACKGROUND_ID } from "./colorizer/ColorizeCanvas2D";
 import { ColorizeCanvas3D } from "./colorizer/ColorizeCanvas3D";
 import { FeatureType } from "./colorizer/Dataset";
-import { renderCanvasStateParamsSelector } from "./colorizer/IRenderCanvas";
+import { IRenderCanvas, renderCanvasStateParamsSelector } from "./colorizer/IRenderCanvas";
 import UrlArrayLoader from "./colorizer/loaders/UrlArrayLoader";
 import { getSharedWorkerPool } from "./colorizer/workers/SharedWorkerPool";
 import { AppThemeContext } from "./components/AppStyle";
@@ -86,11 +86,12 @@ function Viewer(): ReactElement {
   const [, startTransition] = React.useTransition();
 
   // TODO: Make `canv` an IRenderCanvas type? Don't wrap `ColorizeCanvas3D` in `CanvasOverlay`...?
-  const canv = useConstructor(() => {
+  const canv: IRenderCanvas = useConstructor(() => {
     const stateDeps = renderCanvasStateParamsSelector(useViewerStateStore.getState());
     // const innerCanvas = new ColorizeCanvas2D();
     const innerCanvas = new ColorizeCanvas3D(stateDeps);
-    const canvas = new CanvasOverlay(innerCanvas, stateDeps);
+    // const canvas = new CanvasOverlay(innerCanvas, stateDeps);
+    const canvas = innerCanvas;
     canvas.domElement.className = styles.colorizeCanvas;
     // Report frame load results to the store
     canvas.setOnFrameLoadCallback(useViewerStateStore.getState().setFrameLoadResult);
@@ -682,7 +683,7 @@ function Viewer(): ReactElement {
             <Export
               totalFrames={dataset?.numberOfFrames || 0}
               setFrame={setFrame}
-              getCanvasExportDimensions={() => canv.getExportDimensions()}
+              getCanvasExportDimensions={() => canv.resolution.toArray()}
               getCanvas={() => canv.domElement}
               // Stop playback when exporting
               onClick={() => timeControls.pause()}

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -351,7 +351,9 @@ export default class CanvasOverlay implements IRenderCanvas {
       this.innerCanvas.render();
     }
     this.ctx.imageSmoothingEnabled = false;
-    this.ctx.drawImage(this.innerCanvas.domElement, 0, Math.round(this.headerSize.y * devicePixelRatio));
+    if (this.innerCanvas.domElement.width !== 0 && this.innerCanvas.domElement.height !== 0) {
+      this.ctx.drawImage(this.innerCanvas.domElement, 0, Math.round(this.headerSize.y * devicePixelRatio));
+    }
 
     this.ctx.scale(devicePixelRatio, devicePixelRatio);
 

--- a/src/colorizer/ColorizeCanvas3D.ts
+++ b/src/colorizer/ColorizeCanvas3D.ts
@@ -3,11 +3,14 @@ import {
   Light,
   LoadSpec,
   Lut,
+  RawArrayLoader,
   RENDERMODE_RAYMARCH,
   SKY_LIGHT,
+  TiffLoader,
   View3d,
   Volume,
   VolumeLoaderContext,
+  WorkerLoader,
 } from "@aics/vole-core";
 import { Vector2, Vector3 } from "three";
 
@@ -21,14 +24,20 @@ const PREFETCH_CONCURRENCY_LIMIT = 3;
 const loaderContext = new VolumeLoaderContext(CACHE_MAX_SIZE, CONCURRENCY_LIMIT, PREFETCH_CONCURRENCY_LIMIT);
 
 export class ColorizeCanvas3D implements IRenderCanvas {
-  private viewContainer: HTMLElement;
+  // private viewContainer: HTMLElement;
   private view3d: View3d;
   private onLoadFrameCallback: (result: FrameLoadResult) => void;
   private params: RenderCanvasStateParams;
 
+  private canvasResolution: Vector2;
+
   private tempCanvas: HTMLCanvasElement;
 
-  private volumePromise: Promise<FrameLoadResult> | null = null;
+  private loader: WorkerLoader | RawArrayLoader | TiffLoader | null = null;
+  private volume: Volume | null = null;
+  private pendingVolumePromise: Promise<FrameLoadResult> | null = null;
+  private pendingFrame: number;
+  private currentFrame: number;
 
   /**
    * View3d requires a div to be passed in, and it mounts the ThreeJS panel to that div.
@@ -38,10 +47,12 @@ export class ColorizeCanvas3D implements IRenderCanvas {
 
   constructor(params: RenderCanvasStateParams) {
     this.params = params;
-    this.viewContainer = document.createElement("div");
+    // this.viewContainer = document.createElement("div");
+    // this.viewContainer.id = "canvas3d-viewcontainer";
 
-    this.view3d = new View3d({ parentElement: this.viewContainer });
+    this.view3d = new View3d();
     this.view3d.loaderContext = loaderContext;
+    this.canvasResolution = new Vector2(10, 10);
     this.setResolution(10, 10);
     this.view3d.setShowAxis(true);
     this.view3d.setVolumeRenderMode(RENDERMODE_RAYMARCH);
@@ -50,6 +61,8 @@ export class ColorizeCanvas3D implements IRenderCanvas {
     this.tempCanvas = document.createElement("canvas");
     this.tempCanvas.style.width = "10px";
     this.tempCanvas.style.height = "10px";
+    this.pendingFrame = -1;
+    this.currentFrame = -1;
 
     this.onLoadFrameCallback = () => {};
   }
@@ -67,15 +80,11 @@ export class ColorizeCanvas3D implements IRenderCanvas {
 
   get domElement(): HTMLCanvasElement {
     // I hope this works
-    const view3dElement = this.view3d.getDOMElement();
-    if (view3dElement.children.length === 0) {
-      return this.tempCanvas;
-    }
-    return view3dElement.children[0] as HTMLCanvasElement;
+    return this.view3d.getCanvasDOMElement();
   }
 
   get resolution(): Vector2 {
-    return new Vector2(this.viewContainer.clientWidth, this.viewContainer.clientHeight);
+    return this.canvasResolution.clone();
   }
 
   getScaleInfo(): CanvasScaleInfo {
@@ -86,84 +95,118 @@ export class ColorizeCanvas3D implements IRenderCanvas {
 
   setResolution(width: number, height: number): void {
     console.log("ColorizeCanvas3D setResolution", width, height);
-    this.viewContainer.style.width = `${width}px`;
-    this.viewContainer.style.height = `${height}px`;
+    // this.viewContainer.style.width = `${width}px`;
+    // this.viewContainer.style.height = `${height}px`;
     this.view3d.resize(null, width, height);
+    this.canvasResolution.set(width, height);
   }
 
   setParams(params: RenderCanvasStateParams): Promise<void> {
     this.params = params;
+    // Eventually volume change is handled here?
     return Promise.resolve();
   }
 
-  setFrame(_requestedFrame: number): Promise<FrameLoadResult | null> {
-    if (this.volumePromise) {
-      return this.volumePromise;
+  private async loadInitialVolume(path: string | string[]): Promise<Volume> {
+    console.log("Awaiting onOpen");
+    await loaderContext.onOpen();
+
+    // Setup volume loader and load an example volume
+    console.log("Setting up loader");
+    const loader = await loaderContext.createLoader(path);
+    const loadSpec = new LoadSpec();
+    const volume = await loader.createVolume(loadSpec, (v: Volume, channelIndex: number) => {
+      const currentVol = v;
+
+      // currently, this must be called when channel data arrives (here in this callback)
+      this.view3d.onVolumeData(currentVol, [channelIndex]);
+
+      // Get histogram from channel data
+      const histogram = currentVol.getHistogram(channelIndex);
+
+      // Use LUT
+      // const hmin = histogram.findBinOfPercentile(0.5);
+      // const hmax = histogram.findBinOfPercentile(0.983);
+      // const lut = new Lut().createFromMinMax(hmin, hmax);
+      // currentVol.setLut(channelIndex, lut);
+
+      // Use colorize
+      const lut = new Lut().createLabelColors(histogram);
+      currentVol.setColorPalette(channelIndex, lut.lut);
+      currentVol.setColorPaletteAlpha(channelIndex, 0.5);
+
+      // these calls tell the viewer that things are out of date
+      this.view3d.updateActiveChannels(currentVol);
+      this.view3d.updateLuts(currentVol);
+      this.view3d.redraw();
+      console.log("Loaded channel", channelIndex);
+    });
+    this.view3d.addVolume(volume);
+
+    this.view3d.setVolumeChannelEnabled(volume, 0, true);
+    this.view3d.setVolumeChannelOptions(volume, 0, {
+      isosurfaceEnabled: false,
+      isosurfaceOpacity: 1.0,
+      enabled: true,
+      color: [1, 1, 1],
+      emissiveColor: [0, 0, 0],
+    });
+
+    this.view3d.updateDensity(volume, 50);
+    this.view3d.updateExposure(60);
+    this.view3d.setVolumeRotation(volume, [0, 0, 0]);
+    this.view3d.setVolumeTranslation(volume, [0, 0, 0]);
+    this.view3d.setVolumeScale(volume, [1, 1, 1]);
+    this.view3d.setShowBoundingBox(volume, true);
+    this.view3d.setBoundingBoxColor(volume, [0.5, 0.5, 0.5]);
+    this.view3d.resetCamera();
+
+    this.loader = loader;
+    this.volume = volume;
+
+    await loader.loadVolumeData(volume);
+    return volume;
+  }
+
+  setFrame(requestedFrame: number): Promise<FrameLoadResult | null> {
+    if (requestedFrame === this.currentFrame) {
+      this.pendingFrame = -1;
+      return Promise.resolve({
+        frame: this.currentFrame,
+        isFrameLoaded: true,
+        backdropKey: null,
+        isBackdropLoaded: true,
+      });
     }
-    const loadInitialVolume = async (): Promise<FrameLoadResult> => {
-      console.log("Awaiting onOpen");
-      await loaderContext.onOpen();
+    if (requestedFrame === this.pendingFrame && this.pendingVolumePromise) {
+      return this.pendingVolumePromise;
+    }
 
-      // Setup volume loader and load an example volume
-      console.log("Setting up loader");
-      const loader = await loaderContext.createLoader([
-        "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/hipsc_fov_nuclei_timelapse_dataset/hipsc_fov_nuclei_timelapse_data_used_for_analysis/baseline_colonies_fov_timelapse_dataset/20200323_09_small/seg.ome.zarr",
-      ]);
-      const loadSpec = new LoadSpec();
-      const volume = await loader.createVolume(loadSpec, (v: Volume, channelIndex: number) => {
-        const currentVol = v;
-
-        // currently, this must be called when channel data arrives (here in this callback)
-        this.view3d.onVolumeData(currentVol, [channelIndex]);
-
-        // Get histogram from channel data
-        const histogram = currentVol.getHistogram(channelIndex);
-        // const hmin = histogram.findBinOfPercentile(0.5);
-        // const hmax = histogram.findBinOfPercentile(0.983);
-        // const lut = new Lut().createFromMinMax(hmin, hmax);
-        const lut = new Lut().createLabelColors(histogram);
-        // currentVol.setLut(channelIndex, lut);
-        currentVol.setColorPalette(channelIndex, lut.lut);
-        currentVol.setColorPaletteAlpha(channelIndex, 0.5);
-
-        // these calls tell the viewer that things are out of date
-        this.view3d.updateActiveChannels(currentVol);
-        this.view3d.updateLuts(currentVol);
-        this.view3d.redraw();
-        console.log("Loaded channel", channelIndex);
-      });
-      this.view3d.addVolume(volume);
-
-      this.view3d.setVolumeChannelEnabled(volume, 0, true);
-      this.view3d.setVolumeChannelOptions(volume, 0, {
-        isosurfaceEnabled: false,
-        isosurfaceOpacity: 1.0,
-        enabled: true,
-        color: [1, 1, 1],
-        emissiveColor: [0, 0, 0],
+    const loadVolumeFrame = async (): Promise<FrameLoadResult> => {
+      if (!this.volume || !this.loader) {
+        await this.loadInitialVolume([
+          "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/hipsc_fov_nuclei_timelapse_dataset/hipsc_fov_nuclei_timelapse_data_used_for_analysis/baseline_colonies_fov_timelapse_dataset/20200323_09_small/seg.ome.zarr",
+        ]);
+      }
+      await this.view3d.setTime(this.volume!, requestedFrame, (vol) => {
+        if (vol.isLoaded()) {
+        }
       });
 
-      this.view3d.updateDensity(volume, 50);
-      this.view3d.updateExposure(60);
-      this.view3d.setVolumeRotation(volume, [0, 0, 0]);
-      this.view3d.setVolumeTranslation(volume, [0, 0, 0]);
-      this.view3d.setVolumeScale(volume, [1, 1, 1]);
-      this.view3d.setShowBoundingBox(volume, true);
-      this.view3d.setBoundingBoxColor(volume, [1, 0, 0]);
-      this.view3d.resetCamera();
-
-      await loader.loadVolumeData(volume);
       this.render();
-      console.log("Volume data loaded");
+      this.currentFrame = requestedFrame;
+      this.pendingFrame = -1;
+      console.log("Volume data loaded for frame ", requestedFrame);
       return {
-        frame: 0,
+        frame: requestedFrame,
         isFrameLoaded: true,
         backdropKey: null,
         isBackdropLoaded: true,
       };
     };
-    this.volumePromise = loadInitialVolume();
-    return this.volumePromise as Promise<FrameLoadResult>;
+    this.pendingFrame = requestedFrame;
+    this.pendingVolumePromise = loadVolumeFrame();
+    return this.pendingVolumePromise as Promise<FrameLoadResult>;
   }
 
   public setOnFrameLoadCallback(callback: (result: FrameLoadResult) => void): void {
@@ -171,7 +214,7 @@ export class ColorizeCanvas3D implements IRenderCanvas {
   }
 
   render(): void {
-    this.view3d.redraw();
+    this.view3d.render();
   }
 
   dispose(): void {

--- a/src/colorizer/ColorizeCanvas3D.ts
+++ b/src/colorizer/ColorizeCanvas3D.ts
@@ -1,0 +1,157 @@
+import {
+  AREA_LIGHT,
+  Light,
+  LoadSpec,
+  RENDERMODE_RAYMARCH,
+  SKY_LIGHT,
+  View3d,
+  Volume,
+  VolumeLoaderContext,
+} from "@aics/vole-core";
+import { render } from "react-dom";
+import { Vector2, Vector3 } from "three";
+
+import { CanvasScaleInfo, CanvasType, FrameLoadResult } from "./types";
+
+import { IRenderCanvas, RenderCanvasStateParams } from "./IRenderCanvas";
+
+const CACHE_MAX_SIZE = 1_000_000_000;
+const CONCURRENCY_LIMIT = 8;
+const PREFETCH_CONCURRENCY_LIMIT = 3;
+const loaderContext = new VolumeLoaderContext(CACHE_MAX_SIZE, CONCURRENCY_LIMIT, PREFETCH_CONCURRENCY_LIMIT);
+
+export class ColorizeCanvas3D implements IRenderCanvas {
+  private viewContainer: HTMLElement;
+  private view3d: View3d;
+  private onLoadFrameCallback: (result: FrameLoadResult) => void;
+  private params: RenderCanvasStateParams;
+
+  private tempCanvas: HTMLCanvasElement;
+
+  private volumePromise: Promise<FrameLoadResult> | null = null;
+
+  /**
+   * View3d requires a div to be passed in, and it mounts the ThreeJS panel to that div.
+   * See if I can get away with just grabbing the child element of the div?
+   * Or it also seems like ThreeJS will just create its own div...
+   */
+
+  constructor(params: RenderCanvasStateParams) {
+    this.params = params;
+    this.viewContainer = document.createElement("div");
+    this.view3d = new View3d({ parentElement: this.viewContainer });
+    this.view3d.loaderContext = loaderContext;
+    this.setResolution(10, 10);
+    this.view3d.setShowAxis(true);
+    this.initLights();
+    this.view3d.setVolumeRenderMode(RENDERMODE_RAYMARCH);
+
+    this.tempCanvas = document.createElement("canvas");
+    this.tempCanvas.style.width = "10px";
+    this.tempCanvas.style.height = "10px";
+
+    this.onLoadFrameCallback = () => {};
+  }
+
+  private initLights() {
+    const lights = [new Light(SKY_LIGHT), new Light(AREA_LIGHT)];
+    lights[0].mColorTop = new Vector3(0.3, 0.3, 0.3);
+    lights[0].mColorMiddle = new Vector3(0.3, 0.3, 0.3);
+    lights[0].mColorBottom = new Vector3(0.3, 0.3, 0.3);
+    lights[1].mTheta = (14 * Math.PI) / 180.0;
+    lights[1].mPhi = (54 * Math.PI) / 180.0;
+    lights[1].mColor = new Vector3(0.3, 0.3, 0.3);
+    this.view3d.updateLights(lights);
+  }
+
+  get domElement(): HTMLCanvasElement {
+    // I hope this works
+    const view3dElement = this.view3d.getDOMElement();
+    if (view3dElement.children.length === 0) {
+      return this.tempCanvas;
+    }
+    return view3dElement.children[0] as HTMLCanvasElement;
+  }
+
+  get resolution(): Vector2 {
+    return new Vector2(this.viewContainer.clientWidth, this.viewContainer.clientHeight);
+  }
+
+  getScaleInfo(): CanvasScaleInfo {
+    return {
+      type: CanvasType.CANVAS_3D,
+    };
+  }
+
+  setResolution(width: number, height: number): void {
+    this.viewContainer.style.width = `${width}px`;
+    this.viewContainer.style.height = `${height}px`;
+    this.view3d.resize(null, width, height);
+  }
+
+  setParams(params: RenderCanvasStateParams): Promise<void> {
+    this.params = params;
+    return Promise.resolve();
+  }
+
+  setFrame(_requestedFrame: number): Promise<FrameLoadResult | null> {
+    if (this.volumePromise) {
+      return this.volumePromise;
+    }
+    const loadInitialVolume = async (): Promise<FrameLoadResult> => {
+      console.log("Awaiting onOpen");
+      await loaderContext.onOpen();
+
+      // Setup volume loader and load an example volume
+      console.log("Setting up loader");
+      const loader = await loaderContext.createLoader([
+        "https://animatedcell-test-data.s3.us-west-2.amazonaws.com/variance/1.zarr",
+        "https://animatedcell-test-data.s3.us-west-2.amazonaws.com/variance/2.zarr",
+      ]);
+      const loadSpec = new LoadSpec();
+      const volume = await loader.createVolume(loadSpec, (v: Volume, channelIndex: number) => {
+        const currentVol = v;
+
+        // currently, this must be called when channel data arrives (here in this callback)
+        this.view3d.onVolumeData(currentVol, [channelIndex]);
+
+        this.view3d.setVolumeChannelEnabled(currentVol, channelIndex, true);
+
+        // these calls tell the viewer that things are out of date
+        this.view3d.updateActiveChannels(currentVol);
+        this.view3d.updateLuts(currentVol);
+        this.view3d.redraw();
+        console.log("Volume loaded");
+      });
+      this.view3d.addVolume(volume);
+      this.view3d.updateDensity(volume, 12.5);
+      this.view3d.updateExposure(0.75);
+      await loader.loadVolumeData(volume);
+      this.render();
+      return {
+        frame: 0,
+        isFrameLoaded: true,
+        backdropKey: null,
+        isBackdropLoaded: true,
+      };
+    };
+    this.volumePromise = loadInitialVolume();
+    return this.volumePromise as Promise<FrameLoadResult>;
+  }
+
+  public setOnFrameLoadCallback(callback: (result: FrameLoadResult) => void): void {
+    this.onLoadFrameCallback = callback;
+  }
+
+  render(): void {
+    this.view3d.redraw();
+  }
+
+  dispose(): void {
+    this.view3d.removeAllVolumes();
+  }
+
+  getIdAtPixel(_x: number, _y: number): number {
+    return 0;
+  }
+}

--- a/src/colorizer/ColorizeCanvas3D.ts
+++ b/src/colorizer/ColorizeCanvas3D.ts
@@ -133,7 +133,7 @@ export class ColorizeCanvas3D implements IRenderCanvas {
       // Use colorize
       const lut = new Lut().createLabelColors(histogram);
       currentVol.setColorPalette(channelIndex, lut.lut);
-      currentVol.setColorPaletteAlpha(channelIndex, 0.5);
+      currentVol.setColorPaletteAlpha(channelIndex, 1.0);
 
       // these calls tell the viewer that things are out of date
       this.view3d.updateActiveChannels(currentVol);
@@ -152,14 +152,17 @@ export class ColorizeCanvas3D implements IRenderCanvas {
       emissiveColor: [0, 0, 0],
     });
 
-    this.view3d.updateDensity(volume, 50);
-    this.view3d.updateExposure(60);
+    this.view3d.updateDensity(volume, 0.5);
+    this.view3d.updateExposure(0.6);
     this.view3d.setVolumeRotation(volume, [0, 0, 0]);
     this.view3d.setVolumeTranslation(volume, [0, 0, 0]);
     this.view3d.setVolumeScale(volume, [1, 1, 1]);
     this.view3d.setShowBoundingBox(volume, true);
     this.view3d.setBoundingBoxColor(volume, [0.5, 0.5, 0.5]);
     this.view3d.resetCamera();
+    // TODO: Look at gamma/levels settings? Vole-app looks good at levels
+    // 0,75,255
+    // this.view3d.setGamma(volume, 0, 75, 255);
 
     this.loader = loader;
     this.volume = volume;

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -13,7 +13,7 @@ import { INTERNAL_BUILD } from "../constants";
 import { FlexColumn, FlexColumnAlignCenter, VisuallyHidden } from "../styles/utils";
 
 import CanvasUIOverlay from "../colorizer/CanvasOverlay";
-import { renderCanvasStateParamsSelector } from "../colorizer/IRenderCanvas";
+import { IRenderCanvas, renderCanvasStateParamsSelector } from "../colorizer/IRenderCanvas";
 import { useViewerStateStore } from "../state/ViewerState";
 import { AppThemeContext } from "./AppStyle";
 import { AlertBannerProps } from "./Banner";
@@ -85,7 +85,7 @@ const AnnotationModeContainer = styled(FlexColumnAlignCenter)`
 `;
 
 type CanvasWrapperProps = {
-  canv: CanvasUIOverlay;
+  canv: IRenderCanvas;
 
   loading: boolean;
   loadingProgress: number | null;
@@ -217,39 +217,39 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       stroke: theme.color.layout.borders,
       fill: theme.color.layout.background,
     };
-    canv.updateScaleBarStyle(defaultTheme);
-    canv.updateTimestampStyle(defaultTheme);
-    canv.updateInsetBoxStyle({ stroke: theme.color.layout.borders });
-    canv.updateLegendStyle(defaultTheme);
-    canv.updateFooterStyle(sidebarTheme);
-    canv.updateHeaderStyle(sidebarTheme);
+    // canv.updateScaleBarStyle(defaultTheme);
+    // canv.updateTimestampStyle(defaultTheme);
+    // canv.updateInsetBoxStyle({ stroke: theme.color.layout.borders });
+    // canv.updateLegendStyle(defaultTheme);
+    // canv.updateFooterStyle(sidebarTheme);
+    // canv.updateHeaderStyle(sidebarTheme);
   }, [theme]);
 
   // Update overlay settings
   useMemo(() => {
-    canv.isScaleBarVisible = showScaleBar;
+    // canv.isScaleBarVisible = showScaleBar;
   }, [showScaleBar]);
 
   useMemo(() => {
-    canv.isTimestampVisible = showTimestamp;
+    // canv.isTimestampVisible = showTimestamp;
   }, [showTimestamp]);
 
   useMemo(() => {
-    canv.setIsExporting(props.isRecording);
-    canv.isHeaderVisibleOnExport = showHeaderDuringExport;
-    canv.isFooterVisibleOnExport = showLegendDuringExport;
+    // canv.setIsExporting(props.isRecording);
+    // canv.isHeaderVisibleOnExport = showHeaderDuringExport;
+    // canv.isFooterVisibleOnExport = showLegendDuringExport;
   }, [showLegendDuringExport, props.isRecording]);
 
   useMemo(() => {
     const annotationLabels = props.annotationState.data.getLabels();
     const timeToAnnotationLabelIds = dataset ? props.annotationState.data.getTimeToLabelIdMap(dataset) : new Map();
-    canv.setAnnotationData(
-      annotationLabels,
-      timeToAnnotationLabelIds,
-      props.annotationState.currentLabelIdx,
-      props.annotationState.lastClickedId
-    );
-    canv.isAnnotationVisible = props.annotationState.visible;
+    // canv.setAnnotationData(
+    //   annotationLabels,
+    //   timeToAnnotationLabelIds,
+    //   props.annotationState.currentLabelIdx,
+    //   props.annotationState.lastClickedId
+    // );
+    // canv.isAnnotationVisible = props.annotationState.visible;
   }, [
     dataset,
     props.annotationState.data,
@@ -297,8 +297,8 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   useEffect(() => {
     canvasZoomInverse.current = 1.0;
     canvasPanOffset.current = new Vector2(0, 0);
-    canv.setZoom(1.0);
-    canv.setPan(0, 0);
+    // canv.setZoom(1.0);
+    // canv.setPan(0, 0);
   }, [collection]);
 
   /** Report clicked tracks via the passed callback. */
@@ -335,7 +335,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
     (zoomDelta: number): void => {
       canvasZoomInverse.current += zoomDelta;
       canvasZoomInverse.current = clamp(canvasZoomInverse.current, MIN_INVERSE_ZOOM, MAX_INVERSE_ZOOM);
-      canv.setZoom(1 / canvasZoomInverse.current);
+      // canv.setZoom(1 / canvasZoomInverse.current);
     },
     [canv]
   );
@@ -370,7 +370,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       canvasPanOffset.current.x = clamp(canvasPanOffset.current.x + mousePositionDelta.x, -0.5, 0.5);
       canvasPanOffset.current.y = clamp(canvasPanOffset.current.y + mousePositionDelta.y, -0.5, 0.5);
 
-      canv.setPan(canvasPanOffset.current.x, canvasPanOffset.current.y);
+      // canv.setPan(canvasPanOffset.current.x, canvasPanOffset.current.y);
     },
     [handleZoom, getCanvasSizePx, getFrameSizeInScreenPx]
   );
@@ -384,7 +384,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       // Clamp panning
       canvasPanOffset.current.x = clamp(canvasPanOffset.current.x, -0.5, 0.5);
       canvasPanOffset.current.y = clamp(canvasPanOffset.current.y, -0.5, 0.5);
-      canv.setPan(canvasPanOffset.current.x, canvasPanOffset.current.y);
+      // canv.setPan(canvasPanOffset.current.x, canvasPanOffset.current.y);
     },
     [canv, getCanvasSizePx, dataset]
   );
@@ -612,7 +612,11 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   );
 
   return (
-    <CanvasContainer ref={containerRef} $annotationModeEnabled={props.annotationState.isAnnotationModeEnabled}>
+    <CanvasContainer
+      ref={containerRef}
+      $annotationModeEnabled={props.annotationState.isAnnotationModeEnabled}
+      id="canvas-wrapper"
+    >
       {props.annotationState.isAnnotationModeEnabled && (
         <AnnotationModeContainer>Annotation editing in progress...</AnnotationModeContainer>
       )}
@@ -631,8 +635,8 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
             onClick={() => {
               canvasZoomInverse.current = 1.0;
               canvasPanOffset.current = new Vector2(0, 0);
-              canv.setZoom(1.0);
-              canv.setPan(0, 0);
+              // canv.setZoom(1.0);
+              // canv.setPan(0, 0);
             }}
             type="link"
           >

--- a/vite.config.js
+++ b/vite.config.js
@@ -35,10 +35,13 @@ export const DEFAULT_CONFIG = {
     },
   },
   optimizeDeps: {
-    // Temp patch for a bug where the worker couldn't be loaded, since it's a local path.
+    // vole-core uses a worker imported via local import (e.g. new
+    // URL('./local-worker.js', import.meta.url)). If vite bundles the worker,
+    // vole-core will not be able to find it at runtime. We exclude vole-core
+    // from dependency optimization here.
     exclude: ["@aics/vole-core"],
-    // Have to include all CommonJS dependencies of vole-core
-    // See https://vite.dev/config/dep-optimization-options#optimizedeps-exclude
+    // Have to still optimize all CommonJS dependencies of vole-core. See
+    // https://vite.dev/config/dep-optimization-options#optimizedeps-exclude
     include: ["@aics/vole-core > tweakpane", "@aics/vole-core > geotiff", "@aics/vole-core > throttled-queue"],
   },
   plugins: [svgr(), glsl(), react()],

--- a/vite.config.js
+++ b/vite.config.js
@@ -34,6 +34,13 @@ export const DEFAULT_CONFIG = {
       },
     },
   },
+  optimizeDeps: {
+    // Temp patch for a bug where the worker couldn't be loaded, since it's a local path.
+    exclude: ["@aics/vole-core"],
+    // Have to include all CommonJS dependencies of vole-core
+    // See https://vite.dev/config/dep-optimization-options#optimizedeps-exclude
+    include: ["@aics/vole-core > tweakpane", "@aics/vole-core > geotiff", "@aics/vole-core > throttled-queue"],
+  },
   plugins: [svgr(), glsl(), react()],
 };
 


### PR DESCRIPTION
Problem
=======
Closes #548, "3D -  Sync volume time with viewer time," and #546, "Show Vol-E viewer in viewport."

This change adds Vol-E to the project, and temporarily replaces the existing canvas viewport with the test 3D view.

Note that some existing functionality was temporarily broken, and will need to be fixed before this whole branch is merged back to main. For now, I've disabled panning, zooming, and style config in `CanvasWrapper`.

This change also won't support exporting until https://github.com/allen-cell-animated/vole-core/pull/301 is merged and the `vole-core` dependency version is bumped.

Solution
========
- Added `vole-core` to the project
- Added a fix in `vite.config.js` for a worker import issue in `vole-core`.
- Adds the new `ColorizeCanvas3D`, which configures and shows a test segmentation ZARR using `vole-core`'s `View3d`.
  - Synced time loading and playback between the viewer and the `ColorizeCanvas3D`.

## Type of change

* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

Steps to Verify:
----------------
1. Open preview link:

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
2. other important file

Thanks for contributing!
