### PR TITLE
refactor: Added compatibility between `ColorizeCanvas3D` and `OverlayCanvas`.

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -679,7 +679,7 @@ function Viewer(): ReactElement {
               totalFrames={dataset?.numberOfFrames || 0}
               setFrame={setFrame}
               getCanvasExportDimensions={() => canv.getExportDimensions()}
-              getCanvas={() => canv.domElement}
+              getCanvas={() => canv.canvas}
               // Stop playback when exporting
               onClick={() => timeControls.pause()}
               currentFrame={currentFrame}

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -101,6 +101,9 @@ export default class CanvasOverlay implements IRenderCanvas {
     this.canvasElement.style.display = "block";
     // Let mouse events pass through to the inner canvas.
     this.canvasElement.style.pointerEvents = "none";
+    // Ensure the canvas is rendered on top of the inner canvas.
+    this.canvasElement.style.position = "relative";
+    this.canvasElement.style.zIndex = "1";
 
     // Set up DOM elements, which are structured like:
     // canvasContainerDiv
@@ -111,7 +114,6 @@ export default class CanvasOverlay implements IRenderCanvas {
     this.canvasContainerDiv.style.position = "relative";
     this.canvasContainerDiv.style.width = "100%";
     this.canvasContainerDiv.style.height = "100%";
-    this.canvasContainerDiv.style.zIndex = "1";
 
     this.innerCanvasContainerDiv = document.createElement("div");
     this.innerCanvasContainerDiv.appendChild(this.innerCanvas.domElement);
@@ -123,8 +125,8 @@ export default class CanvasOverlay implements IRenderCanvas {
     this.canvasElement.style.top = "0px";
     this.canvasElement.style.left = "0px";
 
-    this.canvasContainerDiv.appendChild(this.canvasElement);
     this.canvasContainerDiv.appendChild(this.innerCanvasContainerDiv);
+    this.canvasContainerDiv.appendChild(this.canvasElement);
 
     this.onFrameLoadCallback = () => {};
 
@@ -385,7 +387,7 @@ export default class CanvasOverlay implements IRenderCanvas {
     this.ctx.imageSmoothingEnabled = false;
 
     if (doesInnerCanvasNeedRender || this.isExporting) {
-      this.innerCanvas.render();
+      this.innerCanvas.render(this.isExporting);
     }
     if (this.isExporting && this.innerCanvas.canvas.width !== 0 && this.innerCanvas.canvas.height !== 0) {
       // In export mode only, draw the inner canvas inside of the overlay

--- a/src/colorizer/ColorizeCanvas2D.ts
+++ b/src/colorizer/ColorizeCanvas2D.ts
@@ -260,6 +260,10 @@ export default class ColorizeCanvas2D implements IRenderCanvas {
     return this.renderer.domElement;
   }
 
+  public get canvas(): HTMLCanvasElement {
+    return this.renderer.domElement;
+  }
+
   private checkPixelRatio(): void {
     if (this.renderer.getPixelRatio() !== window.devicePixelRatio) {
       this.renderer.setPixelRatio(window.devicePixelRatio);

--- a/src/colorizer/ColorizeCanvas3D.ts
+++ b/src/colorizer/ColorizeCanvas3D.ts
@@ -73,7 +73,13 @@ export class ColorizeCanvas3D implements IRenderCanvas {
     this.view3d.updateLights(lights);
   }
 
-  get domElement(): HTMLCanvasElement {
+  get domElement(): HTMLElement {
+    return this.view3d.getDOMElement();
+  }
+
+  get canvas(): HTMLCanvasElement {
+    // TODO: Temp fix while the colorizing and picking branch needs merge from
+    // main
     return this.view3d.getDOMElement() as unknown as HTMLCanvasElement;
   }
 
@@ -81,7 +87,7 @@ export class ColorizeCanvas3D implements IRenderCanvas {
     return this.canvasResolution.clone();
   }
 
-  getScaleInfo(): CanvasScaleInfo {
+  get scaleInfo(): CanvasScaleInfo {
     return {
       type: CanvasType.CANVAS_3D,
     };
@@ -208,9 +214,9 @@ export class ColorizeCanvas3D implements IRenderCanvas {
       this.pendingFrame = -1;
       return Promise.resolve({
         frame: this.currentFrame,
-        isFrameLoaded: true,
+        frameError: false,
         backdropKey: null,
-        isBackdropLoaded: true,
+        backdropError: false,
       });
     }
     if (requestedFrame === this.pendingFrame && this.pendingVolumePromise) {
@@ -228,11 +234,11 @@ export class ColorizeCanvas3D implements IRenderCanvas {
       this.render(true);
       this.currentFrame = requestedFrame;
       this.pendingFrame = -1;
-      const result = {
+      const result: FrameLoadResult = {
         frame: requestedFrame,
-        isFrameLoaded: true,
+        frameError: false,
         backdropKey: null,
-        isBackdropLoaded: true,
+        backdropError: false,
       };
       this.onLoadFrameCallback(result);
       return result;

--- a/src/colorizer/ColorizeCanvas3D.ts
+++ b/src/colorizer/ColorizeCanvas3D.ts
@@ -78,9 +78,7 @@ export class ColorizeCanvas3D implements IRenderCanvas {
   }
 
   get canvas(): HTMLCanvasElement {
-    // TODO: Temp fix while the colorizing and picking branch needs merge from
-    // main
-    return this.view3d.getDOMElement() as unknown as HTMLCanvasElement;
+    return this.view3d.getCanvasDOMElement();
   }
 
   get resolution(): Vector2 {
@@ -260,12 +258,9 @@ export class ColorizeCanvas3D implements IRenderCanvas {
     this.view3d.setSelectedID(this.volume, 0, id + 1);
   }
 
-  render(_synchronous = false): void {
+  render(synchronous = false): void {
     this.syncSelectedId();
-    // this.view3d.redraw();
-    // TODO: Change to below line once vole-core is patched
-    // this.view3d.redraw(synchronous);
-    this.view3d.redraw();
+    this.view3d.redraw(synchronous);
   }
 
   dispose(): void {

--- a/src/colorizer/IRenderCanvas.ts
+++ b/src/colorizer/IRenderCanvas.ts
@@ -58,13 +58,19 @@ export const renderCanvasStateParamsSelector = (state: ViewerStoreState): Render
  * A canvas that renders timelapse data.
  */
 export interface IRenderCanvas {
-  get domElement(): HTMLCanvasElement;
+  /**
+   * Returns a DOM element that can be used to mount the canvas.
+   */
+  get domElement(): HTMLElement;
+
+  get canvas(): HTMLCanvasElement;
 
   /** (X,Y) resolution of the canvas, in pixels. */
   get resolution(): Vector2;
 
   /** Gets information about canvas scaling. Switches types for 2D and 3D
-   * canvases. */
+   * canvases.
+   */
   get scaleInfo(): CanvasScaleInfo;
 
   setResolution(width: number, height: number): void;
@@ -74,6 +80,7 @@ export interface IRenderCanvas {
    * `CanvasStateParams` for a complete list of parameters required.
    */
   setParams(params: RenderCanvasStateParams): Promise<void>;
+
   /**
    * Requests to load and render the image data for a specific frame.
    * @param requestedFrame The frame number to load and render.
@@ -88,10 +95,12 @@ export interface IRenderCanvas {
   setOnFrameLoadCallback(callback: (result: FrameLoadResult) => void): void;
 
   render(): void;
+
   /**
    * Disposes of the canvas and its resources.
    */
   dispose(): void;
+
   /**
    * Gets the ID of the segmentation at a pixel coordinate in the canvas, where
    * `(0,0)` is the top left corner.

--- a/src/colorizer/IRenderCanvas.ts
+++ b/src/colorizer/IRenderCanvas.ts
@@ -94,7 +94,7 @@ export interface IRenderCanvas {
    */
   setOnFrameLoadCallback(callback: (result: FrameLoadResult) => void): void;
 
-  render(): void;
+  render(synchronous?: boolean): void;
 
   /**
    * Disposes of the canvas and its resources.

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -566,8 +566,6 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
 
   // RENDERING /////////////////////////////////////////////////
 
-  canv.render();
-
   const onViewerSettingsLinkClicked = (): void => {
     setOpenTab(TabType.SETTINGS);
   };

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -1,6 +1,6 @@
 import { HomeOutlined, ZoomInOutlined, ZoomOutOutlined } from "@ant-design/icons";
 import { Tooltip } from "antd";
-import React, { ReactElement, ReactNode, useCallback, useContext, useEffect, useRef } from "react";
+import React, { ReactElement, ReactNode, useCallback, useContext, useEffect, useMemo, useRef } from "react";
 import styled from "styled-components";
 import { Vector2 } from "three";
 import { clamp } from "three/src/math/MathUtils";
@@ -12,7 +12,8 @@ import { AnnotationState } from "../colorizer/utils/react_utils";
 import { INTERNAL_BUILD } from "../constants";
 import { FlexColumn, FlexColumnAlignCenter, VisuallyHidden } from "../styles/utils";
 
-import { IRenderCanvas, renderCanvasStateParamsSelector } from "../colorizer/IRenderCanvas";
+import CanvasOverlay from "../colorizer/CanvasOverlay";
+import { renderCanvasStateParamsSelector } from "../colorizer/IRenderCanvas";
 import { useViewerStateStore } from "../state/ViewerState";
 import { AppThemeContext } from "./AppStyle";
 import { AlertBannerProps } from "./Banner";
@@ -84,7 +85,7 @@ const AnnotationModeContainer = styled(FlexColumnAlignCenter)`
 `;
 
 type CanvasWrapperProps = {
-  canv: IRenderCanvas;
+  canv: CanvasOverlay;
 
   loading: boolean;
   loadingProgress: number | null;
@@ -133,10 +134,10 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   const setBackdropVisible = useViewerStateStore((state) => state.setBackdropVisible);
   const setOpenTab = useViewerStateStore((state) => state.setOpenTab);
   const setTrack = useViewerStateStore((state) => state.setTrack);
-  // const showHeaderDuringExport = useViewerStateStore((state) => state.showHeaderDuringExport);
-  // const showLegendDuringExport = useViewerStateStore((state) => state.showLegendDuringExport);
-  // const showScaleBar = useViewerStateStore((state) => state.showScaleBar);
-  // const showTimestamp = useViewerStateStore((state) => state.showTimestamp);
+  const showHeaderDuringExport = useViewerStateStore((state) => state.showHeaderDuringExport);
+  const showLegendDuringExport = useViewerStateStore((state) => state.showLegendDuringExport);
+  const showScaleBar = useViewerStateStore((state) => state.showScaleBar);
+  const showTimestamp = useViewerStateStore((state) => state.showTimestamp);
   const frameLoadResult = useViewerStateStore((state) => state.frameLoadResult);
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -153,6 +154,10 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       canv.setParams(params);
     });
   }, []);
+
+  // TODO: Move management of the zoom/pan into the canvas class itself (or a
+  // helper). CanvasWrapper should have a way to zoom in/out and reset the view,
+  // but otherwise doesn't need to track the zoom/pan state.
 
   /**
    * Canvas zoom level, stored as its inverse. This makes it so linear changes in zoom level
@@ -207,62 +212,58 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   // if these were useEffects, the canvas will lag behind updates since there is no state update to
   // trigger a re-render.
 
-  // TODO: Uncomment these once ColorizeCanvas3D is compatible with
-  // CanvasUIOverlay. I could also move this into global state and have
-  // it be handled by `canvas.setParams`.
-
   // Update the theming of the canvas overlay.
-  // useMemo(() => {
-  //   const defaultTheme = {
-  //     fontSizePx: theme.font.size.label,
-  //     fontColor: theme.color.text.primary,
-  //     fontFamily: theme.font.family,
-  //   };
-  //   const sidebarTheme = {
-  //     ...defaultTheme,
-  //     stroke: theme.color.layout.borders,
-  //     fill: theme.color.layout.background,
-  //   };
-  //   canv.updateScaleBarStyle(defaultTheme);
-  //   canv.updateTimestampStyle(defaultTheme);
-  //   canv.updateInsetBoxStyle({ stroke: theme.color.layout.borders });
-  //   canv.updateLegendStyle(defaultTheme);
-  //   canv.updateFooterStyle(sidebarTheme);
-  //   canv.updateHeaderStyle(sidebarTheme);
-  // }, [theme]);
+  useMemo(() => {
+    const defaultTheme = {
+      fontSizePx: theme.font.size.label,
+      fontColor: theme.color.text.primary,
+      fontFamily: theme.font.family,
+    };
+    const sidebarTheme = {
+      ...defaultTheme,
+      stroke: theme.color.layout.borders,
+      fill: theme.color.layout.background,
+    };
+    canv.updateScaleBarStyle(defaultTheme);
+    canv.updateTimestampStyle(defaultTheme);
+    canv.updateInsetBoxStyle({ stroke: theme.color.layout.borders });
+    canv.updateLegendStyle(defaultTheme);
+    canv.updateFooterStyle(sidebarTheme);
+    canv.updateHeaderStyle(sidebarTheme);
+  }, [theme]);
 
   // Update overlay settings
-  // useMemo(() => {
-  //   canv.isScaleBarVisible = showScaleBar;
-  // }, [showScaleBar]);
+  useMemo(() => {
+    canv.isScaleBarVisible = showScaleBar;
+  }, [showScaleBar]);
 
-  // useMemo(() => {
-  //   canv.isTimestampVisible = showTimestamp;
-  // }, [showTimestamp]);
+  useMemo(() => {
+    canv.isTimestampVisible = showTimestamp;
+  }, [showTimestamp]);
 
-  // useMemo(() => {
-  //   canv.setIsExporting(props.isRecording);
-  //   canv.isHeaderVisibleOnExport = showHeaderDuringExport;
-  //   canv.isFooterVisibleOnExport = showLegendDuringExport;
-  // }, [showLegendDuringExport, props.isRecording]);
+  useMemo(() => {
+    canv.setIsExporting(props.isRecording);
+    canv.isHeaderVisibleOnExport = showHeaderDuringExport;
+    canv.isFooterVisibleOnExport = showLegendDuringExport;
+  }, [showLegendDuringExport, props.isRecording]);
 
-  // useMemo(() => {
-  //   const annotationLabels = props.annotationState.data.getLabels();
-  //   const timeToAnnotationLabelIds = dataset ? props.annotationState.data.getTimeToLabelIdMap(dataset) : new Map();
-  //   canv.setAnnotationData(
-  //     annotationLabels,
-  //     timeToAnnotationLabelIds,
-  //     props.annotationState.currentLabelIdx,
-  //     props.annotationState.lastClickedId
-  //   );
-  //   canv.isAnnotationVisible = props.annotationState.visible;
-  // }, [
-  //   dataset,
-  //   props.annotationState.data,
-  //   props.annotationState.lastClickedId,
-  //   props.annotationState.currentLabelIdx,
-  //   props.annotationState.visible,
-  // ]);
+  useMemo(() => {
+    const annotationLabels = props.annotationState.data.getLabels();
+    const timeToAnnotationLabelIds = dataset ? props.annotationState.data.getTimeToLabelIdMap(dataset) : new Map();
+    canv.setAnnotationData(
+      annotationLabels,
+      timeToAnnotationLabelIds,
+      props.annotationState.currentLabelIdx,
+      props.annotationState.lastClickedId
+    );
+    canv.isAnnotationVisible = props.annotationState.visible;
+  }, [
+    dataset,
+    props.annotationState.data,
+    props.annotationState.lastClickedId,
+    props.annotationState.currentLabelIdx,
+    props.annotationState.visible,
+  ]);
 
   // CANVAS RESIZING /////////////////////////////////////////////////
 
@@ -341,7 +342,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
     (zoomDelta: number): void => {
       canvasZoomInverse.current += zoomDelta;
       canvasZoomInverse.current = clamp(canvasZoomInverse.current, MIN_INVERSE_ZOOM, MAX_INVERSE_ZOOM);
-      // canv.setZoom(1 / canvasZoomInverse.current);
+      canv.setZoom(1 / canvasZoomInverse.current);
     },
     [canv]
   );
@@ -376,7 +377,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       canvasPanOffset.current.x = clamp(canvasPanOffset.current.x + mousePositionDelta.x, -0.5, 0.5);
       canvasPanOffset.current.y = clamp(canvasPanOffset.current.y + mousePositionDelta.y, -0.5, 0.5);
 
-      // canv.setPan(canvasPanOffset.current.x, canvasPanOffset.current.y);
+      canv.setPan(canvasPanOffset.current.x, canvasPanOffset.current.y);
     },
     [handleZoom, getCanvasSizePx, getFrameSizeInScreenPx]
   );
@@ -390,7 +391,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       // Clamp panning
       canvasPanOffset.current.x = clamp(canvasPanOffset.current.x, -0.5, 0.5);
       canvasPanOffset.current.y = clamp(canvasPanOffset.current.y, -0.5, 0.5);
-      // canv.setPan(canvasPanOffset.current.x, canvasPanOffset.current.y);
+      canv.setPan(canvasPanOffset.current.x, canvasPanOffset.current.y);
     },
     [canv, getCanvasSizePx, dataset]
   );
@@ -635,8 +636,8 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
             onClick={() => {
               canvasZoomInverse.current = 1.0;
               canvasPanOffset.current = new Vector2(0, 0);
-              // canv.setZoom(1.0);
-              // canv.setPan(0, 0);
+              canv.setZoom(1.0);
+              canv.setPan(0, 0);
             }}
             type="link"
           >


### PR DESCRIPTION
Problem
=======
This PR continues work on #545 (3D viewport MVP), and restores a lot of OverlayCanvas functionality that I had to previously disable!

Before, the OverlayCanvas would request its inner canvas to render, then take the resulting image and draw it into its own canvas before compositing additional elements on top of it. This was necessary so that, in Export mode, we could get the viewport image from a single canvas. This had some issues, however, namely requiring that OverlayCanvas re-render every time its inner canvas rendered or else we would get desyncs. Additionally, all canvas interaction needed to be forwarded to the inner canvas, which broke orbit controls in the 3D canvas.

This change makes the OverlayCanvas transparent, and mounts the inner canvas behind it. This means that the two of them can be on independent rendering timings and allows 3D trackball interactions to work. In Export mode, OverlayCanvas reverts to the old method of manually drawing the inner canvas into itself.

Solution
========
What I/we did to solve this problem

with @pairperson1


Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
2. other important file

Thanks for contributing!
