### PR TITLE
feat: Calculate lookup tables to support arbitrary segmentation IDs (3D MVP pt. 5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "timelapse-colorizer",
       "version": "1.2.1",
       "dependencies": {
-        "@aics/vole-core": "^3.14.1",
+        "@aics/vole-core": "^3.15.0",
         "@ant-design/icons": "^5.2.5",
         "@fortawesome/fontawesome-svg-core": "^6.5.1",
         "@fortawesome/free-solid-svg-icons": "^6.5.1",
@@ -71,9 +71,9 @@
       "dev": true
     },
     "node_modules/@aics/vole-core": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-3.14.1.tgz",
-      "integrity": "sha512-CtLwx3x0wg7Rf/NGYGTjrvulVtDMZrCXGjqyEp3sUk1UIFPq/4yzID5lWMJYFfLfKx0bactCvE72NZuUE5tKyQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-3.15.0.tgz",
+      "integrity": "sha512-P9Fe7XrgazwcoJpJgFZ6EQkj2VKhijcVid+1XtdIokejhC2eeekH0Z7hIjvClbL2nyIGouufdd0VNgDvblJUaw==",
       "dependencies": {
         "@babel/runtime": "^7.25.6",
         "geotiff": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "vitest-canvas-mock": "^0.3.3"
   },
   "dependencies": {
-    "@aics/vole-core": "^3.14.1",
+    "@aics/vole-core": "^3.15.0",
     "@ant-design/icons": "^5.2.5",
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -792,7 +792,7 @@ function Viewer(): ReactElement {
                 </FlexRowAlignCenter>
               </div>
               <CanvasHoverTooltip
-                lastValidHoveredId={lastValidHoveredId?.globalId ?? -1}
+                lastValidHoveredId={lastValidHoveredId}
                 showObjectHoverInfo={showObjectHoverInfo}
                 annotationState={annotationState}
               >

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -19,6 +19,7 @@ import {
   KNOWN_CATEGORICAL_PALETTES,
   KNOWN_COLOR_RAMPS,
   LoadTroubleshooting,
+  PixelIdInfo,
   ReportWarningCallback,
   TabType,
 } from "./colorizer";
@@ -42,7 +43,6 @@ import { loadInitialCollectionAndDataset } from "./utils/dataset_load_utils";
 
 import CanvasOverlay from "./colorizer/CanvasOverlay";
 import Collection from "./colorizer/Collection";
-import { BACKGROUND_ID } from "./colorizer/ColorizeCanvas2D";
 import { FeatureType } from "./colorizer/Dataset";
 import { renderCanvasStateParamsSelector } from "./colorizer/IRenderCanvas";
 import UrlArrayLoader from "./colorizer/loaders/UrlArrayLoader";
@@ -177,7 +177,7 @@ function Viewer(): ReactElement {
    * canvas after a short delay.
    */
   const [frameInput, setFrameInput] = useState(0);
-  const [lastValidHoveredId, setLastValidHoveredId] = useState<number>(-1);
+  const [lastValidHoveredId, setLastValidHoveredId] = useState<PixelIdInfo>({ segId: -1, globalId: undefined });
   const [showObjectHoverInfo, setShowObjectHoverInfo] = useState(false);
   const currentHoveredId = showObjectHoverInfo ? lastValidHoveredId : null;
 
@@ -534,9 +534,9 @@ function Viewer(): ReactElement {
   }, [isUserDirectlyControllingFrameInput, frameInput]);
 
   const onClickId = useCallback(
-    (id: number) => {
-      if (dataset) {
-        annotationState.handleAnnotationClick(dataset, id);
+    (info: PixelIdInfo) => {
+      if (dataset && info.globalId !== undefined) {
+        annotationState.handleAnnotationClick(dataset, info.globalId);
       }
     },
     [dataset, annotationState.handleAnnotationClick]
@@ -638,7 +638,7 @@ function Viewer(): ReactElement {
       visible: INTERNAL_BUILD,
       children: (
         <div className={styles.tabContent}>
-          <AnnotationTab annotationState={annotationState} hoveredId={currentHoveredId} />
+          <AnnotationTab annotationState={annotationState} hoveredId={currentHoveredId?.globalId || null} />
         </div>
       ),
     },
@@ -792,7 +792,7 @@ function Viewer(): ReactElement {
                 </FlexRowAlignCenter>
               </div>
               <CanvasHoverTooltip
-                lastValidHoveredId={lastValidHoveredId}
+                lastValidHoveredId={lastValidHoveredId?.globalId ?? -1}
                 showObjectHoverInfo={showObjectHoverInfo}
                 annotationState={annotationState}
               >
@@ -802,11 +802,12 @@ function Viewer(): ReactElement {
                   canv={canv}
                   isRecording={isRecording}
                   onClickId={onClickId}
-                  onMouseHover={(id: number): void => {
-                    const isObject = id !== BACKGROUND_ID;
+                  onMouseHover={(info: PixelIdInfo | null): void => {
+                    const isObject = info !== null;
                     setShowObjectHoverInfo(isObject);
                     if (isObject) {
-                      setLastValidHoveredId(id);
+                      // TODO: Show additional information about
+                      setLastValidHoveredId(info);
                     }
                   }}
                   onMouseLeave={() => setShowObjectHoverInfo(false)}

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -638,7 +638,7 @@ function Viewer(): ReactElement {
       visible: INTERNAL_BUILD,
       children: (
         <div className={styles.tabContent}>
-          <AnnotationTab annotationState={annotationState} hoveredId={currentHoveredId?.globalId || null} />
+          <AnnotationTab annotationState={annotationState} hoveredId={currentHoveredId?.globalId ?? null} />
         </div>
       ),
     },
@@ -806,7 +806,6 @@ function Viewer(): ReactElement {
                     const isObject = info !== null;
                     setShowObjectHoverInfo(isObject);
                     if (isObject) {
-                      // TODO: Show additional information about
                       setLastValidHoveredId(info);
                     }
                   }}

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -25,7 +25,7 @@ import {
 } from "./canvas/elements/annotations";
 import { BaseRenderParams, RenderInfo } from "./canvas/types";
 import { getPixelRatio } from "./canvas/utils";
-import { CanvasScaleInfo, CanvasType, FrameLoadResult } from "./types";
+import { CanvasScaleInfo, CanvasType, FrameLoadResult, PixelIdInfo } from "./types";
 import { hasPropertyChanged } from "./utils/data_utils";
 
 import { LabelData } from "./AnnotationData";
@@ -215,7 +215,7 @@ export default class CanvasOverlay implements IRenderCanvas {
     this.render();
   }
 
-  public getIdAtPixel(x: number, y: number): number {
+  public getIdAtPixel(x: number, y: number): PixelIdInfo | null {
     const headerHeight = this.headerSize.y;
     return this.innerCanvas.getIdAtPixel(x, y - headerHeight);
   }

--- a/src/colorizer/ColorizeCanvas2D.ts
+++ b/src/colorizer/ColorizeCanvas2D.ts
@@ -681,7 +681,6 @@ export default class ColorizeCanvas2D implements IRenderCanvas {
 
     // get 32bit value from 4 8bit values
     const segId = pixbuf[0] | (pixbuf[1] << 8) | (pixbuf[2] << 16) | (pixbuf[3] << 24);
-
     const globalId = getGlobalIdFromSegId(dataset.frameToGlobalIdLookup, this.currentFrame, segId);
     return { segId, globalId };
   }

--- a/src/colorizer/ColorizeCanvas2D.ts
+++ b/src/colorizer/ColorizeCanvas2D.ts
@@ -31,8 +31,8 @@ import {
   OUTLIER_COLOR_DEFAULT,
   OUTLINE_COLOR_DEFAULT,
 } from "./constants";
-import { Canvas2DScaleInfo, CanvasType, DrawMode, FeatureDataType, FrameLoadResult } from "./types";
-import { hasPropertyChanged } from "./utils/data_utils";
+import { Canvas2DScaleInfo, CanvasType, DrawMode, FeatureDataType, FrameLoadResult, PixelIdInfo } from "./types";
+import { getGlobalIdFromSegId, hasPropertyChanged } from "./utils/data_utils";
 import { packDataTexture } from "./utils/texture_utils";
 
 import ColorRamp from "./ColorRamp";
@@ -663,7 +663,12 @@ export default class ColorizeCanvas2D implements IRenderCanvas {
     this.pickMaterial.dispose();
   }
 
-  public getIdAtPixel(x: number, y: number): number {
+  public getIdAtPixel(x: number, y: number): PixelIdInfo | null {
+    const dataset = this.params?.dataset;
+    if (!dataset) {
+      return null;
+    }
+
     const rt = this.renderer.getRenderTarget();
 
     this.renderer.setRenderTarget(this.pickRenderTarget);
@@ -675,8 +680,9 @@ export default class ColorizeCanvas2D implements IRenderCanvas {
     this.renderer.setRenderTarget(rt);
 
     // get 32bit value from 4 8bit values
-    const value = pixbuf[0] | (pixbuf[1] << 8) | (pixbuf[2] << 16) | (pixbuf[3] << 24);
-    // offset by 1 since 0 is background.
-    return value - 1;
+    const segId = pixbuf[0] | (pixbuf[1] << 8) | (pixbuf[2] << 16) | (pixbuf[3] << 24);
+
+    const globalId = getGlobalIdFromSegId(dataset.frameToGlobalIdLookup, this.currentFrame, segId);
+    return { segId, globalId };
   }
 }

--- a/src/colorizer/ColorizeCanvas2D.ts
+++ b/src/colorizer/ColorizeCanvas2D.ts
@@ -681,6 +681,10 @@ export default class ColorizeCanvas2D implements IRenderCanvas {
 
     // get 32bit value from 4 8bit values
     const segId = pixbuf[0] | (pixbuf[1] << 8) | (pixbuf[2] << 16) | (pixbuf[3] << 24);
+
+    if (segId === 0) {
+      return null;
+    }
     const globalId = getGlobalIdFromSegId(dataset.frameToGlobalIdLookup, this.currentFrame, segId);
     return { segId, globalId };
   }

--- a/src/colorizer/ColorizeCanvas3D.ts
+++ b/src/colorizer/ColorizeCanvas3D.ts
@@ -124,7 +124,7 @@ export class ColorizeCanvas3D implements IRenderCanvas {
           outlierDrawMode: this.params.outlierDrawSettings.mode,
           outOfRangeDrawMode: this.params.outOfRangeDrawSettings.mode,
           hideOutOfRange: this.params.outOfRangeDrawSettings.mode === DrawMode.HIDE,
-          frameToGlobalIdLookup: dataset.frameToGlobalIdLookup!,
+          frameToGlobalIdLookup: dataset.frameToGlobalIdLookup ?? new Map(),
         };
         this.view3d.setChannelColorizeFeature(volume, channelIndex, feature);
       }
@@ -308,8 +308,7 @@ export class ColorizeCanvas3D implements IRenderCanvas {
     // during colorizer setup.
     if (this.volume?.isLoaded() && dataset) {
       const segId = this.view3d.hitTest(x, y);
-      const globalIdInfo = dataset.frameToGlobalIdLookup?.get(this.currentFrame);
-      if (!globalIdInfo || segId === -1) {
+      if (segId === -1) {
         // Background hit
         return null;
       }

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -564,7 +564,7 @@ export default class Dataset {
       // Construct default segIds array (0, 1, 2, ...)
       this.segIds = new Uint32Array(this.numObjects);
       for (let i = 0; i < this.numObjects; i++) {
-        this.segIds[i] = i;
+        this.segIds[i] = i + 1;
       }
     }
 

--- a/src/colorizer/IRenderCanvas.ts
+++ b/src/colorizer/IRenderCanvas.ts
@@ -1,7 +1,7 @@
 import { Vector2 } from "three";
 
 import { ViewerStoreState } from "../state/slices";
-import { CanvasScaleInfo, FrameLoadResult } from "./types";
+import { CanvasScaleInfo, FrameLoadResult, PixelIdInfo } from "./types";
 
 export type RenderCanvasStateParams = Pick<
   ViewerStoreState,
@@ -106,6 +106,11 @@ export interface IRenderCanvas {
   /**
    * Gets the ID of the segmentation at a pixel coordinate in the canvas, where
    * `(0,0)` is the top left corner.
+   *
+   * @returns
+   * - If there is a segmentation present, returns an object containing the
+   *   segmentation ID and the global ID (if one exists).
+   * - If there is no segmentation present, returns `null`.
    */
-  getIdAtPixel(x: number, y: number): number;
+  getIdAtPixel(x: number, y: number): PixelIdInfo | null;
 }

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -231,29 +231,40 @@ export enum AnnotationSelectionMode {
   TRACK,
 }
 
+/**
+ * Data used to map from the segmentation ID (e.g. raw pixel value) of an object
+ * in a given frame to its global ID in the dataset, which is used to index into
+ * data arrays for feature, time, track, and other data. We use a lookup because
+ * segmentation IDs are not guaranteed to be unique across frames.
+ *
+ * The global ID of an object with segmentation ID `segId` and
+ * GlobalIdLookupInfo `info` is given by:
+ *
+ * ```
+ * info.lut[segId - info.minSegId] - 1
+ * ```
+ *
+ *  If the segmentation ID is not present in the dataset, the global ID is
+ * `NaN` or `-1`.
+ */
 export type GlobalIdLookupInfo = {
   /**
-   * A LUT mapping from the segmentation ID (e.g. raw pixel value) of an object
-   * in a given frame to its global ID in the dataset, which is used to index
-   * into data arrays for feature, time, track, and other data. We use a lookup
-   * because segmentation IDs are not guaranteed to be unique across frames.
+   * A LUT that maps from segmentation IDs to global IDs.
    *
    * An optimization is performed where all segmentation IDs are offset by the
    * smallest segmentation ID in the frame to reduce the size of the LUT.
    * Additionally, the value `0` is reserved to indicate that a segmentation ID
    * does not have a global ID, so all global IDs are offset by 1.
    *
-   * The global ID of an object with segmentation ID `segId` is `lut[segId -
-   * minSegId] - 1`.
-   *
    * For example, if we had the following segmentation IDs and global IDs:
+   * 
    * | Segmentation IDs | Global ID | Global ID + 1 |
    * |------------------|-----------|---------------|
    * | 3                | 0         | 1             |
    * | 4                | 2         | 3             |
    * | 6                | 4         | 5             |
    * | 9                | 1         | 2             |
-   *
+
    * The raw, pre-optimized LUT would be: `[0, 0, 0, 1, 3, 0, 5, 0, 0, 2]`. We
    * can reduce the size of the LUT by removing the starting 0s and just
    * tracking the smallest ID separately, which gives us `[1, 3, 0, 5, 0, 0,

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -238,20 +238,21 @@ export type GlobalIdLookupInfo = {
    * into data arrays for feature, time, track, and other data. We use a lookup
    * because segmentation IDs are not guaranteed to be unique across frames.
    *
-   * An additional optimization is performed where all segmentation IDs are
-   * offset by the smallest segmentation ID in the frame to reduce the size of
-   * the LUT.
+   * An optimization is performed where all segmentation IDs are offset by the
+   * smallest segmentation ID in the frame to reduce the size of the LUT.
+   * Additionally, the value `0` is reserved to indicate that a segmentation ID
+   * does not have a global ID, so all global IDs are offset by 1.
    *
    * The global ID of an object with segmentation ID `segId` is `lut[segId -
-   * minSegId]`.
+   * minSegId] - 1`.
    *
    * For example, if we had the following segmentation IDs and global IDs:
-   * | Segmentation IDs | Global ID |
-   * |------------------|-----------|
-   * | 3                | 1         |
-   * | 4                | 3         |
-   * | 6                | 5         |
-   * | 9                | 2         |
+   * | Segmentation IDs | Global ID | Global ID + 1 |
+   * |------------------|-----------|---------------|
+   * | 3                | 0         | 1             |
+   * | 4                | 2         | 3             |
+   * | 6                | 4         | 5             |
+   * | 9                | 1         | 2             |
    *
    * The raw, pre-optimized LUT would be: `[0, 0, 0, 1, 3, 0, 5, 0, 0, 2]`. We
    * can reduce the size of the LUT by removing the starting 0s and just
@@ -268,6 +269,15 @@ export type GlobalIdLookupInfo = {
    * The smallest segmentation on this frame, used for memory optimization.
    */
   minSegId: number;
+};
+
+export type PixelIdInfo = {
+  /** Segmentation ID of the pixel.*/
+  segId: number;
+  /** Global ID derived from the segmentation ID, used to index into data
+   * arrays. `undefined` if the segmentation ID is missing from the dataset.
+   */
+  globalId?: number;
 };
 
 /**

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -285,7 +285,8 @@ export type GlobalIdLookupInfo = {
 export type PixelIdInfo = {
   /** Segmentation ID of the pixel.*/
   segId: number;
-  /** Global ID derived from the segmentation ID, used to index into data
+  /**
+   * Global ID derived from the segmentation ID, used to index into data
    * arrays. `undefined` if the segmentation ID is missing from the dataset.
    */
   globalId?: number;

--- a/src/colorizer/utils/data_utils.ts
+++ b/src/colorizer/utils/data_utils.ts
@@ -1,6 +1,14 @@
 import { MAX_FEATURE_CATEGORIES } from "../../constants";
 import { ColorRampData } from "../colors/color_ramps";
-import { FeatureThreshold, isThresholdCategorical, isThresholdNumeric, ThresholdType } from "../types";
+import {
+  FeatureDataType,
+  FeatureThreshold,
+  GlobalIdLookupInfo,
+  isThresholdCategorical,
+  isThresholdNumeric,
+  ThresholdType,
+} from "../types";
+import { packDataTexture } from "./texture_utils";
 
 import ColorRamp from "../ColorRamp";
 import Dataset, { FeatureType } from "../Dataset";
@@ -239,4 +247,63 @@ export function hasPropertyChanged<T extends Record<string, unknown>>(
     }
   }
   return false;
+}
+
+/**
+ * Creates a lookup table that can be used to find the global ID from a
+ * segmentation ID (raw pixel value) for each frame in the dataset.
+ */
+export function buildFrameToGlobalIdLookup(
+  times: Uint32Array,
+  segIds: Uint32Array,
+  numFrames: number
+): Map<number, GlobalIdLookupInfo> {
+  const frameToLut = new Map<number, Uint32Array>();
+
+  // Get min and max segmentation IDs for each frame.
+  const frameToMinSegId: number[] = [];
+  const frameToMaxSegId: number[] = [];
+  for (let i = 0; i < times.length; i++) {
+    const time = times[i];
+    const segId = segIds[i];
+    frameToMinSegId[time] = Math.min(frameToMinSegId[time] ?? segId, segId);
+    frameToMaxSegId[time] = Math.max(frameToMaxSegId[time] ?? segId, segId);
+  }
+
+  // Initialize the arrays to hold the global IDs for each frame.
+  for (let i = 0; i < numFrames; i++) {
+    const minSegId = frameToMinSegId[i] ?? 0;
+    const maxSegId = frameToMaxSegId[i] ?? 0;
+    const lut = new Uint32Array(maxSegId - minSegId + 1);
+    frameToLut.set(i, lut);
+  }
+
+  // For each object with segmentation ID `segId` at time `t`, fill the arrays
+  // so that `frameToLut.get(t)[segId]` is the global ID of the object, used to
+  // index into the global data arrays. However, we do one extra trick for
+  // memory optimization, where the arrays are truncated to below the smallest
+  // segmentation ID for that frame. For an array [0, 0, 0, 1, 0, 2, 3], the
+  // array is saved as [1, 0, 2, 3].
+  for (let i = 0; i < times.length; i++) {
+    const time = times[i];
+    const minSegId = frameToMinSegId[time] ?? 0;
+    const segId = segIds[i] - minSegId;
+    const lut = frameToLut.get(time);
+    if (lut) {
+      lut[segId] = i;
+    }
+  }
+
+  return new Map<number, GlobalIdLookupInfo>(
+    Array.from(frameToLut.entries()).map(([frame, lut]) => {
+      return [
+        frame,
+        {
+          lut,
+          texture: packDataTexture(lut, FeatureDataType.U32),
+          minSegId: frameToMinSegId[frame] ?? 0,
+        },
+      ];
+    })
+  );
 }

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -311,19 +311,19 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   /** Report clicked tracks via the passed callback. */
   const handleClick = useCallback(
     async (event: MouseEvent): Promise<void> => {
-      const info = canv.getIdAtPixel(event.offsetX, event.offsetY);
+      const id = canv.getIdAtPixel(event.offsetX, event.offsetY);
       // Reset track input
-      if (dataset === null || info === null || info.globalId === undefined) {
+      if (dataset === null || id === null || id.globalId === undefined) {
         clearTrack();
         return;
       } else {
-        const trackId = dataset.getTrackId(info.globalId);
+        const trackId = dataset.getTrackId(id.globalId);
         const newTrack = dataset.getTrack(trackId);
         if (newTrack) {
           setTrack(newTrack);
         }
       }
-      props.onClickId(info);
+      props.onClickId(id);
     },
     [canv, dataset, props.onClickId, setTrack, clearTrack]
   );
@@ -524,8 +524,8 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       if (!dataset) {
         return;
       }
-      const info = canv.getIdAtPixel(x, y);
-      props.onMouseHover(info);
+      const id = canv.getIdAtPixel(x, y);
+      props.onMouseHover(id);
     },
     [dataset, canv]
   );

--- a/src/components/Tooltips/CanvasHoverTooltip.tsx
+++ b/src/components/Tooltips/CanvasHoverTooltip.tsx
@@ -122,7 +122,7 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
     <p key="feature_value">
       {featureName ?? "Feature"}: <span style={{ whiteSpace: "nowrap" }}>{hoveredFeatureValue}</span>
     </p>,
-    <DebugText key="object_id">Seg ID: {lastHoveredId.segId}</DebugText>,
+    <DebugText key="object_id">Pixel value: {lastHoveredId.segId}</DebugText>,
   ];
 
   if (vectorTooltipText) {

--- a/src/components/Tooltips/CanvasHoverTooltip.tsx
+++ b/src/components/Tooltips/CanvasHoverTooltip.tsx
@@ -44,7 +44,7 @@ const DebugText = styled.p`
  * - If vectors are enabled, the vector value (either magnitude or components) will be displayed.
  */
 export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverTooltipProps>): ReactElement {
-  const { lastValidHoveredId: lastHovered } = props;
+  const { lastValidHoveredId: lastHoveredId } = props;
 
   const dataset = useViewerStateStore((state) => state.dataset);
   const featureKey = useViewerStateStore((state) => state.featureKey);
@@ -71,8 +71,8 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
   );
 
   const getHoveredFeatureValue = useCallback((): string => {
-    if (lastHovered.globalId !== undefined && dataset !== null && featureKey !== null) {
-      const featureVal = getFeatureValue(lastHovered.globalId);
+    if (lastHoveredId.globalId !== undefined && dataset !== null && featureKey !== null) {
+      const featureVal = getFeatureValue(lastHoveredId.globalId);
       const categories = dataset.getFeatureCategories(featureKey);
       if (categories !== null) {
         return categories[Number.parseInt(featureVal, 10)];
@@ -81,14 +81,14 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
       }
     }
     return "N/A";
-  }, [lastHovered, dataset, getFeatureValue, featureKey]);
+  }, [lastHoveredId, dataset, getFeatureValue, featureKey]);
   const hoveredFeatureValue = getHoveredFeatureValue();
 
   const getVectorTooltipText = useCallback((): string | null => {
-    if (!vectorConfig.visible || lastHovered.globalId === undefined || !motionDeltas) {
+    if (!vectorConfig.visible || lastHoveredId.globalId === undefined || !motionDeltas) {
       return null;
     }
-    const globalId = lastHovered.globalId;
+    const globalId = lastHoveredId.globalId;
     const motionDelta = [motionDeltas[2 * globalId], motionDeltas[2 * globalId + 1]];
 
     if (Number.isNaN(motionDelta[0]) || Number.isNaN(motionDelta[1])) {
@@ -112,17 +112,17 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
       return `${vectorName}: (${x}, ${y}) px
        `;
     }
-  }, [vectorConfig, lastHovered, motionDeltas]);
+  }, [vectorConfig, lastHoveredId, motionDeltas]);
   const vectorTooltipText = getVectorTooltipText();
 
   const objectInfoContent = [
     <p key="track_id">
-      Track ID: {lastHovered.globalId !== undefined ? dataset?.getTrackId(lastHovered.globalId) : "N/A"}
+      Track ID: {lastHoveredId.globalId !== undefined ? dataset?.getTrackId(lastHoveredId.globalId) : "N/A"}
     </p>,
     <p key="feature_value">
       {featureName ?? "Feature"}: <span style={{ whiteSpace: "nowrap" }}>{hoveredFeatureValue}</span>
     </p>,
-    <DebugText key="object_id">Seg ID: {lastHovered.segId}</DebugText>,
+    <DebugText key="object_id">Seg ID: {lastHoveredId.segId}</DebugText>,
   ];
 
   if (vectorTooltipText) {
@@ -131,8 +131,8 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
 
   // Show all current labels applied to the hovered object
   const labelData = props.annotationState.data.getLabels();
-  if (lastHovered.globalId !== undefined) {
-    const labels = props.annotationState.data.getLabelsAppliedToId(lastHovered.globalId);
+  if (lastHoveredId.globalId !== undefined) {
+    const labels = props.annotationState.data.getLabelsAppliedToId(lastHoveredId.globalId);
     if (labels.length > 0 && props.annotationState.visible) {
       objectInfoContent.push(
         <div style={{ lineHeight: "28px" }}>
@@ -167,8 +167,8 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
       </Tag>
     );
 
-    if (lastHovered.globalId !== undefined) {
-      const isHoveredIdLabeled = props.annotationState.data.isLabelOnId(currentLabelIdx, lastHovered.globalId);
+    if (lastHoveredId.globalId !== undefined) {
+      const isHoveredIdLabeled = props.annotationState.data.isLabelOnId(currentLabelIdx, lastHoveredId.globalId);
       if (props.annotationState.selectionMode === AnnotationSelectionMode.TRACK) {
         const verb = isHoveredIdLabeled ? "unlabel" : "label";
         annotationLabel = (
@@ -181,7 +181,7 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
         );
       } else if (props.annotationState.selectionMode === AnnotationSelectionMode.RANGE && dataset) {
         if (props.showObjectHoverInfo) {
-          const hoveredRange = props.annotationState.getSelectRangeFromId(dataset, lastHovered.globalId);
+          const hoveredRange = props.annotationState.getSelectRangeFromId(dataset, lastHoveredId.globalId);
           if (hoveredRange !== null && hoveredRange.length > 1) {
             // Get min and max track IDs
             const id0 = hoveredRange[0];

--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -2,10 +2,9 @@ import semver from "semver";
 import { Vector2 } from "three";
 import { describe, expect, it } from "vitest";
 
-import { FeatureDataType } from "../src/colorizer";
 import { AnyManifestFile, ManifestFile } from "../src/colorizer/utils/dataset_utils";
 import { MAX_FEATURE_CATEGORIES } from "../src/constants";
-import { MOCK_DATASET_ARRAY_LOADER_DEFAULT_SOURCE, MOCK_DATASET_MANIFEST } from "./state/ViewerState/constants";
+import { MOCK_DATASET_MANIFEST } from "./state/ViewerState/constants";
 import {
   ANY_ERROR,
   DEFAULT_DATASET_DIR,
@@ -13,7 +12,6 @@ import {
   makeMockAsyncLoader,
   makeMockDataset,
   MockArrayLoader,
-  MockArraySource,
   MockFrameLoader,
 } from "./test_utils";
 
@@ -268,38 +266,5 @@ describe("Dataset", () => {
     expect(dataset.has3dFrames()).to.be.true;
     const source = dataset.frames3dSrc;
     expect(source).to.equal(DEFAULT_DATASET_DIR + "seg.ome.zarr");
-  });
-
-  describe("frameToIdOffset", () => {
-    it("returns 0 offsets if segmentation IDs are globally unique", async () => {
-      const mockArrayLoaderSource = {
-        ...MOCK_DATASET_ARRAY_LOADER_DEFAULT_SOURCE,
-        [DEFAULT_DATASET_DIR + "seg_ids.json"]: new MockArraySource(
-          FeatureDataType.U32,
-          new Uint32Array([1, 2, 3, 4, 5, 6, 7, 8, 9])
-        ),
-      };
-      const mockArrayLoader = new MockArrayLoader(mockArrayLoaderSource);
-      const dataset = await makeMockDataset(MOCK_DATASET_MANIFEST, mockArrayLoader);
-
-      const frameToIdOffset = dataset.frameToIdOffset;
-      expect(frameToIdOffset).to.deep.equal(new Uint32Array([0, 0, 0, 0]));
-    });
-
-    it("calculates ID offsets from frame-local segmentation IDs", async () => {
-      const mockArrayLoaderSource = {
-        ...MOCK_DATASET_ARRAY_LOADER_DEFAULT_SOURCE,
-        [DEFAULT_DATASET_DIR + "seg_ids.json"]: new MockArraySource(
-          FeatureDataType.U32,
-          // time array:  [0, 0, 0, 1, 1, 1, 2, 2, 3]
-          new Uint32Array([1, 2, 3, 1, 2, 3, 1, 2, 1])
-        ),
-      };
-      const mockArrayLoader = new MockArrayLoader(mockArrayLoaderSource);
-      const dataset = await makeMockDataset(MOCK_DATASET_MANIFEST, mockArrayLoader);
-
-      const frameToIdOffset = dataset.frameToIdOffset;
-      expect(frameToIdOffset).to.deep.equal(new Uint32Array([0, 3, 6, 8]));
-    });
   });
 });

--- a/tests/data_utils.test.ts
+++ b/tests/data_utils.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import { FeatureThreshold, ThresholdType } from "../src/colorizer/types";
-import { getIntervals, getKeyFromName, validateThresholds } from "../src/colorizer/utils/data_utils";
+import {
+  buildFrameToGlobalIdLookup,
+  getIntervals,
+  getKeyFromName,
+  validateThresholds,
+} from "../src/colorizer/utils/data_utils";
 import { makeMockDataset } from "./test_utils";
 
 describe("data_utils", () => {
@@ -127,6 +132,99 @@ describe("data_utils", () => {
         [9, 10],
         [14, 14],
       ]);
+    });
+  });
+
+  describe("buildFrameToGlobalIdLookup", () => {
+    it("maps globally-unique segmentation ids to global ids", () => {
+      const times = Uint32Array.from([0, 0, 0, 0, 0]);
+      const segIds = Uint32Array.from([0, 1, 2, 3, 4]);
+      const numFrames = 1;
+      const frameToGlobalIdLookup = buildFrameToGlobalIdLookup(times, segIds, numFrames);
+      expect(frameToGlobalIdLookup.size).to.equal(1);
+      const lookup0 = frameToGlobalIdLookup.get(0);
+      expect(lookup0).to.not.be.undefined;
+      expect(lookup0?.lut).to.deep.equal(new Uint32Array([0, 1, 2, 3, 4]));
+      expect(lookup0?.minSegId).to.equal(0);
+    });
+
+    it("maps globally-unique segmentation ids across multiple frames", () => {
+      const times = Uint32Array.from([0, 0, 0, 0, 0, 2, 2, 2]);
+      const segIds = Uint32Array.from([0, 1, 2, 3, 4, 5, 6, 7]);
+      const numFrames = 3;
+      const frameToGlobalIdLookup = buildFrameToGlobalIdLookup(times, segIds, numFrames);
+      expect(frameToGlobalIdLookup.size).to.equal(3);
+
+      const lookup0 = frameToGlobalIdLookup.get(0);
+      expect(lookup0?.lut).to.deep.equal(new Uint32Array([0, 1, 2, 3, 4]));
+      expect(lookup0?.minSegId).to.equal(0);
+
+      const lookup1 = frameToGlobalIdLookup.get(1);
+      expect(lookup1?.lut).to.deep.equal(new Uint32Array([0]));
+      expect(lookup1?.minSegId).to.equal(0);
+
+      const lookup2 = frameToGlobalIdLookup.get(2);
+      expect(lookup2?.lut).to.deep.equal(new Uint32Array([5, 6, 7]));
+      expect(lookup2?.minSegId).to.equal(5);
+    });
+
+    it("maps non-unique segmentation ids across multiple frames", () => {
+      const times = Uint32Array.from([0, 0, 0, 0, 2, 2, 2]);
+      const segIds = Uint32Array.from([1, 2, 3, 4, 1, 2, 3]);
+      const numFrames = 3;
+      const frameToGlobalIdLookup = buildFrameToGlobalIdLookup(times, segIds, numFrames);
+      expect(frameToGlobalIdLookup.size).to.equal(3);
+      const lookup0 = frameToGlobalIdLookup.get(0);
+
+      expect(lookup0?.lut).to.deep.equal(new Uint32Array([0, 1, 2, 3]));
+      expect(lookup0?.minSegId).to.equal(1);
+
+      const lookup1 = frameToGlobalIdLookup.get(1);
+      expect(lookup1?.lut).to.deep.equal(new Uint32Array([0]));
+      expect(lookup1?.minSegId).to.equal(0);
+
+      const lookup2 = frameToGlobalIdLookup.get(2);
+      expect(lookup2?.lut).to.deep.equal(new Uint32Array([4, 5, 6]));
+      expect(lookup2?.minSegId).to.equal(1);
+    });
+
+    it("maps sparse segmentation ids", () => {
+      const times = Uint32Array.from([0, 0, 0, 0, 1, 1]);
+      const segIds = Uint32Array.from([1, 2, 4, 7, 3, 4]);
+      const numFrames = 2;
+      const frameToGlobalIdLookup = buildFrameToGlobalIdLookup(times, segIds, numFrames);
+      expect(frameToGlobalIdLookup.size).to.equal(2);
+
+      // lut[segId - minSegId] = index in original times/segIds arrays
+      //                                        seg IDs:  1  2     4        7
+      const lookup0 = frameToGlobalIdLookup.get(0);
+      expect(lookup0?.lut).to.deep.equal(new Uint32Array([0, 1, 0, 2, 0, 0, 3]));
+      expect(lookup0?.minSegId).to.equal(1);
+
+      const lookup1 = frameToGlobalIdLookup.get(1);
+      //                                        seg IDs:  3  4
+      expect(lookup1?.lut).to.deep.equal(new Uint32Array([4, 5]));
+      expect(lookup1?.minSegId).to.equal(3);
+    });
+
+    it("maps unsorted, non-unique segmentation ids", () => {
+      const times = Uint32Array.from([0, 1, 0, 1, 0, 1]);
+      const segIds = Uint32Array.from([4, 2, 3, 5, 1, 4]);
+      // Time 0: 1, 3, 4
+      // Time 1: 2, 4, 5
+      const numFrames = 2;
+      const frameToGlobalIdLookup = buildFrameToGlobalIdLookup(times, segIds, numFrames);
+      expect(frameToGlobalIdLookup.size).to.equal(2);
+
+      const lookup0 = frameToGlobalIdLookup.get(0);
+      //                                        seg IDs:  1     3  4
+      expect(lookup0?.lut).to.deep.equal(new Uint32Array([4, 0, 2, 0]));
+      expect(lookup0?.minSegId).to.equal(1);
+
+      const lookup1 = frameToGlobalIdLookup.get(1);
+      //                                        seg IDs:  2     4  5
+      expect(lookup1?.lut).to.deep.equal(new Uint32Array([1, 0, 5, 3]));
+      expect(lookup1?.minSegId).to.equal(2);
     });
   });
 });

--- a/tests/data_utils.test.ts
+++ b/tests/data_utils.test.ts
@@ -144,7 +144,8 @@ describe("data_utils", () => {
       expect(frameToGlobalIdLookup.size).to.equal(1);
       const lookup0 = frameToGlobalIdLookup.get(0);
       expect(lookup0).to.not.be.undefined;
-      expect(lookup0?.lut).to.deep.equal(new Uint32Array([0, 1, 2, 3, 4]));
+      // Values will be offset by 1 so 0 represents missing data
+      expect(lookup0?.lut).to.deep.equal(new Uint32Array([1, 2, 3, 4, 5]));
       expect(lookup0?.minSegId).to.equal(0);
     });
 
@@ -156,7 +157,7 @@ describe("data_utils", () => {
       expect(frameToGlobalIdLookup.size).to.equal(3);
 
       const lookup0 = frameToGlobalIdLookup.get(0);
-      expect(lookup0?.lut).to.deep.equal(new Uint32Array([0, 1, 2, 3, 4]));
+      expect(lookup0?.lut).to.deep.equal(new Uint32Array([1, 2, 3, 4, 5]));
       expect(lookup0?.minSegId).to.equal(0);
 
       const lookup1 = frameToGlobalIdLookup.get(1);
@@ -164,7 +165,7 @@ describe("data_utils", () => {
       expect(lookup1?.minSegId).to.equal(0);
 
       const lookup2 = frameToGlobalIdLookup.get(2);
-      expect(lookup2?.lut).to.deep.equal(new Uint32Array([5, 6, 7]));
+      expect(lookup2?.lut).to.deep.equal(new Uint32Array([6, 7, 8]));
       expect(lookup2?.minSegId).to.equal(5);
     });
 
@@ -176,7 +177,7 @@ describe("data_utils", () => {
       expect(frameToGlobalIdLookup.size).to.equal(3);
       const lookup0 = frameToGlobalIdLookup.get(0);
 
-      expect(lookup0?.lut).to.deep.equal(new Uint32Array([0, 1, 2, 3]));
+      expect(lookup0?.lut).to.deep.equal(new Uint32Array([1, 2, 3, 4]));
       expect(lookup0?.minSegId).to.equal(1);
 
       const lookup1 = frameToGlobalIdLookup.get(1);
@@ -184,7 +185,7 @@ describe("data_utils", () => {
       expect(lookup1?.minSegId).to.equal(0);
 
       const lookup2 = frameToGlobalIdLookup.get(2);
-      expect(lookup2?.lut).to.deep.equal(new Uint32Array([4, 5, 6]));
+      expect(lookup2?.lut).to.deep.equal(new Uint32Array([5, 6, 7]));
       expect(lookup2?.minSegId).to.equal(1);
     });
 
@@ -198,12 +199,12 @@ describe("data_utils", () => {
       // lut[segId - minSegId] = index in original times/segIds arrays
       //                                        seg IDs:  1  2     4        7
       const lookup0 = frameToGlobalIdLookup.get(0);
-      expect(lookup0?.lut).to.deep.equal(new Uint32Array([0, 1, 0, 2, 0, 0, 3]));
+      expect(lookup0?.lut).to.deep.equal(new Uint32Array([1, 2, 0, 3, 0, 0, 4]));
       expect(lookup0?.minSegId).to.equal(1);
 
       const lookup1 = frameToGlobalIdLookup.get(1);
       //                                        seg IDs:  3  4
-      expect(lookup1?.lut).to.deep.equal(new Uint32Array([4, 5]));
+      expect(lookup1?.lut).to.deep.equal(new Uint32Array([5, 6]));
       expect(lookup1?.minSegId).to.equal(3);
     });
 
@@ -218,12 +219,12 @@ describe("data_utils", () => {
 
       const lookup0 = frameToGlobalIdLookup.get(0);
       //                                        seg IDs:  1     3  4
-      expect(lookup0?.lut).to.deep.equal(new Uint32Array([4, 0, 2, 0]));
+      expect(lookup0?.lut).to.deep.equal(new Uint32Array([5, 0, 3, 1]));
       expect(lookup0?.minSegId).to.equal(1);
 
       const lookup1 = frameToGlobalIdLookup.get(1);
       //                                        seg IDs:  2     4  5
-      expect(lookup1?.lut).to.deep.equal(new Uint32Array([1, 0, 5, 3]));
+      expect(lookup1?.lut).to.deep.equal(new Uint32Array([2, 0, 6, 4]));
       expect(lookup1?.minSegId).to.equal(2);
     });
   });

--- a/tests/data_utils.test.ts
+++ b/tests/data_utils.test.ts
@@ -196,7 +196,7 @@ describe("data_utils", () => {
       const frameToGlobalIdLookup = buildFrameToGlobalIdLookup(times, segIds, numFrames);
       expect(frameToGlobalIdLookup.size).to.equal(2);
 
-      // lut[segId - minSegId] = index in original times/segIds arrays
+      // lut[segId - minSegId] - 1 = index in original times/segIds arrays
       //                                        seg IDs:  1  2     4        7
       const lookup0 = frameToGlobalIdLookup.get(0);
       expect(lookup0?.lut).to.deep.equal(new Uint32Array([1, 2, 0, 3, 0, 0, 4]));


### PR DESCRIPTION
Problem
=======
Closes #630, "display datasets with arbitrary segmentation IDs". 

This change allows datasets to skip the preprocessing step for 3D volumes and virtually eliminates it for 2D images as well! It removes a lot of the assumptions we were previously making about the ordering of data, and handles edge cases caused by missing data that we were previously not addressing.

NOTE: This branch will fail unit tests until the corresponding PR in vole-core (https://github.com/allen-cell-animated/vole-core/pull/313) is merged and released.

*Estimated review size: medium, 20-30 minutes (most of line count is unit tests, comments, and whitespace)*

Solution
========
- On load, Datasets now create a lookup for every frame that maps from segmentation IDs to global indices into the feature arrays.
  - This is passed into the 3D and 2D viewports.
- Updated Canvas `getIdAtPixel` to report additional information (both seg ID + global ID) to handle the case where segmentations do not have a corresponding global ID (e.g. data is missing).
- Updated canvas hover tooltip to show segmentation ID for debugging.
- Added unit tests.

## Type of change

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-637/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fpeyton.lee%2Ftfe-emt-nuclear-segmentations%2Fdata%2Ftfe%2Fcollection.json&dataset=EMT+3D&feature=volume&t=47&color=matplotlib-cool&keep-range=1&range=1999%2C90963
2. Play through time. Coloring by volume should look consistent (besides occasional flashing)

Screenshots (optional):
-----------------------
**Video talk-through (🔊):**

https://github.com/user-attachments/assets/f1c2db34-1571-405e-9e9c-e25ceb4b9730


Keyfiles (delete if not relevant):
-----------------------
1. `types.ts`
4. `data_utils.ts`
5. `IRenderCanvas.ts`

