### PR TITLE
fix: URL is synced after initial load

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -180,8 +180,6 @@ function Viewer(): ReactElement {
 
   // EVENT LISTENERS ////////////////////////////////////////////////////////
   const updateUrlParams = useCallback(
-    // TODO: Update types for makeDebouncedCallback since right now it requires
-    // an argument (even if it's a dummy one) to be passed to the callback.
     makeDebouncedCallback(() => {
       if (isInitialDatasetLoaded) {
         const params = serializeViewerState(useViewerStateStore.getState());
@@ -190,6 +188,13 @@ function Viewer(): ReactElement {
     }),
     [isInitialDatasetLoaded]
   );
+
+  useEffect(() => {
+    // Update the URL parameters once after the dataset is loaded for the first time.
+    if (isInitialDatasetLoaded) {
+      updateUrlParams();
+    }
+  }, [isInitialDatasetLoaded]);
 
   useEffect(() => {
     return useViewerStateStore.subscribe(selectSerializationDependencies, (state, prevState) => {
@@ -204,7 +209,7 @@ function Viewer(): ReactElement {
       ) {
         return;
       }
-      updateUrlParams(state);
+      updateUrlParams();
     });
   }, [isRecording, updateUrlParams]);
 

--- a/src/state/utils/store_utils.ts
+++ b/src/state/utils/store_utils.ts
@@ -40,23 +40,23 @@ export const addDerivedStateSubscriber = <T, const U>(
  * @param debounceMs The number of milliseconds to wait before calling the
  * debounced callback. Defaults to 250ms.
  */
-export const makeDebouncedCallback = <T, U, CallbackFn extends (args: T) => Partial<U> | undefined | void>(
-  callback: CallbackFn,
+export const makeDebouncedCallback = <T extends (...args: any) => any>(
+  callback: T,
   debounceMs: number = 250
-): ((args: T) => void) => {
+): ((...args: Parameters<T>) => void) => {
   // TODO: Compare arguments to lastArgs to allow repeated calls with the same
   // arguments.
   let timeout: ReturnType<typeof setTimeout> | null = null;
-  let lastArgs: T | null = null;
+  let lastArgs: Parameters<T> | null = null;
 
-  return (args: T): void => {
+  return (...args: Parameters<T>): void => {
     lastArgs = args;
     if (timeout) {
       clearTimeout(timeout);
     }
     timeout = setTimeout(() => {
       if (lastArgs) {
-        callback(lastArgs);
+        callback(...lastArgs);
       }
       timeout = null;
     }, debounceMs);


### PR DESCRIPTION
Problem
=======
Closes #615, "URL does not update after initial load."

This fixes a bug where the URL would not be synced after initial load, and would not update until a state update was triggered. This change ensures that URL contains all current state information right after the first load.

*Estimated review size: tiny, <5 minutes*

Solution
========
- Fixed types on `makeDebouncedCallback`.
- Triggered a URL sync after the initial dataset is loaded.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open the preview link here: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-623/viewer?dataset=https://raw.githubusercontent.com/allen-cell-animated/colorizer-data/refs/heads/main/documentation/getting_started_guide/example/processed_dataset/manifest.json

The URL should be changed from this:
```
https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-623/viewer
?dataset=https://raw.githubusercontent.com/allen-cell-animated/colorizer-data/refs/heads/main/documentation/getting_started_guide/example/processed_dataset/manifest.json
```
to this:
```
https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-623/viewer
?dataset=https%3A%2F%2Fraw.githubusercontent.com%2Fallen-cell-animated%2Fcolorizer-data%2Frefs%2Fheads%2Fmain%2Fdocumentation%2Fgetting_started_guide%2Fexample%2Fprocessed_dataset%2Fmanifest.json
&feature=area&t=0&color=matplotlib-cool&keep-range=0&range=113.100%2C907.900&palette-key=adobe&path=1
&scalebar=1&timestamp=1&filter-color=dddddd&filter-mode=1&outlier-color=c0c0c0&outlier-mode=1
&outline-color=ff00ff&tab=track_plot&scatter-range=all&bg=0&bg-brightness=100&bg-sat=100&fg-alpha=50
&vc=0&vc-key=_motion_&vc-color=000000&vc-scale=4&vc-tooltip=m&vc-time-int=5
```
