### PR TITLE
feature: Colorize + picking in TFE Viewport (3D MVP pt. 3)

### DIFF
--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -1,4 +1,4 @@
-import { RGBAFormat, RGBAIntegerFormat, Texture, Vector2 } from "three";
+import { DataTexture, RGBAFormat, RGBAIntegerFormat, Texture, Vector2 } from "three";
 
 import { MAX_FEATURE_CATEGORIES } from "../constants";
 import {
@@ -29,7 +29,7 @@ export type FeatureData = {
   name: string;
   key: string;
   data: Float32Array;
-  tex: Texture;
+  tex: DataTexture;
   min: number;
   max: number;
   unit: string;

--- a/src/colorizer/loaders/ILoader.ts
+++ b/src/colorizer/loaders/ILoader.ts
@@ -1,4 +1,4 @@
-import { Texture } from "three";
+import { DataTexture, Texture } from "three";
 
 import { FeatureArrayType, FeatureDataType } from "../types";
 
@@ -6,7 +6,7 @@ export interface ArraySource<T extends FeatureDataType> {
   /** Create a `TypedArray` of the specified type from this data source */
   getBuffer(): FeatureArrayType[T];
   /** Create a square texture of the specified type from this data source */
-  getTexture(): Texture;
+  getTexture(): DataTexture;
   /** Get the minimum value of the contained data */
   getMin(): number;
   /** Get the maximum value of the contained data */


### PR DESCRIPTION
Problem
=======
Closes #550, "3D - Colorize cells in 3D view" and #553, "3D - show highlight ID around selected cell."

*Estimated review size: small, 15 minutes*

NOTE: This branch will fail unit tests/linting until the corresponding PR https://github.com/allen-cell-animated/vole-core/pull/302 is merged and released. 

Solution
========
- Updates `vole-core` to ()
- Changes ILoader type to specify `DataTexture` for `vole-core` colorize compatibility.
- Syncs colorizing and highlighted tracks with the `vole-core` `View3d` viewer.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open preview link:
2. Click around 

(Note that not all functionality works yet: see notes in attached video.)

Screenshots (optional):
-----------------------
Show-n-tell images/animations here
