### PR TITLE
feature: Support for 3D dataset definitions (3D MVP pt. 4b)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "timelapse-colorizer",
       "version": "1.2.1",
       "dependencies": {
-        "@aics/vole-core": "^3.13.1",
+        "@aics/vole-core": "^3.14.1",
         "@ant-design/icons": "^5.2.5",
         "@fortawesome/fontawesome-svg-core": "^6.5.1",
         "@fortawesome/free-solid-svg-icons": "^6.5.1",
@@ -71,9 +71,9 @@
       "dev": true
     },
     "node_modules/@aics/vole-core": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-3.13.1.tgz",
-      "integrity": "sha512-pg8w2ZikxkfUgW9I1ahJUwlXwfVQw6H2ovAuOytmpwjAyaAFqFkiqebzf3Ygt62VMT/quQGs4bjxHGi1g4tZlw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-3.14.1.tgz",
+      "integrity": "sha512-CtLwx3x0wg7Rf/NGYGTjrvulVtDMZrCXGjqyEp3sUk1UIFPq/4yzID5lWMJYFfLfKx0bactCvE72NZuUE5tKyQ==",
       "dependencies": {
         "@babel/runtime": "^7.25.6",
         "geotiff": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "vitest-canvas-mock": "^0.3.3"
   },
   "dependencies": {
-    "@aics/vole-core": "^3.13.1",
+    "@aics/vole-core": "^3.14.1",
     "@ant-design/icons": "^5.2.5",
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -91,7 +91,7 @@ function Viewer(): ReactElement {
     canvas.domElement.className = styles.colorizeCanvas;
     // Report frame load results to the store
     canvas.setOnFrameLoadCallback((result) => {
-      useViewerStateStore.getState().setFrameLoadResult;
+      useViewerStateStore.getState().setFrameLoadResult(result);
       useViewerStateStore.setState({ currentFrame: result.frame });
     });
     useViewerStateStore.getState().setFrameLoadCallback(async (frame: number) => await canvas.setFrame(frame));

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -90,7 +90,10 @@ function Viewer(): ReactElement {
     const canvas = new CanvasOverlay(stateDeps);
     canvas.domElement.className = styles.colorizeCanvas;
     // Report frame load results to the store
-    canvas.setOnFrameLoadCallback(useViewerStateStore.getState().setFrameLoadResult);
+    canvas.setOnFrameLoadCallback((result) => {
+      useViewerStateStore.getState().setFrameLoadResult;
+      useViewerStateStore.setState({ currentFrame: result.frame });
+    });
     useViewerStateStore.getState().setFrameLoadCallback(async (frame: number) => await canvas.setFrame(frame));
     return canvas;
   });

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -42,8 +42,7 @@ import { loadInitialCollectionAndDataset } from "./utils/dataset_load_utils";
 
 import CanvasOverlay from "./colorizer/CanvasOverlay";
 import Collection from "./colorizer/Collection";
-import ColorizeCanvas2D, { BACKGROUND_ID } from "./colorizer/ColorizeCanvas2D";
-import { ColorizeCanvas3D } from "./colorizer/ColorizeCanvas3D";
+import { BACKGROUND_ID } from "./colorizer/ColorizeCanvas2D";
 import { FeatureType } from "./colorizer/Dataset";
 import { renderCanvasStateParamsSelector } from "./colorizer/IRenderCanvas";
 import UrlArrayLoader from "./colorizer/loaders/UrlArrayLoader";
@@ -88,12 +87,7 @@ function Viewer(): ReactElement {
 
   const canv: CanvasOverlay = useConstructor(() => {
     const stateDeps = renderCanvasStateParamsSelector(useViewerStateStore.getState());
-    // TODO: Once Datasets can report whether they are 2D or 3D, CanvasOverlay
-    // should construct and swap between the two types of canvases on its own.
-    const use3DCanvas = true;
-    const innerCanvas = use3DCanvas ? new ColorizeCanvas3D(stateDeps) : new ColorizeCanvas2D();
-
-    const canvas = new CanvasOverlay(innerCanvas, stateDeps);
+    const canvas = new CanvasOverlay(stateDeps);
     canvas.domElement.className = styles.colorizeCanvas;
     // Report frame load results to the store
     canvas.setOnFrameLoadCallback(useViewerStateStore.getState().setFrameLoadResult);

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -48,6 +48,7 @@ export default class CanvasOverlay implements IRenderCanvas {
   private canvasElement: HTMLCanvasElement;
 
   private innerCanvas2d: ColorizeCanvas2D;
+  // Initialization of inner canvas is deferred until needed.
   private innerCanvas3d: ColorizeCanvas3D | null;
 
   private innerCanvas: IRenderCanvas;
@@ -272,7 +273,7 @@ export default class CanvasOverlay implements IRenderCanvas {
     const prevParams = this.params;
     this.params = params;
 
-    // If the dataset has changed, construct and initialize the inner
+    // If the dataset has changed types, construct and initialize the inner
     // canvas.
     if (hasPropertyChanged(params, prevParams, ["dataset"])) {
       if (params.dataset) {
@@ -281,7 +282,9 @@ export default class CanvasOverlay implements IRenderCanvas {
           await this.setCanvas(this.innerCanvas2d);
         } else if (params.dataset.has3dFrames() && this.innerCanvasType !== CanvasType.CANVAS_3D) {
           this.innerCanvasType = CanvasType.CANVAS_3D;
-          this.innerCanvas3d = new ColorizeCanvas3D();
+          if (!this.innerCanvas3d) {
+            this.innerCanvas3d = new ColorizeCanvas3D();
+          }
           await this.setCanvas(this.innerCanvas3d);
         }
       }

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -48,7 +48,7 @@ export default class CanvasOverlay implements IRenderCanvas {
   private canvasElement: HTMLCanvasElement;
 
   private innerCanvas2d: ColorizeCanvas2D;
-  // Initialization of inner canvas is deferred until needed.
+  // Initialization of inner 3D canvas is deferred until needed.
   private innerCanvas3d: ColorizeCanvas3D | null;
 
   private innerCanvas: IRenderCanvas;

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -275,22 +275,27 @@ export default class CanvasOverlay implements IRenderCanvas {
 
     // If the dataset has changed types, construct and initialize the inner
     // canvas.
+    let hasUpdatedCanvasParams = false;
     if (hasPropertyChanged(params, prevParams, ["dataset"])) {
       if (params.dataset) {
         if (params.dataset.has2dFrames() && this.innerCanvasType !== CanvasType.CANVAS_2D) {
           this.innerCanvasType = CanvasType.CANVAS_2D;
           await this.setCanvas(this.innerCanvas2d);
+          hasUpdatedCanvasParams = true;
         } else if (params.dataset.has3dFrames() && this.innerCanvasType !== CanvasType.CANVAS_3D) {
           this.innerCanvasType = CanvasType.CANVAS_3D;
           if (!this.innerCanvas3d) {
             this.innerCanvas3d = new ColorizeCanvas3D();
           }
           await this.setCanvas(this.innerCanvas3d);
+          hasUpdatedCanvasParams = true;
         }
       }
     }
 
-    await this.innerCanvas.setParams(params);
+    if (!hasUpdatedCanvasParams) {
+      await this.innerCanvas.setParams(params);
+    }
 
     // Inner canvas will re-render on setParams, so it doesn't need
     // to be re-rendered here.

--- a/src/colorizer/ColorizeCanvas3D.ts
+++ b/src/colorizer/ColorizeCanvas3D.ts
@@ -114,6 +114,7 @@ export class ColorizeCanvas3D implements IRenderCanvas {
           outlierDrawMode: this.params.outlierDrawSettings.mode,
           outOfRangeDrawMode: this.params.outOfRangeDrawSettings.mode,
           hideOutOfRange: this.params.outOfRangeDrawSettings.mode === DrawMode.HIDE,
+          timeToIdOffset: dataset.frameIdOffset ?? new Uint32Array([0]),
         };
         // TODO: This needs to be called again AFTER each channel has loaded.
         // Maybe setup this colorizing in the volume loader callback?

--- a/src/colorizer/ColorizeCanvas3D.ts
+++ b/src/colorizer/ColorizeCanvas3D.ts
@@ -124,7 +124,7 @@ export class ColorizeCanvas3D implements IRenderCanvas {
           outlierDrawMode: this.params.outlierDrawSettings.mode,
           outOfRangeDrawMode: this.params.outOfRangeDrawSettings.mode,
           hideOutOfRange: this.params.outOfRangeDrawSettings.mode === DrawMode.HIDE,
-          timeToIdOffset: dataset.frameIdOffset ?? new Uint32Array([0]),
+          timeToIdOffset: dataset.frameToIdOffset ?? new Uint32Array([0]),
         };
         // TODO: This needs to be called again AFTER each channel has loaded.
         // Maybe setup this colorizing in the volume loader callback?
@@ -310,7 +310,7 @@ export class ColorizeCanvas3D implements IRenderCanvas {
     // during colorizer setup.
     if (this.volume?.isLoaded() && dataset) {
       const frameLocalId = this.view3d.hitTest(x, y);
-      const offset = dataset.frameIdOffset ? dataset.frameIdOffset[this.currentFrame] : 0;
+      const offset = dataset.frameToIdOffset ? dataset.frameToIdOffset[this.currentFrame] : 0;
       const id = frameLocalId <= 0 ? 0 : frameLocalId + offset;
       return id - 1;
     }

--- a/src/colorizer/ColorizeCanvas3D.ts
+++ b/src/colorizer/ColorizeCanvas3D.ts
@@ -163,13 +163,13 @@ export class ColorizeCanvas3D implements IRenderCanvas {
     }
 
     if (hasPropertyChanged(params, prevParams, ["dataset"])) {
-      if (params.dataset !== null && params.dataset.has3dFrames() && params.dataset.frames3dSrc) {
+      if (params.dataset !== null && params.dataset.has3dFrames() && params.dataset.frames3d) {
         if (this.volume) {
           this.view3d.removeAllVolumes();
           this.volume.cleanup();
           this.volume = null;
         }
-        this.initializingVolumePromise = this.loadNewVolume(params.dataset.frames3dSrc);
+        this.initializingVolumePromise = this.loadNewVolume(params.dataset.frames3d.source);
         this.initializingVolumePromise.then(() => {
           this.setFrame(params.pendingFrame);
         });
@@ -205,7 +205,7 @@ export class ColorizeCanvas3D implements IRenderCanvas {
     });
     this.view3d.addVolume(volume);
 
-    const segChannel = this.params.dataset?.segmentationChannel ?? 0;
+    const segChannel = this.params.dataset?.frames3d?.segmentationChannel ?? 0;
     this.view3d.setVolumeChannelEnabled(volume, segChannel, true);
     this.view3d.setVolumeChannelOptions(volume, segChannel, {
       isosurfaceEnabled: false,
@@ -290,7 +290,7 @@ export class ColorizeCanvas3D implements IRenderCanvas {
       return;
     }
     const id = this.params.track ? this.params.track.getIdAtTime(this.currentFrame) : -1;
-    this.view3d.setSelectedID(this.volume, this.params.dataset.segmentationChannel ?? 0, id + 1);
+    this.view3d.setSelectedID(this.volume, this.params.dataset.frames3d?.segmentationChannel ?? 0, id + 1);
   }
 
   render(synchronous = false): void {
@@ -304,9 +304,6 @@ export class ColorizeCanvas3D implements IRenderCanvas {
 
   getIdAtPixel(x: number, y: number): number {
     const dataset = this.params?.dataset;
-    // TODO: Currently `View3d.hitTest` reports the per-frame IDs, not global IDs.
-    // Ideally, vole-core should handle this based on the frame ID offset array that's passed into it
-    // during colorizer setup.
     if (this.volume?.isLoaded() && dataset) {
       const frameLocalId = this.view3d.hitTest(x, y);
       const offset = dataset.frameToIdOffset ? dataset.frameToIdOffset[this.currentFrame] : 0;

--- a/src/colorizer/ColorizeCanvas3D.ts
+++ b/src/colorizer/ColorizeCanvas3D.ts
@@ -188,6 +188,7 @@ export class ColorizeCanvas3D implements IRenderCanvas {
     }
     await loaderContext.onOpen();
 
+    console.log("Loading volume from path:", path);
     this.loader = await loaderContext.createLoader(path);
     const loadSpec = new LoadSpec();
     loadSpec.time = this.params.pendingFrame;

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -58,7 +58,7 @@ const MAX_CACHED_BACKDROPS_BYTES = 500_000_000; // 500 MB
 
 export default class Dataset {
   private frameLoader: ITextureImageLoader;
-  private frameFiles: string[];
+  private frameFiles?: string[];
   private frames: DataCache<number, Texture> | null;
   private frameDimensions: Vector2 | null;
 
@@ -308,7 +308,7 @@ export default class Dataset {
   }
 
   public get numberOfFrames(): number {
-    return this.frameFiles.length || 0;
+    return this.frameFiles?.length ?? 0;
   }
 
   public get featureKeys(): string[] {
@@ -325,7 +325,7 @@ export default class Dataset {
 
   /** Loads a single frame from the dataset */
   public async loadFrame(index: number): Promise<Texture | undefined> {
-    if (index < 0 || index >= this.frameFiles.length) {
+    if (index < 0 || this.frameFiles === undefined || index >= this.frameFiles.length) {
       return undefined;
     }
 
@@ -375,11 +375,6 @@ export default class Dataset {
     const frames = this.backdropData.get(key)?.frames;
     // TODO: Wrapping or clamping?
     if (!frames || index < 0 || index >= frames.length) {
-      return undefined;
-    }
-
-    // Allow for undefined or null backdrop frames in the manifest
-    if (this.frameFiles[index] === undefined || this.frameFiles[index] === null) {
       return undefined;
     }
 
@@ -559,7 +554,7 @@ export default class Dataset {
     }
     console.log("Frame to smallest ID: ", frameToSmallestId);
     console.log("Frame to largest ID: ", frameToLargestId);
-    this.frameIdOffset = new Uint32Array(this.numberOfFrames);
+    this.frameIdOffset = new Uint32Array(frameToSmallestId);
   }
 
   /** Frees the GPU resources held by this dataset */
@@ -580,7 +575,7 @@ export default class Dataset {
   }
 
   public getTotalFrames(): number {
-    return this.frameFiles.length;
+    return this.frameFiles?.length ?? 0;
   }
 
   public isValidFrameIndex(index: number): boolean {

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -67,9 +67,19 @@ export default class Dataset {
   private totalFrames3d?: number;
 
   private segIdsFile?: string;
-  /** Lookup from a global index of an object to the segmentation ID in the
+  /** Lookup from a global index of an object to the raw segmentation ID in the
    * frame/image where it appears. */
   public segIds?: Uint32Array | null;
+  /**
+   * Lookup table from a frame number to the offsets with which to read data
+   * from globally-indexed arrays for objects on that frame. Note that this
+   * assumes that all objects in a frame have segmentation IDs that are
+   * monotonically increasing (e.g. skips no values), and that a frame's objects
+   * all have adjacent indices in the global array.
+   *
+   * For any object with segmentation ID `segId` in frame `frame`, the global
+   * index of that object is given by `segId + frameToIdOffsets[frame]`.
+   */
   public frameToIdOffset: Uint32Array | null;
 
   private backdropLoader: ITextureImageLoader;
@@ -480,12 +490,12 @@ export default class Dataset {
     this.boundsFile = manifest.bounds;
     this.segIdsFile = manifest.segIds;
 
-    if (manifest.backdrops) {
+    if (manifest.backdrops && manifest.frames) {
       for (const { name, key, frames } of manifest.backdrops) {
         this.backdropData.set(key, { name, frames });
-        if (frames.length !== this.frameFiles.length || 0) {
+        if (frames.length !== this.frameFiles?.length || 0) {
           throw new Error(
-            `Number of frames (${this.frameFiles.length}) does not match number of images (${frames.length}) for backdrop '${key}'. ` +
+            `Number of frames (${this.frameFiles?.length}) does not match number of images (${frames.length}) for backdrop '${key}'. ` +
               ` If you are a dataset author, please ensure that the number of frames in the manifest matches the number of images for each backdrop.`
           );
         }

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -148,6 +148,16 @@ export default class Dataset {
   private resolvePathToUrl = (url: string): string => {
     if (url.startsWith("http://") || url.startsWith("https://")) {
       return url;
+    } else if (urlUtils.isAllenPath(url)) {
+      const newUrl = urlUtils.convertAllenPathToHttps(url);
+      if (newUrl) {
+        return newUrl;
+      } else {
+        throw new Error(
+          `Error while resolving path: Allen filepath '${url}' was detected but could not be converted to an HTTPS URL.` +
+            ` This may be because the file is in a directory that is not publicly servable.`
+        );
+      }
     } else {
       return `${this.baseUrl}/${url}`;
     }

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -389,16 +389,21 @@ export default class Dataset {
   }
 
   /**
-   * Returns a Uint32Array of ID offsets for each time in the dataset.
+   * Returns a lookup table of ID offsets for each time in the dataset, used to
+   * get the global indices for objects in the image/frame data.
+   *
+   * When looking up data for an object with segmentation ID `segId` in the
+   * image/frame data at time `time`, the global index of the object is given by
+   * `segId + frameToIdOffsets[time]`.
    *
    * NOTE: This makes a lot of VERY LARGE assumptions about the frame data,
    * namely that either:
    * - Frame data has segmentation IDs that are globally unique, OR
-   * - Frame data has segmentation IDs that increase monotonically
-   *   (e.g. 2, 3, 4, 5, etc.) on that frame.
+   * - Frame data has segmentation IDs that increase monotonically (e.g. 2, 3,
+   *   4, 5, etc.) on that frame.
    *
    * The second assumption breaks down if there are any skipped segmentation IDs
-   * in the frame. A more robust version of this is described in
+   * in the frame. A future, more robust version of this is described in
    * https://github.com/allen-cell-animated/timelapse-colorizer/issues/630.
    */
   private buildFrameToIdOffsetsFromSegIds(): Uint32Array {
@@ -407,12 +412,12 @@ export default class Dataset {
     const frameToSmallestSegIdIdx: number[] = Array.from({ length: this.numberOfFrames }).fill(-1) as number[];
     for (let idx = 0; idx < this.numObjects; idx++) {
       const time = this.times![idx];
-      const seg_id = this.segIds?.[idx] ?? idx;
+      const segId = this.segIds?.[idx] ?? idx;
       if (frameToSmallestSegIdIdx[time] === -1) {
         frameToSmallestSegIdIdx[time] = idx;
       } else {
-        const last_min_seg_id = this.segIds?.[frameToSmallestSegIdIdx[time]] ?? Infinity;
-        if (seg_id < last_min_seg_id) {
+        const lastMinSegId = this.segIds?.[frameToSmallestSegIdIdx[time]] ?? Infinity;
+        if (segId < lastMinSegId) {
           frameToSmallestSegIdIdx[time] = idx;
         }
       }

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -79,8 +79,8 @@ export default class Dataset {
    * monotonically increasing (e.g. skips no values), and that a frame's objects
    * all have adjacent indices in the global array.
    *
-   * For any object with segmentation ID `segId` in frame `frame`, the global
-   * index of that object is given by `segId + frameToIdOffsets[frame]`.
+   * For any object with segmentation ID `segId` at time `t`, the global
+   * index of that object is given by `segId + frameToIdOffsets[t]`.
    */
   public frameToIdOffset: Uint32Array | null;
 
@@ -418,8 +418,8 @@ export default class Dataset {
    * get the global indices for objects in the image/frame data.
    *
    * When looking up data for an object with segmentation ID `segId` in the
-   * image/frame data at time `time`, the global index of the object is given by
-   * `segId + frameToIdOffsets[time]`.
+   * image/frame data at time `t`, the global index of the object is given by
+   * `segId + frameToIdOffsets[t]`.
    *
    * NOTE: This makes a lot of VERY LARGE assumptions about the frame data,
    * namely that either:

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -43,6 +43,14 @@ type BackdropData = {
   frames: string[];
 };
 
+export type Frames3dData = {
+  /** Source for 3D data, resolved to http/https URLs. Expected to be a path to an OME-Zarr array.*/
+  source: string;
+  /** Index of the segmentation channel in the source data. */
+  segmentationChannel: number;
+  totalFrames: number;
+};
+
 const defaultMetadata: ManifestFileMetadata = {
   frameDims: {
     width: 0,
@@ -62,11 +70,7 @@ export default class Dataset {
   private frames: DataCache<number, Texture> | null;
   private frameDimensions: Vector2 | null;
 
-  /** Source for 3D data, resolved to http/https URLs. */
-  public frames3dSrc?: string | string[];
-  /** Index of the segmentation channel in the 3D data. */
-  public segmentationChannel?: number;
-  private totalFrames3d?: number;
+  public frames3d?: Frames3dData;
 
   private segIdsFile?: string;
   /** Lookup from a global index of an object to the raw segmentation ID in the
@@ -161,13 +165,6 @@ export default class Dataset {
     } else {
       return `${this.baseUrl}/${url}`;
     }
-  };
-
-  private resolvePathsToUrls = <T extends string | string[]>(url: T): T => {
-    if (Array.isArray(url)) {
-      return url.map((u) => this.resolvePathToUrl(u)) as T;
-    }
-    return this.resolvePathToUrl(url) as T;
   };
 
   private parseFeatureType(inputType: string | undefined, defaultType = FeatureType.CONTINUOUS): FeatureType {
@@ -323,7 +320,7 @@ export default class Dataset {
   }
 
   public has3dFrames(): boolean {
-    return this.frames3dSrc !== undefined;
+    return this.frames3d !== undefined;
   }
 
   /**
@@ -503,10 +500,14 @@ export default class Dataset {
     const manifest = updateManifestVersion(await options.manifestLoader(this.manifestUrl));
 
     this.frameFiles = manifest.frames;
-    const frames3dSrc = manifest.frames3d?.source;
-    this.frames3dSrc = frames3dSrc ? this.resolvePathsToUrls(frames3dSrc) : undefined;
-    this.segmentationChannel = manifest.frames3d?.segmentationChannel ?? 0;
-    this.totalFrames3d = manifest.frames3d?.totalFrames ?? 0;
+    const frames3dSrc = manifest.frames3d;
+    if (frames3dSrc && frames3dSrc.source) {
+      this.frames3d = {
+        source: this.resolvePathToUrl(frames3dSrc.source),
+        segmentationChannel: manifest.frames3d?.segmentationChannel ?? 0,
+        totalFrames: manifest.frames3d?.totalFrames ?? 0,
+      };
+    }
     this.outlierFile = manifest.outliers;
     this.metadata = { ...defaultMetadata, ...manifest.metadata };
 
@@ -650,7 +651,7 @@ export default class Dataset {
     if (this.has2dFrames()) {
       return this.frameFiles?.length ?? 0;
     } else {
-      return this.totalFrames3d ?? 0;
+      return this.frames3d?.totalFrames ?? 0;
     }
   }
 

--- a/src/colorizer/IRenderCanvas.ts
+++ b/src/colorizer/IRenderCanvas.ts
@@ -8,6 +8,7 @@ export type RenderCanvasStateParams = Pick<
   | "dataset"
   | "collection"
   | "datasetKey"
+  | "pendingFrame"
   | "featureKey"
   | "track"
   | "showTrackPath"
@@ -34,6 +35,7 @@ export const renderCanvasStateParamsSelector = (state: ViewerStoreState): Render
   collection: state.collection,
   datasetKey: state.datasetKey,
   featureKey: state.featureKey,
+  pendingFrame: state.pendingFrame,
   track: state.track,
   showTrackPath: state.showTrackPath,
   colorRamp: state.colorRamp,

--- a/src/colorizer/utils/dataset_utils.ts
+++ b/src/colorizer/utils/dataset_utils.ts
@@ -79,11 +79,8 @@ type ManifestFileV1_0_0 = Omit<ManifestFileV0_0_0, "features" | "featureMetadata
 type ManifestFileV1_1_0 = Spread<
   ManifestFileV1_0_0 & {
     metadata?: Partial<ManifestFileMetadataV1_1_0>;
-    /**
-     * Offsets raw, per-frame object IDs in 2D or 3D data into
-     * indices for the global data arrays.
-     */
-    frameIdOffsets?: string;
+    /** Segmentation IDs for objects as they appear in image/frame data. */
+    segIds?: string;
     /** Required data for  */
     frames3d?: {
       source: string | string[];

--- a/src/colorizer/utils/dataset_utils.ts
+++ b/src/colorizer/utils/dataset_utils.ts
@@ -32,7 +32,7 @@ export type ManifestFileMetadata = Spread<ManifestFileMetadataV1_1_0>;
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 type ManifestFileV0_0_0 = {
-  frames: string[];
+  frames?: string[];
   /** Deprecated; Map from feature name to relative path. */
   features: Record<string, string>;
   /** Deprecated; avoid using in new datasets. Instead, use the new `FeatureMetadata` spec. */
@@ -79,12 +79,30 @@ type ManifestFileV1_0_0 = Omit<ManifestFileV0_0_0, "features" | "featureMetadata
 type ManifestFileV1_1_0 = Spread<
   ManifestFileV1_0_0 & {
     metadata?: Partial<ManifestFileMetadataV1_1_0>;
-    /** Segmentation IDs for objects as they appear in image/frame data. */
+    /**
+     * Segmentation IDs for objects as they appear in image/frame data.
+     * Segmentation IDs should be unique for each object in a frame, and for
+     * best performance should be contiguous integers starting from 1.
+     *
+     * If an object at some time `t` has segmentation ID `21`, all pixels with a
+     * value of 21 in the frame at time `t` belong to that object.
+     */
     segIds?: string;
-    /** Required data for  */
+    /**
+     * Optional 3D volumetric segmentation data.
+     */
     frames3d?: {
+      /**
+       * URL or path relative to the root of the manifest. Expected to be a
+       * time-series ZARR array (e.g. ends with `.ome.zarr`). */
       source: string | string[];
+      /**
+       * The index of the channel to use as a segmentation. If multiple volumes
+       * are specified in `source`, `segmentationChannel` indexes into a list of
+       * the channels of all volumes concatenated together.
+       **/
       segmentationChannel: number;
+      /** Total number of frames in the time-series volume. */
       totalFrames: number;
     };
   }

--- a/src/colorizer/utils/dataset_utils.ts
+++ b/src/colorizer/utils/dataset_utils.ts
@@ -94,8 +94,8 @@ type ManifestFileV1_1_0 = Spread<
     frames3d?: {
       /**
        * URL or path relative to the root of the manifest. Expected to be a
-       * time-series ZARR array (e.g. ends with `.ome.zarr`). */
-      source: string | string[];
+       * time-series ZARR (e.g. ends with `.ome.zarr`). */
+      source: string;
       /**
        * The index of the channel to use as a segmentation. If multiple volumes
        * are specified in `source`, `segmentationChannel` indexes into a list of

--- a/src/colorizer/utils/dataset_utils.ts
+++ b/src/colorizer/utils/dataset_utils.ts
@@ -33,13 +33,6 @@ export type ManifestFileMetadata = Spread<ManifestFileMetadataV1_1_0>;
 // eslint-disable-next-line @typescript-eslint/naming-convention
 type ManifestFileV0_0_0 = {
   frames: string[];
-  /** Offsets for  */
-  frameIdOffsets?: string;
-  frames3d?: {
-    source: string | string[];
-    segmentationChannel: number;
-    totalFrames: number;
-  };
   /** Deprecated; Map from feature name to relative path. */
   features: Record<string, string>;
   /** Deprecated; avoid using in new datasets. Instead, use the new `FeatureMetadata` spec. */
@@ -57,7 +50,6 @@ type ManifestFileV0_0_0 = {
   centroids?: string;
   bounds?: string;
   metadata?: Partial<ManifestFileMetadataV0_0_0>;
-  // TODO:
 };
 
 // v1.0.0 removes the featureMetadata field, replaces the features map with an ordered
@@ -87,6 +79,17 @@ type ManifestFileV1_0_0 = Omit<ManifestFileV0_0_0, "features" | "featureMetadata
 type ManifestFileV1_1_0 = Spread<
   ManifestFileV1_0_0 & {
     metadata?: Partial<ManifestFileMetadataV1_1_0>;
+    /**
+     * Offsets raw, per-frame object IDs in 2D or 3D data into
+     * indices for the global data arrays.
+     */
+    frameIdOffsets?: string;
+    /** Required data for  */
+    frames3d?: {
+      source: string | string[];
+      segmentationChannel: number;
+      totalFrames: number;
+    };
   }
 >;
 

--- a/src/colorizer/utils/dataset_utils.ts
+++ b/src/colorizer/utils/dataset_utils.ts
@@ -33,6 +33,12 @@ export type ManifestFileMetadata = Spread<ManifestFileMetadataV1_1_0>;
 // eslint-disable-next-line @typescript-eslint/naming-convention
 type ManifestFileV0_0_0 = {
   frames: string[];
+  /** Offsets for  */
+  frameIdOffsets?: string;
+  frames3d?: {
+    source: string | string[];
+    segmentationChannel: number;
+  };
   /** Deprecated; Map from feature name to relative path. */
   features: Record<string, string>;
   /** Deprecated; avoid using in new datasets. Instead, use the new `FeatureMetadata` spec. */
@@ -50,6 +56,7 @@ type ManifestFileV0_0_0 = {
   centroids?: string;
   bounds?: string;
   metadata?: Partial<ManifestFileMetadataV0_0_0>;
+  // TODO:
 };
 
 // v1.0.0 removes the featureMetadata field, replaces the features map with an ordered

--- a/src/colorizer/utils/dataset_utils.ts
+++ b/src/colorizer/utils/dataset_utils.ts
@@ -38,6 +38,7 @@ type ManifestFileV0_0_0 = {
   frames3d?: {
     source: string | string[];
     segmentationChannel: number;
+    totalFrames: number;
   };
   /** Deprecated; Map from feature name to relative path. */
   features: Record<string, string>;

--- a/src/state/slices/time_slice.ts
+++ b/src/state/slices/time_slice.ts
@@ -138,7 +138,7 @@ export const addTimeDerivedStateSubscribers = (store: SubscribableStore<DatasetS
 
       // Clamp and reload the frame
       const newFrame = Math.min(store.getState().currentFrame, totalFrames - 1);
-      store.setState({ currentFrame: newFrame, pendingFrame: newFrame });
+      store.setState({ currentFrame: -1, pendingFrame: newFrame });
       if (dataset !== null) {
         // TODO: This may cause a race condition since ColorizeCanvas already
         // loads the frame when the dataset is set.

--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -260,14 +260,31 @@ describe("Dataset", () => {
       ...MOCK_DATASET_MANIFEST,
       frames3d: {
         source: "seg.ome.zarr",
+        segmentationChannel: 1,
+        totalFrames: 4,
+      },
+    };
+    const dataset = await makeMockDataset(manifestWith3dSource);
+    expect(dataset.has3dFrames()).to.be.true;
+    const frames3d = dataset.frames3d;
+    expect(frames3d?.source).to.equal(DEFAULT_DATASET_DIR + "seg.ome.zarr");
+    expect(frames3d?.segmentationChannel).to.equal(1);
+    expect(frames3d?.totalFrames).to.equal(4);
+  });
+
+  it("converts allen Zarr paths to URLs", async () => {
+    const manifestWith3dSource: AnyManifestFile = {
+      ...MOCK_DATASET_MANIFEST,
+      frames3d: {
+        source: "/allen/aics/assay-dev/some/path/to/seg.ome.zarr",
         segmentationChannel: 0,
         totalFrames: 4,
       },
     };
     const dataset = await makeMockDataset(manifestWith3dSource);
     expect(dataset.has3dFrames()).to.be.true;
-    const source = dataset.frames3dSrc;
-    expect(source).to.equal(DEFAULT_DATASET_DIR + "seg.ome.zarr");
+    const frames3d = dataset.frames3d;
+    expect(frames3d?.source).to.equal("https://dev-aics-dtp-001.int.allencell.org/assay-dev/some/path/to/seg.ome.zarr");
   });
 
   describe("frameToIdOffset", () => {

--- a/tests/state/ViewerState/constants.ts
+++ b/tests/state/ViewerState/constants.ts
@@ -83,16 +83,21 @@ export const MOCK_DATASET_MANIFEST: AnyManifestFile = {
   ],
   times: "times.json",
   tracks: "tracks.json",
+  segIds: "seg_ids.json",
 };
 
-export const MOCK_DATASET_ARRAY_LOADER = new MockArrayLoader({
+export const MOCK_DATASET_ARRAY_LOADER_DEFAULT_SOURCE = {
   [DEFAULT_DATASET_DIR + "times.json"]: new MockArraySource(
     FeatureDataType.U32,
-    new Uint32Array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+    new Uint32Array([0, 0, 0, 1, 1, 1, 2, 2, 3])
+  ),
+  [DEFAULT_DATASET_DIR + "seg_ids.json"]: new MockArraySource(
+    FeatureDataType.U32,
+    new Uint32Array([0, 1, 2, 3, 4, 5, 6, 7, 8])
   ),
   [DEFAULT_DATASET_DIR + "tracks.json"]: new MockArraySource(
     FeatureDataType.U32,
-    new Uint32Array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    new Uint32Array([0, 1, 2, 0, 1, 2, 0, 1, 2])
   ),
   [DEFAULT_DATASET_DIR + "feature1.json"]: new MockArraySource(
     FeatureDataType.F32,
@@ -110,7 +115,9 @@ export const MOCK_DATASET_ARRAY_LOADER = new MockArrayLoader({
     FeatureDataType.F32,
     new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
   ),
-});
+};
+
+export const MOCK_DATASET_ARRAY_LOADER = new MockArrayLoader(MOCK_DATASET_ARRAY_LOADER_DEFAULT_SOURCE);
 
 export const MOCK_DATASET = await makeMockDataset(MOCK_DATASET_MANIFEST, MOCK_DATASET_ARRAY_LOADER);
 

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -111,8 +111,8 @@ export class MockArraySource<T extends FeatureDataType> implements ArraySource<T
   getBuffer<T extends FeatureDataType>(): FeatureArrayType[T] {
     return this.data as unknown as FeatureArrayType[T];
   }
-  getTexture(): Texture {
-    return new Texture();
+  getTexture(): DataTexture {
+    return new DataTexture();
   }
   getMin(): number {
     return 0;


### PR DESCRIPTION
Problem
=======
Closes #547, "Get 3D data source from dataset," and #551, "support frame-local IDs."

This PR defines 3D dataset info and allows them to be loaded into TFE! Datasets can provide a `frames3d` parameter, which specifies the source of a 3D file (anything that can be opened by Vol-E) and some additional metadata.

When a dataset with 3D data is loaded, the TFE viewport switches to load and show the data in 3D.

*Estimated review size: medium, 30-40 minutes*

Solution
========
- Updated the dataset manifest definition to support a `frames3d` object parameter, containing 3D dataset source files and metadata.
- Datasets are now expected to provide a segmentation ID column (`seg_ids`), which is used for mapping from frame data to a global index.
- OverlayCanvas now keeps its own internal 2D and 3D canvas, and swaps between them as needed based on the opened Dataset.
- ColorizeCanvas3D now loads 3D data from the dataset rather than using a hard-coded volume.


## Type of change

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link with the test dataset loaded here: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-625/viewer?collection=https://raw.githubusercontent.com/allen-cell-animated/timelapse-colorizer/refs/heads/test-datasets/docs/nucmorph-zarr/collection.json

Screenshots (optional):
-----------------------
**Video talk-through (🔊):**

https://github.com/user-attachments/assets/415d8fe7-5885-46d2-8eb5-9aad0b16138b

**Pt. 2 - Code overview:**

https://github.com/user-attachments/assets/e7282e1c-8f8f-40f8-8fb7-d5f93d324aa3

Keyfiles:
-----------------------
(IN ORDER)

1. `dataset_utils.ts`
2. `Dataset.ts`
4. `CanvasOverlay.ts`
5. `ColorizeCanvas3d.ts`
