### PR TITLE
feat: Improved label creation flow (new annotations pt. 1)

### DIFF
--- a/src/colorizer/AnnotationData.ts
+++ b/src/colorizer/AnnotationData.ts
@@ -1,6 +1,7 @@
 import Papa from "papaparse";
 import { Color } from "three";
 
+import { removeUndefinedProperties } from "../state/utils/data_validation";
 import { DEFAULT_CATEGORICAL_PALETTE_KEY, KNOWN_CATEGORICAL_PALETTES } from "./colors/categorical_palettes";
 
 import Dataset from "./Dataset";
@@ -8,6 +9,15 @@ import Dataset from "./Dataset";
 const CSV_COL_ID = "ID";
 const CSV_COL_TIME = "Frame";
 const CSV_COL_TRACK = "Track";
+
+export const DEFAULT_ANNOTATION_LABEL_COLORS = KNOWN_CATEGORICAL_PALETTES.get(
+  DEFAULT_CATEGORICAL_PALETTE_KEY
+)!.colorStops;
+
+export type LabelOptions = {
+  name: string;
+  color: Color;
+};
 
 export type LabelData = {
   name: string;
@@ -83,6 +93,13 @@ export interface IAnnotationDataGetters {
   getTimeToLabelIdMap(dataset: Dataset): Map<number, Record<number, number[]>>;
 
   /**
+   * Returns the next default label settings, including name and color. Useful
+   * for ensuring labels have unique names and colors, even if some have been
+   * deleted.
+   */
+  getNextDefaultLabelSettings(): LabelOptions;
+
+  /**
    * Converts the annotation data to a CSV string.
    *
    * @param dataset Dataset object to use for time and track information.
@@ -110,14 +127,11 @@ export interface IAnnotationDataGetters {
 }
 
 export interface IAnnotationDataSetters {
-  /** Creates a new label and returns its index in the array of labels (as
-   * returned by `getLabels()`).
-   * @param name The name of the label. If no name is provided, a default name
-   * ("Label {number}") will be used.
-   * @param color The color to use for the label. If no color is provided, a
-   * color will be chosen from the default categorical palette.
+  /**
+   * Creates a new label with the given options and returns its index in the
+   * array of labels (as returned by `getLabels()`).
    * */
-  createNewLabel(name?: string, color?: Color): number;
+  createNewLabel(options?: Partial<LabelOptions>): number;
 
   setLabelName(labelIdx: number, name: string): void;
   setLabelColor(labelIdx: number, color: Color): void;
@@ -224,21 +238,22 @@ export class AnnotationData implements IAnnotationData {
     return idsToLabels;
   }
 
+  getNextDefaultLabelSettings(): LabelOptions {
+    const color = new Color(
+      DEFAULT_ANNOTATION_LABEL_COLORS[this.numLabelsCreated % DEFAULT_ANNOTATION_LABEL_COLORS.length]
+    );
+    const name = `Label ${this.numLabelsCreated + 1}`;
+    return { name, color };
+  }
+
   // Setters
 
   /** Creates a new label and returns its index. */
-  createNewLabel(name?: string, color?: Color): number {
-    if (!color) {
-      const palette = KNOWN_CATEGORICAL_PALETTES.get(DEFAULT_CATEGORICAL_PALETTE_KEY)!;
-      color = new Color(palette.colorStops[this.numLabelsCreated % palette.colorStops.length]);
-    }
-    if (!name) {
-      name = `Label ${this.numLabelsCreated + 1}`;
-    }
-
+  createNewLabel(options: Partial<LabelOptions> = {}): number {
+    options = removeUndefinedProperties(options);
     this.labelData.push({
-      name,
-      color,
+      ...this.getNextDefaultLabelSettings(),
+      ...options,
       ids: new Set(),
     });
 

--- a/src/colorizer/AnnotationData.ts
+++ b/src/colorizer/AnnotationData.ts
@@ -162,6 +162,7 @@ export class AnnotationData implements IAnnotationData {
     this.getLabeledIds = this.getLabeledIds.bind(this);
     this.getTimeToLabelIdMap = this.getTimeToLabelIdMap.bind(this);
     this.getLabels = this.getLabels.bind(this);
+    this.getNextDefaultLabelSettings = this.getNextDefaultLabelSettings.bind(this);
     this.createNewLabel = this.createNewLabel.bind(this);
     this.setLabelName = this.setLabelName.bind(this);
     this.setLabelColor = this.setLabelColor.bind(this);

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -345,6 +345,7 @@ export default class CanvasOverlay implements IRenderCanvas {
     this.timeToLabelIds = timeToLabelIds;
     this.selectedLabelIdx = selectedLabelIdx;
     this.lastClickedId = lastClickedId;
+    this.render(false);
   }
 
   // Rendering functions ////////////////////////////

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -283,6 +283,9 @@ export type AnnotationState =  {
   data: IAnnotationDataGetters;
 } & IAnnotationDataSetters;
 
+// TODO: Move this into a zustand state slice. A lot of the logic here is
+// attempting to synchronize updates between the annotation data and the UI,
+// which can be handled by zustand.
 export const useAnnotations = (): AnnotationState => {
   const annotationData = useConstructor(() => new AnnotationData());
 
@@ -457,6 +460,7 @@ export const useAnnotations = (): AnnotationState => {
       getLabeledIds: annotationData.getLabeledIds,
       getTimeToLabelIdMap: annotationData.getTimeToLabelIdMap,
       isLabelOnId: annotationData.isLabelOnId,
+      getNextDefaultLabelSettings: annotationData.getNextDefaultLabelSettings,
       toCsv: annotationData.toCsv,
     }),
     [dataUpdateCounter]

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -4,6 +4,10 @@ import styled from "styled-components";
 
 import { latoRegularEot, latoRegularTtf, latoRegularWoff, latoRegularWoff2 } from "../assets";
 
+export const Z_INDEX_TOOLTIP = 2000;
+export const Z_INDEX_POPOVER = 2050;
+export const Z_INDEX_MODAL = 2100;
+
 type AppStyleProps = {
   className?: string;
 };
@@ -410,18 +414,25 @@ export default function AppStyle(props: PropsWithChildren<AppStyleProps>): React
               marginLG: 0,
             },
             Tooltip: {
-              zIndexPopup: 2000,
+              zIndexPopup: Z_INDEX_TOOLTIP,
+            },
+            Popover: {
+              zIndexPopup: Z_INDEX_POPOVER,
             },
             Popconfirm: {
-              zIndexPopup: 2050,
+              zIndexPopup: Z_INDEX_POPOVER,
               colorText: theme.color.text.secondary,
             },
             Modal: {
               // Set z-index to 2100 here because Ant sets popups to 1050 by default, and modals to 1000.
-              zIndexBase: 2100,
-              zIndexPopupBase: 2100,
+              zIndexBase: Z_INDEX_MODAL,
+              zIndexPopupBase: Z_INDEX_MODAL,
               titleFontSize: theme.font.size.section,
               margin: 20,
+            },
+            Table: {
+              colorIcon: theme.color.text.disabled,
+              colorIconHover: theme.color.text.hint,
             },
           },
         }}

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -75,7 +75,7 @@ const theme = {
     viewport: {
       overlayBackground: "rgba(255, 255, 255, 0.8)",
       overlayOutline: "rgba(0, 0, 0, 0.2)",
-      annotationOutline: palette.themeLight,
+      annotationOutline: palette.successMediumDark,
     },
     // TODO: Reorganize the button colors by primary/default/secondary etc.
     button: {

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -146,6 +146,20 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
     return currentLabelIdx !== null ? annotationData.getLabeledIds(currentLabelIdx) : [];
   }, [currentLabelIdx, annotationData]);
 
+  const labelSelectionDropdown = (
+    <>
+      <VisuallyHidden id={LABEL_DROPDOWN_LABEL_ID}>Current label</VisuallyHidden>
+      <SelectionDropdown
+        selected={(currentLabelIdx ?? -1).toString()}
+        items={selectLabelOptions}
+        onChange={onSelectLabelIdx}
+        disabled={currentLabelIdx === null}
+        showSelectedItemTooltip={false}
+        htmlLabelId={LABEL_DROPDOWN_LABEL_ID}
+      ></SelectionDropdown>
+    </>
+  );
+
   return (
     <FlexColumnAlignCenter $gap={10}>
       <FlexRow style={{ width: "100%", justifyContent: "space-between" }}>
@@ -190,21 +204,11 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
       {/* Label selection and edit/create/delete buttons */}
       <FlexRow $gap={6} style={{ width: "100%" }}>
         <FlexRow $gap={6}>
-          <VisuallyHidden id={LABEL_DROPDOWN_LABEL_ID}>Current label</VisuallyHidden>
-          <SelectionDropdown
-            selected={(currentLabelIdx ?? -1).toString()}
-            items={selectLabelOptions}
-            onChange={onSelectLabelIdx}
-            disabled={currentLabelIdx === null}
-            showSelectedItemTooltip={false}
-            htmlLabelId={LABEL_DROPDOWN_LABEL_ID}
-          ></SelectionDropdown>
-
           {/*
            * Hide edit-related buttons until edit mode is enabled.
            * Note that currentLabelIdx will never be null when edit mode is enabled.
            */}
-          {isAnnotationModeEnabled && currentLabelIdx !== null && (
+          {isAnnotationModeEnabled && currentLabelIdx !== null ? (
             <LabelEditControls
               onCreateNewLabel={onCreateNewLabel}
               onDeleteLabel={onDeleteLabel}
@@ -215,7 +219,11 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
               selectionMode={props.annotationState.selectionMode}
               setSelectionMode={props.annotationState.setSelectionMode}
               defaultLabelOptions={props.annotationState.data.getNextDefaultLabelSettings()}
-            />
+            >
+              {labelSelectionDropdown}
+            </LabelEditControls>
+          ) : (
+            labelSelectionDropdown
           )}
         </FlexRow>
 

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -12,7 +12,7 @@ import { FlexColumnAlignCenter, FlexRow, VisuallyHidden } from "../../../styles/
 import { download } from "../../../utils/file_io";
 import { SelectItem } from "../../Dropdowns/types";
 
-import { LabelData } from "../../../colorizer/AnnotationData";
+import { LabelData, LabelOptions } from "../../../colorizer/AnnotationData";
 import TextButton from "../../Buttons/TextButton";
 import SelectionDropdown from "../../Dropdowns/SelectionDropdown";
 import LoadingSpinner from "../../LoadingSpinner";
@@ -84,8 +84,8 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
     });
   };
 
-  const onCreateNewLabel = (): void => {
-    const index = createNewLabel();
+  const onCreateNewLabel = (options: LabelOptions): void => {
+    const index = createNewLabel(options);
     setCurrentLabelIdx(index);
   };
 
@@ -179,6 +179,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
               selectedLabelIdx={currentLabelIdx}
               selectionMode={props.annotationState.selectionMode}
               setSelectionMode={props.annotationState.setSelectionMode}
+              defaultLabelOptions={props.annotationState.data.getNextDefaultLabelSettings()}
             />
           )}
         </FlexRow>

--- a/src/components/Tabs/Annotation/CreateLabelForm.tsx
+++ b/src/components/Tabs/Annotation/CreateLabelForm.tsx
@@ -1,0 +1,90 @@
+import { Color as AntdColor } from "@rc-component/color-picker";
+import { Button, ColorPicker, Input, InputRef } from "antd";
+import React, { ReactElement, useEffect, useRef, useState } from "react";
+import { Color } from "three";
+
+import { FlexColumn, FlexRow } from "../../../styles/utils";
+
+import { LabelOptions } from "../../../colorizer/AnnotationData";
+import { DEFAULT_LABEL_COLOR_PRESETS } from "./LabelEditControls";
+
+type CreateLabelFormProps = {
+  initialLabelOptions: LabelOptions;
+  onConfirm: (options: LabelOptions) => void;
+  onCancel: () => void;
+  onColorChanged: (color: Color) => void;
+  confirmText?: string;
+  focusNameInput?: boolean;
+};
+
+const defaultProps: Partial<CreateLabelFormProps> = {
+  confirmText: "Create",
+  focusNameInput: true,
+};
+
+export default function CreateLabelForm(inputProps: CreateLabelFormProps): ReactElement {
+  const props = { ...defaultProps, ...inputProps } as Required<CreateLabelFormProps>;
+
+  const [color, setColor] = useState(props.initialLabelOptions.color);
+  const [nameInput, setNameInput] = useState(props.initialLabelOptions.name);
+  const nameInputRef = useRef<InputRef>(null);
+
+  useEffect(() => {
+    if (nameInputRef.current && props.focusNameInput) {
+      nameInputRef.current.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    setColor(props.initialLabelOptions.color);
+  }, [props.initialLabelOptions.color]);
+
+  useEffect(() => {
+    setNameInput(props.initialLabelOptions.name);
+  }, [props.initialLabelOptions.name]);
+
+  const confirm = (): void => {
+    props.onConfirm({
+      color: color,
+      name: nameInput.trim(),
+    });
+  };
+
+  const onColorPickerChange = (_color: unknown, hex: string): void => {
+    const newColor = new Color(hex);
+    setColor(newColor);
+    props.onColorChanged(newColor);
+  };
+
+  return (
+    <FlexColumn style={{ width: "250px" }} $gap={10}>
+      <label style={{ gap: "10px", display: "flex", flexDirection: "row" }}>
+        <span>Name</span>
+        <Input
+          value={nameInput}
+          onChange={(e) => setNameInput(e.target.value)}
+          onPressEnter={confirm}
+          ref={nameInputRef}
+        ></Input>
+      </label>
+      <label style={{ gap: "10px", display: "flex", flexDirection: "row" }}>
+        <span>Color</span>
+        <div>
+          <ColorPicker
+            size="small"
+            value={new AntdColor(color.getHexString())}
+            onChange={onColorPickerChange}
+            disabledAlpha={true}
+            presets={DEFAULT_LABEL_COLOR_PRESETS}
+          />
+        </div>
+      </label>
+      <FlexRow style={{ marginLeft: "auto" }} $gap={10}>
+        <Button onClick={props.onCancel}>Cancel</Button>
+        <Button onClick={confirm} type="primary">
+          {props.confirmText}
+        </Button>
+      </FlexRow>
+    </FlexColumn>
+  );
+}

--- a/src/components/Tabs/Annotation/CreateLabelForm.tsx
+++ b/src/components/Tabs/Annotation/CreateLabelForm.tsx
@@ -1,11 +1,12 @@
 import { Color as AntdColor } from "@rc-component/color-picker";
-import { Button, ColorPicker, Input, InputRef } from "antd";
+import { Button, ColorPicker, ConfigProvider, Input, InputRef } from "antd";
 import React, { ReactElement, useEffect, useRef, useState } from "react";
 import { Color } from "three";
 
 import { FlexColumn, FlexRow } from "../../../styles/utils";
 
 import { LabelOptions } from "../../../colorizer/AnnotationData";
+import { Z_INDEX_POPOVER } from "../../AppStyle";
 import { DEFAULT_LABEL_COLOR_PRESETS } from "./LabelEditControls";
 
 type CreateLabelFormProps = {
@@ -15,12 +16,14 @@ type CreateLabelFormProps = {
   onColorChanged?: (color: Color) => void;
   confirmText?: string;
   focusNameInput?: boolean;
+  zIndex?: number;
 };
 
 const defaultProps: Partial<CreateLabelFormProps> = {
   confirmText: "Create",
   focusNameInput: true,
   onColorChanged: () => {},
+  zIndex: Z_INDEX_POPOVER,
 };
 
 export default function CreateLabelForm(inputProps: CreateLabelFormProps): ReactElement {
@@ -32,9 +35,10 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
 
   useEffect(() => {
     if (nameInputRef.current && props.focusNameInput) {
+      console.log("Focusing name input");
       nameInputRef.current.focus();
     }
-  }, []);
+  }, [props.focusNameInput]);
 
   useEffect(() => {
     setColor(props.initialLabelOptions.color);
@@ -70,15 +74,21 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
       </label>
       <label style={{ gap: "10px", display: "flex", flexDirection: "row" }}>
         <span>Color</span>
-        <div>
-          <ColorPicker
-            size="small"
-            value={new AntdColor(color.getHexString())}
-            onChange={onColorPickerChange}
-            disabledAlpha={true}
-            presets={DEFAULT_LABEL_COLOR_PRESETS}
-          />
-        </div>
+        {/* TODO: This is a fix for a bug where the ColorPicker's popover cannot have its
+         * containing element set. This means that we have to manually set the zIndex
+         * if it's in a modal or other element with a higher zIndex.
+         */}
+        <ConfigProvider theme={{ components: { Popover: { zIndexPopup: props.zIndex } } }}>
+          <div>
+            <ColorPicker
+              size="small"
+              value={new AntdColor(color.getHexString())}
+              onChange={onColorPickerChange}
+              disabledAlpha={true}
+              presets={DEFAULT_LABEL_COLOR_PRESETS}
+            />
+          </div>
+        </ConfigProvider>
       </label>
       <FlexRow style={{ marginLeft: "auto" }} $gap={10}>
         <Button onClick={props.onCancel}>Cancel</Button>

--- a/src/components/Tabs/Annotation/CreateLabelForm.tsx
+++ b/src/components/Tabs/Annotation/CreateLabelForm.tsx
@@ -40,14 +40,6 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
     }
   }, [props.focusNameInput]);
 
-  useEffect(() => {
-    setColor(props.initialLabelOptions.color);
-  }, [props.initialLabelOptions.color]);
-
-  useEffect(() => {
-    setNameInput(props.initialLabelOptions.name);
-  }, [props.initialLabelOptions.name]);
-
   const confirm = (): void => {
     props.onConfirm({
       color: color,

--- a/src/components/Tabs/Annotation/CreateLabelForm.tsx
+++ b/src/components/Tabs/Annotation/CreateLabelForm.tsx
@@ -12,7 +12,7 @@ type CreateLabelFormProps = {
   initialLabelOptions: LabelOptions;
   onConfirm: (options: LabelOptions) => void;
   onCancel: () => void;
-  onColorChanged: (color: Color) => void;
+  onColorChanged?: (color: Color) => void;
   confirmText?: string;
   focusNameInput?: boolean;
 };
@@ -20,6 +20,7 @@ type CreateLabelFormProps = {
 const defaultProps: Partial<CreateLabelFormProps> = {
   confirmText: "Create",
   focusNameInput: true,
+  onColorChanged: () => {},
 };
 
 export default function CreateLabelForm(inputProps: CreateLabelFormProps): ReactElement {

--- a/src/components/Tabs/Annotation/CreateLabelForm.tsx
+++ b/src/components/Tabs/Annotation/CreateLabelForm.tsx
@@ -1,12 +1,13 @@
 import { Color as AntdColor } from "@rc-component/color-picker";
 import { Button, ColorPicker, ConfigProvider, Input, InputRef } from "antd";
 import React, { ReactElement, useEffect, useRef, useState } from "react";
-import { Color } from "three";
+import { Color, ColorRepresentation } from "three";
 
 import { FlexColumn, FlexRow } from "../../../styles/utils";
 
 import { LabelOptions } from "../../../colorizer/AnnotationData";
 import { Z_INDEX_POPOVER } from "../../AppStyle";
+import { SettingsContainer, SettingsItem } from "../../SettingsContainer";
 import { DEFAULT_LABEL_COLOR_PRESETS } from "./LabelEditControls";
 
 type CreateLabelFormProps = {
@@ -35,7 +36,6 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
 
   useEffect(() => {
     if (nameInputRef.current && props.focusNameInput) {
-      console.log("Focusing name input");
       nameInputRef.current.focus();
     }
   }, [props.focusNameInput]);
@@ -56,40 +56,40 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
   };
 
   const onColorPickerChange = (_color: unknown, hex: string): void => {
-    const newColor = new Color(hex);
+    const newColor = new Color(hex as ColorRepresentation);
     setColor(newColor);
     props.onColorChanged(newColor);
   };
 
   return (
     <FlexColumn style={{ width: "250px" }} $gap={10}>
-      <label style={{ gap: "10px", display: "flex", flexDirection: "row" }}>
-        <span>Name</span>
-        <Input
-          value={nameInput}
-          onChange={(e) => setNameInput(e.target.value)}
-          onPressEnter={confirm}
-          ref={nameInputRef}
-        ></Input>
-      </label>
-      <label style={{ gap: "10px", display: "flex", flexDirection: "row" }}>
-        <span>Color</span>
-        {/* TODO: This is a fix for a bug where the ColorPicker's popover cannot have its
-         * containing element set. This means that we have to manually set the zIndex
-         * if it's in a modal or other element with a higher zIndex.
-         */}
-        <ConfigProvider theme={{ components: { Popover: { zIndexPopup: props.zIndex } } }}>
-          <div>
-            <ColorPicker
-              size="small"
-              value={new AntdColor(color.getHexString())}
-              onChange={onColorPickerChange}
-              disabledAlpha={true}
-              presets={DEFAULT_LABEL_COLOR_PRESETS}
-            />
-          </div>
-        </ConfigProvider>
-      </label>
+      <SettingsContainer>
+        <SettingsItem label="Name">
+          <Input
+            value={nameInput}
+            onChange={(e) => setNameInput(e.target.value)}
+            onPressEnter={confirm}
+            ref={nameInputRef}
+          ></Input>
+        </SettingsItem>
+        <SettingsItem label="Color">
+          {/* TODO: This is a fix for a bug where the ColorPicker's popover cannot have its
+           * containing element set. This means that we have to manually set the zIndex
+           * if it's in a modal or other element with a higher zIndex.
+           */}
+          <ConfigProvider theme={{ components: { Popover: { zIndexPopup: props.zIndex } } }}>
+            <div>
+              <ColorPicker
+                size="small"
+                value={new AntdColor(color.getHexString())}
+                onChange={onColorPickerChange}
+                disabledAlpha={true}
+                presets={DEFAULT_LABEL_COLOR_PRESETS}
+              />
+            </div>
+          </ConfigProvider>
+        </SettingsItem>
+      </SettingsContainer>
       <FlexRow style={{ marginLeft: "auto" }} $gap={10}>
         <Button onClick={props.onCancel}>Cancel</Button>
         <Button onClick={confirm} type="primary">

--- a/src/components/Tabs/Annotation/LabelEditControls.tsx
+++ b/src/components/Tabs/Annotation/LabelEditControls.tsx
@@ -9,16 +9,24 @@ import { AnnotationSelectionMode } from "../../../colorizer";
 import { StyledRadioGroup } from "../../../styles/components";
 import { FlexColumn, FlexRow } from "../../../styles/utils";
 
-import { LabelData } from "../../../colorizer/AnnotationData";
+import { DEFAULT_ANNOTATION_LABEL_COLORS, LabelData, LabelOptions } from "../../../colorizer/AnnotationData";
 import { AppThemeContext } from "../../AppStyle";
 import IconButton from "../../IconButton";
 import { TooltipWithSubtitle } from "../../Tooltips/TooltipWithSubtitle";
 
+export const DEFAULT_LABEL_COLOR_PRESETS = [
+  {
+    label: "Presets",
+    colors: DEFAULT_ANNOTATION_LABEL_COLORS,
+  },
+];
+
 type LabelEditControlsProps = {
-  onCreateNewLabel: () => void;
+  onCreateNewLabel: (options: LabelOptions) => void;
   onDeleteLabel: () => void;
   setLabelColor: (color: Color) => void;
   setLabelName: (name: string) => void;
+  defaultLabelOptions: LabelOptions;
   selectedLabel: LabelData;
   selectedLabelIdx: number;
   selectionMode: AnnotationSelectionMode;
@@ -27,6 +35,8 @@ type LabelEditControlsProps = {
 
 export default function LabelEditControls(props: LabelEditControlsProps): ReactElement {
   const theme = useContext(AppThemeContext);
+
+  const [showCreatePopover, setShowCreatePopover] = useState(false);
 
   const [showEditPopover, setShowEditPopover] = useState(false);
   const [editPopoverNameInput, setEditPopoverNameInput] = useState("");
@@ -50,12 +60,14 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
   };
 
   const onClickCreateNewLabel = (): void => {
-    props.onCreateNewLabel();
+    setShowDeletePopup(false);
     setShowEditPopover(false);
+    setShowCreatePopover(!showCreatePopover);
   };
 
   const deleteLabel = (): void => {
     props.onDeleteLabel();
+    setShowCreatePopover(false);
     setShowEditPopover(false);
     setShowDeletePopup(false);
   };
@@ -110,6 +122,7 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
             value={new AntdColor(props.selectedLabel.color.getHexString())}
             onChange={onColorPickerChange}
             disabledAlpha={true}
+            presets={DEFAULT_LABEL_COLOR_PRESETS}
           />
         </div>
       </label>

--- a/src/components/Tabs/Annotation/LabelEditControls.tsx
+++ b/src/components/Tabs/Annotation/LabelEditControls.tsx
@@ -37,12 +37,15 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
   const theme = useContext(AppThemeContext);
 
   const [showCreatePopover, setShowCreatePopover] = useState(false);
+  const createPopoverContainerRef = useRef<HTMLDivElement>(null);
   const [showEditPopover, setShowEditPopover] = useState(false);
   const editPopoverContainerRef = useRef<HTMLDivElement>(null);
 
   const [showDeletePopup, setShowDeletePopup] = useState(false);
 
   const savedLabelOptions = useRef<LabelOptions | null>(null);
+
+  // Edit popover handlers
 
   const onClickEditButton = (): void => {
     setShowEditPopover(!showEditPopover);
@@ -68,11 +71,15 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
     setShowEditPopover(false);
   };
 
-  const onClickCreateNewLabel = (): void => {
+  // Create popover handlers
+
+  const onClickCreateButton = (): void => {
+    setShowCreatePopover(!showCreatePopover);
     setShowDeletePopup(false);
     setShowEditPopover(false);
-    setShowCreatePopover(!showCreatePopover);
   };
+
+  // Delete popover handlers
 
   const deleteLabel = (): void => {
     props.onDeleteLabel();
@@ -87,15 +94,18 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
       return;
     }
     if (props.selectedLabel.ids.size > 0) {
+      // Ask for confirmation if there are selected objects.
       setShowDeletePopup(true);
       setShowEditPopover(false);
+      setShowCreatePopover(false);
     } else {
       deleteLabel();
     }
   };
 
   useEffect(() => {
-    // If the selection changes, close the edit/delete popovers.
+    // If the selection changes, close the popovers.
+    setShowCreatePopover(false);
     setShowEditPopover(false);
     setShowDeletePopup(false);
   }, [props.selectedLabelIdx]);
@@ -115,11 +125,30 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
 
   return (
     <FlexRow $gap={6}>
-      <Tooltip title="Create new label" placement="top">
-        <IconButton onClick={onClickCreateNewLabel} type="outlined">
-          <TagAddIconSVG />
-        </IconButton>
-      </Tooltip>
+      <Popover
+        title={<p style={{ fontSize: theme.font.size.label }}>Create label</p>}
+        trigger={["click"]}
+        placement="bottom"
+        content={
+          <CreateLabelForm
+            initialLabelOptions={props.defaultLabelOptions}
+            onConfirm={props.onCreateNewLabel}
+            onCancel={() => setShowCreatePopover(false)}
+            confirmText="Create"
+          />
+        }
+        open={showCreatePopover}
+        getPopupContainer={() => createPopoverContainerRef.current!}
+        style={{ zIndex: "1000" }}
+      >
+        <div ref={createPopoverContainerRef}>
+          <Tooltip title="Create new label" placement="top">
+            <IconButton onClick={onClickCreateButton} type="outlined">
+              <TagAddIconSVG />
+            </IconButton>
+          </Tooltip>
+        </div>
+      </Popover>
       <Popover
         title={<p style={{ fontSize: theme.font.size.label }}>Edit label</p>}
         trigger={["click"]}

--- a/src/components/Tabs/Annotation/LabelEditControls.tsx
+++ b/src/components/Tabs/Annotation/LabelEditControls.tsx
@@ -1,12 +1,11 @@
 import { DeleteOutlined, EditOutlined } from "@ant-design/icons";
 import { Popconfirm, Popover, Radio, Tooltip } from "antd";
-import React, { ReactElement, useContext, useEffect, useRef, useState } from "react";
+import React, { PropsWithChildren, ReactElement, useContext, useEffect, useRef, useState } from "react";
 import { Color } from "three";
 
 import { TagAddIconSVG } from "../../../assets";
 import { AnnotationSelectionMode } from "../../../colorizer";
 import { StyledRadioGroup } from "../../../styles/components";
-import { FlexRow } from "../../../styles/utils";
 
 import { DEFAULT_ANNOTATION_LABEL_COLORS, LabelData, LabelOptions } from "../../../colorizer/AnnotationData";
 import { AppThemeContext } from "../../AppStyle";
@@ -33,7 +32,7 @@ type LabelEditControlsProps = {
   setSelectionMode: (mode: AnnotationSelectionMode) => void;
 };
 
-export default function LabelEditControls(props: LabelEditControlsProps): ReactElement {
+export default function LabelEditControls(props: PropsWithChildren<LabelEditControlsProps>): ReactElement {
   const theme = useContext(AppThemeContext);
 
   const [showCreatePopover, setShowCreatePopover] = useState(false);
@@ -109,7 +108,7 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
   }, [props.selectedLabelIdx]);
 
   return (
-    <FlexRow $gap={6}>
+    <>
       <Popover
         title={<p style={{ fontSize: theme.font.size.label }}>Create label</p>}
         trigger={["click"]}
@@ -129,12 +128,13 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
       >
         <div ref={createPopoverContainerRef}>
           <Tooltip title="Create new label" placement="top">
-            <IconButton onClick={onClickCreateButton} type="outlined">
+            <IconButton onClick={onClickCreateButton} type="primary">
               <TagAddIconSVG />
             </IconButton>
           </Tooltip>
         </div>
       </Popover>
+      {props.children}
       <Popover
         title={<p style={{ fontSize: theme.font.size.label }}>Edit label</p>}
         trigger={["click"]}
@@ -181,7 +181,7 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
       </Popconfirm>
 
       <label style={{ display: "flex", flexDirection: "row", gap: "6px", marginLeft: "8px" }}>
-        <span style={{ fontSize: theme.font.size.label }}>Select by </span>
+        <span style={{ fontSize: theme.font.size.label, width: "max-content" }}>Select by </span>
         <StyledRadioGroup
           style={{ display: "flex", flexDirection: "row" }}
           value={props.selectionMode}
@@ -209,6 +209,6 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
           </Tooltip>
         </StyledRadioGroup>
       </label>
-    </FlexRow>
+    </>
   );
 }

--- a/src/components/Tabs/Annotation/LabelEditControls.tsx
+++ b/src/components/Tabs/Annotation/LabelEditControls.tsx
@@ -125,7 +125,7 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
         open={showCreatePopover}
         onOpenChange={hideOnOpenChange(setShowCreatePopover)}
         getPopupContainer={() => createPopoverContainerRef.current!}
-        style={{ zIndex: "1000" }}
+        destroyTooltipOnHide={true}
       >
         <div ref={createPopoverContainerRef}>
           <Tooltip title="Create new label" placement="top">
@@ -153,7 +153,7 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
         open={showEditPopover}
         onOpenChange={hideOnOpenChange(setShowEditPopover)}
         getPopupContainer={() => editPopoverContainerRef.current!}
-        style={{ zIndex: "1000" }}
+        destroyTooltipOnHide={true}
       >
         <div ref={editPopoverContainerRef}>
           <Tooltip title="Edit label" placement="top">

--- a/tests/colorizer/AnnotationData.test.ts
+++ b/tests/colorizer/AnnotationData.test.ts
@@ -143,9 +143,9 @@ describe("AnnotationData", () => {
 
     it("exports to CSV", () => {
       const annotationData = new AnnotationData();
-      annotationData.createNewLabel("Label 1");
-      annotationData.createNewLabel("Label 2");
-      annotationData.createNewLabel("Label 3");
+      annotationData.createNewLabel({ name: "Label 1" });
+      annotationData.createNewLabel({ name: "Label 2" });
+      annotationData.createNewLabel({ name: "Label 3" });
 
       annotationData.setLabelOnIds(0, [0], true);
       annotationData.setLabelOnIds(1, [1], true);
@@ -159,10 +159,10 @@ describe("AnnotationData", () => {
 
     it("handles labels with quote and comma characters", () => {
       const annotationData = new AnnotationData();
-      annotationData.createNewLabel('"label');
-      annotationData.createNewLabel(",,,,,");
-      annotationData.createNewLabel('a","fake label');
-      annotationData.createNewLabel('","');
+      annotationData.createNewLabel({ name: '"label' });
+      annotationData.createNewLabel({ name: ",,,,," });
+      annotationData.createNewLabel({ name: 'a","fake label' });
+      annotationData.createNewLabel({ name: '","' });
 
       annotationData.setLabelOnIds(0, [0], true);
       annotationData.setLabelOnIds(1, [1], true);
@@ -184,9 +184,9 @@ describe("AnnotationData", () => {
 
     it("trims column name whitespace on export", () => {
       const annotationData = new AnnotationData();
-      annotationData.createNewLabel(" \t Label 1");
-      annotationData.createNewLabel("\tLabel 2  ");
-      annotationData.createNewLabel("\t\tLabel 3 \t ");
+      annotationData.createNewLabel({ name: " \t Label 1" });
+      annotationData.createNewLabel({ name: "\tLabel 2  " });
+      annotationData.createNewLabel({ name: "\t\tLabel 3 \t " });
 
       const csv = annotationData.toCsv(mockDataset);
       expect(csv).to.equal(`ID,Track,Frame,Label 1,Label 2,Label 3\r\n`);
@@ -195,12 +195,12 @@ describe("AnnotationData", () => {
     it("escapes column names starting with special characters", () => {
       // See https://owasp.org/www-community/attacks/CSV_Injection
       const annotationData = new AnnotationData();
-      annotationData.createNewLabel("=SUM(A2:A5)");
-      annotationData.createNewLabel("@label");
-      annotationData.createNewLabel("+label");
-      annotationData.createNewLabel("-label");
-      annotationData.createNewLabel("\tlabel 1");
-      annotationData.createNewLabel("\rlabel 2");
+      annotationData.createNewLabel({ name: "=SUM(A2:A5)" });
+      annotationData.createNewLabel({ name: "@label" });
+      annotationData.createNewLabel({ name: "+label" });
+      annotationData.createNewLabel({ name: "-label" });
+      annotationData.createNewLabel({ name: "\tlabel 1" });
+      annotationData.createNewLabel({ name: "\rlabel 2" });
 
       const csv = annotationData.toCsv(mockDataset);
       expect(csv).to.equal(`ID,Track,Frame,"'=SUM(A2:A5)","'@label","'+label","'-label",label 1,label 2\r\n`);


### PR DESCRIPTION
Problem
=======
Closes #568, "Annotation - Open edit dialog when creating new labels."

This PR adds various improvements to the annotation label creation and editing UI. Most notably, users are prompted to add in write in a label name + choose a label color when they create a new label. This is intended to help avoid confusion about 

This change also builds a foundation towards #459, "multi-value labels". The form will be extended with additional label configuration options for different label types and behavior.

*Estimated review size: medium, 30 minutes*

Solution
========
- Updated the API for creating new labels to specify an options object.
- Added a shared form component for both creating and editing labels.
- Added a modal that appears when activating annotation edit mode for the first time prompting the user to configure the initial label.
- Added a popover that appears when users click the "Create label" button.
- Label color is reset if the edit operation is canceled.

Minor changes:
- Changes the table icon colors (which show sorting order) to be more visible.
- Changes the glow outline of the viewport to green when annotation mode is enabled.

## Type of change

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open PR preview here: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview-internal/pr-646/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&feature=volume&bg-key=max_intensity_zprojection_of_lamin_b1&t=15&tab=annotation
2. Click to enable annotation mode. A modal should appear prompting you for a new label name. Create a label.
3. Toggling on/off annotation mode again should not cause the modal to reappear.
4. Reenable annotation mode. Click the "edit label" button and a popover should appear.
5. Click the "create label" button. A new popover should appear and the old one should close. Create a new label.

Screenshots (optional):
-----------------------

**Video talk-through (🔊):**

https://github.com/user-attachments/assets/7ef6e423-d3ab-451f-9d11-365f5c126ee7

Addendum (for the two tiny changes):

https://github.com/user-attachments/assets/79610093-214e-4982-9058-af5d35903033

