### PR TITLE
feat: Support 3D centroids (3D pt. 6)

### DIFF
--- a/src/colorizer/ColorizeCanvas2D.ts
+++ b/src/colorizer/ColorizeCanvas2D.ts
@@ -410,8 +410,9 @@ export default class ColorizeCanvas2D implements IRenderCanvas {
       }
 
       // Normalize from pixel coordinates to canvas space [-1, 1]
-      this.points[3 * i + 0] = (track.centroids[3 * trackIndex] / dataset.frameResolution.x) * 2.0 - 1.0;
-      this.points[3 * i + 1] = -((track.centroids[3 * trackIndex + 1] / dataset.frameResolution.y) * 2.0 - 1.0);
+      const centroid = dataset.getCentroid(track.ids[trackIndex])!;
+      this.points[3 * i + 0] = (centroid[0] / dataset.frameResolution.x) * 2.0 - 1.0;
+      this.points[3 * i + 1] = -((centroid[1] / dataset.frameResolution.y) * 2.0 - 1.0);
       this.points[3 * i + 2] = 0;
     }
     // Assign new BufferAttribute because the old array has been discarded.

--- a/src/colorizer/ColorizeCanvas2D.ts
+++ b/src/colorizer/ColorizeCanvas2D.ts
@@ -410,8 +410,8 @@ export default class ColorizeCanvas2D implements IRenderCanvas {
       }
 
       // Normalize from pixel coordinates to canvas space [-1, 1]
-      this.points[3 * i + 0] = (track.centroids[2 * trackIndex] / dataset.frameResolution.x) * 2.0 - 1.0;
-      this.points[3 * i + 1] = -((track.centroids[2 * trackIndex + 1] / dataset.frameResolution.y) * 2.0 - 1.0);
+      this.points[3 * i + 0] = (track.centroids[3 * trackIndex] / dataset.frameResolution.x) * 2.0 - 1.0;
+      this.points[3 * i + 1] = -((track.centroids[3 * trackIndex + 1] / dataset.frameResolution.y) * 2.0 - 1.0);
       this.points[3 * i + 2] = 0;
     }
     // Assign new BufferAttribute because the old array has been discarded.

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -697,7 +697,7 @@ export default class Dataset {
     const centroidsData = this.centroids;
     if (centroidsData) {
       centroids = ids.reduce((result, i) => {
-        result.push(centroidsData[3 * i], centroidsData[3 * i + 1], centroidsData[3 * i + 2]);
+        result.push(...this.getCentroid(i)!);
         return result;
       }, [] as number[]);
     }

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -667,7 +667,7 @@ export default class Dataset {
     const x = this.centroids?.[index];
     const y = this.centroids?.[index + 1];
     const z = this.centroids?.[index + 2];
-    if (x && y && z) {
+    if (x !== undefined && y !== undefined && z !== undefined) {
       return [x, y, z];
     }
     return undefined;

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -11,6 +11,7 @@ import {
 import { AnalyticsEvent, triggerAnalyticsEvent } from "./utils/analytics";
 import { formatAsBulletList, getKeyFromName } from "./utils/data_utils";
 import { ManifestFile, ManifestFileMetadata, updateManifestVersion } from "./utils/dataset_utils";
+import { padCentroidsTo3d } from "./utils/math_utils";
 import * as urlUtils from "./utils/url_utils";
 
 import DataCache from "./DataCache";
@@ -607,6 +608,11 @@ export default class Dataset {
     // Construct offset array for frame IDs to segmentation IDs.
     this.frameToIdOffset = this.buildFrameToIdOffsetsFromSegIds();
 
+    // Fixup 2D centroids to 3D
+    if (this.centroids) {
+      this.centroids = padCentroidsTo3d(this.centroids, this.numObjects);
+    }
+
     // Analytics reporting
     triggerAnalyticsEvent(AnalyticsEvent.DATASET_LOAD, {
       datasetWriterVersion: this.metadata.writerVersion || "N/A",
@@ -656,12 +662,13 @@ export default class Dataset {
   /**
    * Returns the 2D centroid of a given object id.
    */
-  public getCentroid(objectId: number): [number, number] | undefined {
-    const index = objectId * 2;
+  public getCentroid(objectId: number): [number, number, number] | undefined {
+    const index = objectId * 3;
     const x = this.centroids?.[index];
     const y = this.centroids?.[index + 1];
-    if (x && y) {
-      return [x, y];
+    const z = this.centroids?.[index + 2];
+    if (x && y && z) {
+      return [x, y, z];
     }
     return undefined;
   }
@@ -687,9 +694,10 @@ export default class Dataset {
     const times = this.times ? ids.map((i) => (this.times ? this.times[i] : 0)) : [];
 
     let centroids: number[] = [];
-    if (this.centroids) {
+    const centroidsData = this.centroids;
+    if (centroidsData) {
       centroids = ids.reduce((result, i) => {
-        result.push(this.centroids![2 * i], this.centroids![2 * i + 1]);
+        result.push(centroidsData[3 * i], centroidsData[3 * i + 1], centroidsData[3 * i + 2]);
         return result;
       }, [] as number[]);
     }

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -629,17 +629,17 @@ export default class Dataset {
   }
 
   /**
-   * Returns the 2D centroid of a given object id.
+   * Returns the 3D centroid of a given object id.
    */
   public getCentroid(objectId: number): [number, number, number] | undefined {
     const index = objectId * 3;
-    const x = this.centroids?.[index];
-    const y = this.centroids?.[index + 1];
-    const z = this.centroids?.[index + 2];
-    if (x !== undefined && y !== undefined && z !== undefined) {
-      return [x, y, z];
+    if (this.centroids === undefined || this.centroids === null || index + 2 >= this.centroids.length) {
+      return undefined;
     }
-    return undefined;
+    const x = this.centroids[index];
+    const y = this.centroids[index + 1];
+    const z = this.centroids[index + 2];
+    return [x, y, z];
   }
 
   private getIdsOfTrack(trackId: number): number[] {

--- a/src/colorizer/Track.ts
+++ b/src/colorizer/Track.ts
@@ -25,7 +25,7 @@ export default class Track {
       this.ids = indices.map((i) => ids[i]);
 
       this.centroids = indices.reduce((result, i) => {
-        result.push(centroids[i * 2], centroids[i * 2 + 1]);
+        result.push(centroids[i * 3], centroids[i * 3 + 1], centroids[i * 3 + 2]);
         return result;
       }, [] as number[]);
 

--- a/src/colorizer/VectorField.ts
+++ b/src/colorizer/VectorField.ts
@@ -203,7 +203,7 @@ export default class VectorField {
     return vertices;
   }
 
-  private getArrowVertices(centroid: [number, number], delta: [number, number]): Float32Array {
+  private getArrowVertices(centroid: [number, number, number], delta: [number, number, number]): Float32Array {
     // Draw the main vector line segment from centroid to centroid + delta.
     // TODO: Perform scaling as a step in a vertex shader.
     const vertices = new Float32Array(VERTICES_PER_VECTOR_LINE * VERTEX_LENGTH);
@@ -212,6 +212,8 @@ export default class VectorField {
     const vectorEnd: ArrayVector3 = [
       centroid[0] + delta[0] * this.scaleFactor,
       centroid[1] + delta[1] * this.scaleFactor,
+      // NOTE: We discard 3D component of vector here because this is in 2D, but
+      // some future 3D vector visualization may want to use this.
       0,
     ];
     const normVectorEnd = this.framePixelsToRelativeFrameCoords(vectorEnd);
@@ -251,8 +253,9 @@ export default class VectorField {
       const time = this.dataset.getTime(i);
       const ids = timeToIds.get(time) ?? [];
       if (
-        Number.isNaN(this.vectorData[i * 2]) ||
-        Number.isNaN(this.vectorData[i * 2 + 1]) ||
+        Number.isNaN(this.vectorData[i * 3]) ||
+        Number.isNaN(this.vectorData[i * 3 + 1]) ||
+        Number.isNaN(this.vectorData[i * 3 + 2]) ||
         this.dataset.getCentroid(i) === undefined
       ) {
         continue;
@@ -273,7 +276,11 @@ export default class VectorField {
 
       for (const objectId of ids) {
         const centroid = this.dataset.getCentroid(objectId)!;
-        const delta: [number, number] = [this.vectorData[objectId * 2], this.vectorData[objectId * 2 + 1]];
+        const delta: [number, number, number] = [
+          this.vectorData[objectId * 3],
+          this.vectorData[objectId * 3 + 1],
+          this.vectorData[objectId * 3 + 2],
+        ];
 
         const arrowVertices = this.getArrowVertices(centroid, delta);
         vertices.set(arrowVertices, nextEmptyIndex * VERTEX_LENGTH);

--- a/src/colorizer/utils/math_utils.ts
+++ b/src/colorizer/utils/math_utils.ts
@@ -206,7 +206,7 @@ export function constructAllTracksFromData(trackIds: Uint32Array, times: Uint32A
     }
     trackData.ids.push(id);
     trackData.times.push(times[id]);
-    trackData.centroids.push(centroids[id * 2], centroids[id * 2 + 1]);
+    trackData.centroids.push(centroids[id * 3], centroids[id * 3 + 1], centroids[id * 3 + 2]);
   }
 
   // Construct and return tracks. Tracks will automatically sort their data by time.
@@ -220,8 +220,8 @@ export function constructAllTracksFromData(trackIds: Uint32Array, times: Uint32A
  * Returns a lookup from any timepoints `t` in the track to the position delta between the centroid
  * at time `t` and `t-1`. If the track does not exist at timepoint `t-1`, the delta is undefined.
  */
-function timeToMotionDelta(track: Track): { [key: number]: [number, number] | undefined } {
-  const deltas: { [key: number]: [number, number] | undefined } = {};
+function timeToMotionDelta(track: Track): { [key: number]: [number, number, number] | undefined } {
+  const deltas: { [key: number]: [number, number, number] | undefined } = {};
 
   // Track IDs are sorted by time, but are not guaranteed to be contiguous.
   // For each time `t`, check if `t-1` exists and then calculate the delta.
@@ -232,11 +232,17 @@ function timeToMotionDelta(track: Track): { [key: number]: [number, number] | un
       deltas[time] = undefined;
     }
 
-    const currentCentroidX = track.centroids[i * 2];
-    const currentCentroidY = track.centroids[i * 2 + 1];
-    const prevCentroidX = track.centroids[(i - 1) * 2];
-    const prevCentroidY = track.centroids[(i - 1) * 2 + 1];
-    deltas[time] = [currentCentroidX - prevCentroidX, currentCentroidY - prevCentroidY];
+    const currentCentroidX = track.centroids[i * 3];
+    const currentCentroidY = track.centroids[i * 3 + 1];
+    const currentCentroidZ = track.centroids[i * 3 + 2];
+    const prevCentroidX = track.centroids[(i - 1) * 3];
+    const prevCentroidY = track.centroids[(i - 1) * 3 + 1];
+    const prevCentroidZ = track.centroids[(i - 1) * 3 + 2];
+    deltas[time] = [
+      currentCentroidX - prevCentroidX,
+      currentCentroidY - prevCentroidY,
+      currentCentroidZ - prevCentroidZ,
+    ];
   }
 
   return deltas;
@@ -261,7 +267,7 @@ export function calculateMotionDeltas(tracks: Track[], numTimeIntervals: number)
   for (const track of tracks) {
     numObjects += track.ids.length;
   }
-  const motionDeltas = new Float32Array(numObjects * 2);
+  const motionDeltas = new Float32Array(numObjects * 3);
 
   for (const track of tracks) {
     const timeToDelta = timeToMotionDelta(track);
@@ -271,7 +277,7 @@ export function calculateMotionDeltas(tracks: Track[], numTimeIntervals: number)
       const timestamp = track.times[i];
 
       // Get all valid deltas for timepoints `t` to `t - numTimesteps`.
-      const deltas: [number, number][] = [];
+      const deltas: [number, number, number][] = [];
       for (let j = 0; j < numTimeIntervals; j++) {
         const delta = timeToDelta[timestamp - j];
         if (delta) {
@@ -282,19 +288,50 @@ export function calculateMotionDeltas(tracks: Track[], numTimeIntervals: number)
       // Check that the object has enough valid deltas to meet the threshold;
       // if so average and store the delta.
       if (deltas.length === numTimeIntervals) {
-        const averagedDelta: [number, number] = deltas.reduce(
-          (acc, delta) => [acc[0] + delta[0] / deltas.length, acc[1] + delta[1] / deltas.length],
-          [0, 0]
+        const averagedDelta: [number, number, number] = deltas.reduce(
+          (acc, delta) => [
+            acc[0] + delta[0] / deltas.length,
+            acc[1] + delta[1] / deltas.length,
+            acc[2] + delta[2] / deltas.length,
+          ],
+          [0, 0, 0]
         );
-        motionDeltas[2 * objectId] = averagedDelta[0];
-        motionDeltas[2 * objectId + 1] = averagedDelta[1];
+        motionDeltas[3 * objectId] = averagedDelta[0];
+        motionDeltas[3 * objectId + 1] = averagedDelta[1];
+        motionDeltas[3 * objectId + 2] = averagedDelta[2];
       } else {
         // NOTE: These may need to become Infinity for shader compatibility
-        motionDeltas[2 * objectId] = NaN;
-        motionDeltas[2 * objectId + 1] = NaN;
+        motionDeltas[3 * objectId] = NaN;
+        motionDeltas[3 * objectId + 1] = NaN;
+        motionDeltas[3 * objectId + 2] = NaN;
       }
     }
   }
 
   return motionDeltas;
+}
+
+/**
+ * If the centroids data is in 2D (only x and y coords), pad the data to 3D by adding
+ * a z coordinate of 0.
+ * @param centroidsData
+ * @param numObjects
+ */
+export function padCentroidsTo3d(centroidsData: Uint16Array, numObjects: number): Uint16Array {
+  if (centroidsData.length === numObjects * 3) {
+    return centroidsData;
+  } else if (centroidsData.length === numObjects * 2) {
+    const paddedCentroids = new Uint16Array(numObjects * 3);
+    for (let i = 0; i < numObjects; i++) {
+      paddedCentroids[i * 3] = centroidsData[i * 2];
+      paddedCentroids[i * 3 + 1] = centroidsData[i * 2 + 1];
+      paddedCentroids[i * 3 + 2] = 0;
+    }
+    return paddedCentroids;
+  } else {
+    console.warn(
+      `padCentroidsTo3d: Length of centroids data (${centroidsData.length}) is not a multiple of the number of objects (${numObjects}).`
+    );
+    return centroidsData;
+  }
 }

--- a/src/colorizer/workers/SharedWorkerPool.ts
+++ b/src/colorizer/workers/SharedWorkerPool.ts
@@ -68,8 +68,8 @@ export default class SharedWorkerPool {
    * @param config Vector configuration settings, including the number of time intervals to average over.
    * @returns one of the following:
    * - `undefined` if the configuration is invalid or the dataset is missing required data.
-   * - `Float32Array` of motion deltas for each object in the dataset, with length equal to `2 * dataset.numObjects`.
-   * For each object ID `i`, the motion delta is stored at `[2i, 2i + 1]`. If the delta cannot be calculated
+   * - `Float32Array` of motion deltas for each object in the dataset, with length equal to `3 * dataset.numObjects`.
+   * For each object ID `i`, the motion delta is stored at `[3i, 3i + 1, 3i + 2]`. If the delta cannot be calculated
    * for the object (e.g. it does not exist for part or all of the  the time interval), the values will be `NaN`.
    */
   async getMotionDeltas(dataset: Dataset, timeIntervals: number): Promise<Float32Array | undefined> {

--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -302,4 +302,44 @@ describe("Dataset", () => {
       expect(frameToIdOffset).to.deep.equal(new Uint32Array([0, 3, 6, 8]));
     });
   });
+
+  describe("centroids data", () => {
+    it("loads 2D centroid data as 3D", async () => {
+      const mockArrayLoaderSource = {
+        ...MOCK_DATASET_ARRAY_LOADER_DEFAULT_SOURCE,
+        [DEFAULT_DATASET_DIR + "centroids.json"]: new MockArraySource(
+          FeatureDataType.F32,
+          new Float32Array([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8])
+        ),
+      };
+      const mockArrayLoader = new MockArrayLoader(mockArrayLoaderSource);
+      const mockDatasetManifest = {
+        ...MOCK_DATASET_MANIFEST,
+        centroids: "centroids.json",
+      };
+      const dataset = await makeMockDataset(mockDatasetManifest, mockArrayLoader);
+      expect(dataset.centroids).to.deep.equal(
+        new Uint16Array([0, 0, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0, 4, 4, 0, 5, 5, 0, 6, 6, 0, 7, 7, 0, 8, 8, 0])
+      );
+    });
+
+    it("loads 3D centroid data", async () => {
+      const mockArrayLoaderSource = {
+        ...MOCK_DATASET_ARRAY_LOADER_DEFAULT_SOURCE,
+        [DEFAULT_DATASET_DIR + "centroids.json"]: new MockArraySource(
+          FeatureDataType.U16,
+          new Uint16Array([0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8])
+        ),
+      };
+      const mockArrayLoader = new MockArrayLoader(mockArrayLoaderSource);
+      const mockDatasetManifest = {
+        ...MOCK_DATASET_MANIFEST,
+        centroids: "centroids.json",
+      };
+      const dataset = await makeMockDataset(mockDatasetManifest, mockArrayLoader);
+      expect(dataset.centroids).to.deep.equal(
+        new Uint16Array([0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8])
+      );
+    });
+  });
 });


### PR DESCRIPTION
Problem
=======
Closes #556, "support 3D centroids."

This change updates Dataset to store centroids with 3D coordinates instead of just 2D, and updates all of the internal logic dealing with centroids data to match.

*Estimated review size: small, 10-15 minutes*

Solution
========
- Updated `Dataset` to convert from 2D centroids to 3D centroids on load.
- Updated logic for track paths, annotation, and vectors to use 3D centroid coordinates.
- Fixed a bug in `Dataset.getCentroid` where it would return `undefined` for vectors with `0` as a component.
- Added unit tests.

## Type of change

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open PR preview: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-643/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&feature=volume&track=74440&t=118&path=1&vc=1&vc-key=_motion_&vc-color=000000&vc-scale=8&vc-tooltip=m&vc-time-int=5
2. Click on a track and play through time. The motion vectors and track path should update correctly.

Screenshots (optional):
-----------------------
**Video talk-through (🔊):**

https://github.com/user-attachments/assets/95a348de-ddc1-41db-b613-1b4cf1d624c6

