### PR TITLE
feat: Added three cyclical color ramps 

### DIFF
--- a/src/colorizer/colors/color_ramps.ts
+++ b/src/colorizer/colors/color_ramps.ts
@@ -186,6 +186,54 @@ const rawColorRampData: RawColorData[] = [
     // seaborn.cubehelix_palette(start=2.3, rot=-0.3, as_cmap=True, reverse=True)
     colorStops: ["#0f3221", "#31673d", "#64945a", "#a0ba84", "#d9ddbf"],
   },
+  {
+    key: "fabio_crameri-romao",
+    name: "Crameri - RomaO (Cyclical)",
+    // Note: this is reversed from the original to match the other palettes
+    // which typically reserve warm colors for higher values.
+    colorStops: [
+      "#733957",
+      "#664476",
+      "#585893",
+      "#4F76AE",
+      "#5494C0",
+      "#6AB2CB",
+      "#8DCEDB",
+      "#B1DDD7",
+      "#CCE1B1",
+      "#D6D790",
+      "#CFBC66",
+      "#BC9540",
+      "#A9732E",
+      "#98572C",
+      "#8B4433",
+      "#7E3943",
+      "#733957",
+    ],
+  },
+  {
+    key: "fabio_crameri-viko",
+    name: "Crameri - VikO (Cyclical)",
+    colorStops: [
+      "#4F1A3D",
+      "#442551",
+      "#38396C",
+      "#345487",
+      "#43739F",
+      "#6895B6",
+      "#90AFC5",
+      "#BAC1C6",
+      "#D5BEB3",
+      "#D9AC94",
+      "#D0916F",
+      "#BE714B",
+      "#A34D2D",
+      "#842E1F",
+      "#6C1B21",
+      "#5B152C",
+      "#50193C",
+    ],
+  },
 ];
 
 // Convert the color stops into color ramps
@@ -222,5 +270,7 @@ export const DISPLAY_COLOR_RAMP_KEYS = [
   "esri-blue_red_8",
   "esri-green_brown_1",
   "matplotlib-purple_orange",
+  "fabio_crameri-romao",
+  "fabio_crameri-viko",
 ];
 export const DEFAULT_COLOR_RAMP_KEY = Array.from(colorRampMap.keys())[0];

--- a/src/colorizer/colors/color_ramps.ts
+++ b/src/colorizer/colors/color_ramps.ts
@@ -234,6 +234,29 @@ const rawColorRampData: RawColorData[] = [
       "#50193C",
     ],
   },
+  {
+    key: "fabio_crameri-broco",
+    name: "Crameri - BrocO (Cyclical)",
+    colorStops: [
+      "#372F38",
+      "#36344C",
+      "#39456A",
+      "#47608A",
+      "#5F7DA3",
+      "#7E99B8",
+      "#9FB4C8",
+      "#BDC8D0",
+      "#CFD3C6",
+      "#C9CAA9",
+      "#B3B284",
+      "#959462",
+      "#777646",
+      "#5C5A33",
+      "#484329",
+      "#3C352B",
+      "#372F37",
+    ],
+  },
 ];
 
 // Convert the color stops into color ramps
@@ -272,5 +295,6 @@ export const DISPLAY_COLOR_RAMP_KEYS = [
   "matplotlib-purple_orange",
   "fabio_crameri-romao",
   "fabio_crameri-viko",
+  "fabio_crameri-broco",
 ];
 export const DEFAULT_COLOR_RAMP_KEY = Array.from(colorRampMap.keys())[0];


### PR DESCRIPTION
Problem
=======
Closes #613, "cyclical color maps."

Some of the new simulation data coming out of ABM uses orientation as a feature. I've added a few cyclical color maps to help visualize them. I've checked with Jess and these three initial color maps were picked!

*Estimated review size: small, 5 minutes*

Solution
========
- Added three cyclical color ramps from Fabio Crameri: https://www.fabiocrameri.ch/cycliccolourmaps/

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-614/viewer?dataset=https%3A%2F%2Farcade-working-bucket.s3.us-west-2.amazonaws.com%2F0tfe%2Fcrawling_agents_tfe_demo%2Fmanifest.json&feature=orientation&color=fabio_crameri-romao
2. Switch between any of the color ramps at the bottom of the dropdown.

Screenshots (optional):
-----------------------

**Video talk-through (🔊):**

https://github.com/user-attachments/assets/6c52188b-f857-443f-a60e-46de0d73e041


https://github.com/user-attachments/assets/e1683670-4e9e-46f7-9919-406821b15081
