### PR TITLE
fix: Fixed categorical colors being incorrect in viewport

### DIFF
--- a/src/colorizer/ColorRamp.ts
+++ b/src/colorizer/ColorRamp.ts
@@ -12,7 +12,16 @@ export default class ColorRamp {
 
   constructor(colorStops: ColorRepresentation[], type: ColorRampType = ColorRampType.LINEAR) {
     this.colorStops = colorStops.map((color) => new Color(color));
-    const dataArr = this.colorStops.flatMap((col) => [col.r, col.g, col.b, 1]);
+    const dataArr = this.colorStops.flatMap((col) => {
+      // Must use getHex() instead of accessing color properties directly (e.g.
+      // `col.r`) so the returned color is in sRGB and not LinearSRGB color
+      // space. See https://threejs.org/manual/#en/color-management.
+      const hex = col.getHex();
+      const r = ((hex >> 16) & 0xff) / 255;
+      const g = ((hex >> 8) & 0xff) / 255;
+      const b = (hex & 0xff) / 255;
+      return [r, g, b, 1];
+    });
     this.texture = new DataTexture(new Float32Array(dataArr), this.colorStops.length, 1, RGBAFormat, FloatType);
     this.type = type;
     if (this.type === ColorRampType.HARD_STOP) {


### PR DESCRIPTION
Problem
=======
Closes #626, "categorical colors are incorrect after upgrading Three.js version".

*Estimated review size: tiny, <5 minutes*
(Note: static checks will be broken until a dependency in Vol-e core is merged)

Solution
========
- Parses color stops as sRGB hex values instead of directly accessing LinearSRGB values.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open the preview link. Categorical colors should appear in the viewport as they do in the color pickers. https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-633/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&feature=trajectory_termination_annotation&bg-key=max_intensity_zprojection_of_lamin_b1&t=199

Screenshots (optional):
-----------------------
| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/28468886-c918-4d89-8e91-fcb85ae9c8e6) | ![image](https://github.com/user-attachments/assets/69d152e1-a7ca-4864-b8b5-bd14e945d9d3) |
