### PR TITLE
refactor: Multi-value data for labels (new annotations pt. 3)

### DIFF
--- a/src/colorizer/AnnotationData.ts
+++ b/src/colorizer/AnnotationData.ts
@@ -269,7 +269,10 @@ export class AnnotationData implements IAnnotationData {
         }
       }
       throw new Error(
-        `AnnotationData.getValueFromId: ID was listed as being in label ${labelIdx} () Value for ID ${id} not found in label data ${labelIdx}.`
+        "AnnotationData.getValueFromId: ID was listed as being labeled by label " +
+          `#${labelIdx} ('${labelData.options.name}'), but no value for ID ${id} was ` +
+          "found in the label data. This indicates a mismatch between the value lookup " +
+          " and the labeled IDs, and is likely a developer error."
       );
     } else {
       return null;
@@ -300,8 +303,7 @@ export class AnnotationData implements IAnnotationData {
         if (labelData.lastValue === null) {
           return "0";
         } else {
-          const lastValue = parseInt(labelData.lastValue, 10);
-          return (lastValue + 1).toString();
+          return labelData.lastValue;
         }
     }
   }
@@ -402,6 +404,7 @@ export class AnnotationData implements IAnnotationData {
         if (ids.size === 0) {
           labelData.valueToIds.delete(value);
         }
+        break;
       }
     }
     this.markIdMapAsDirty();

--- a/src/colorizer/AnnotationData.ts
+++ b/src/colorizer/AnnotationData.ts
@@ -10,7 +10,8 @@ const CSV_COL_ID = "ID";
 const CSV_COL_TIME = "Frame";
 const CSV_COL_TRACK = "Track";
 
-export const BOOLEAN_VALUE = "true";
+export const BOOLEAN_VALUE_TRUE = "true";
+export const BOOLEAN_VALUE_FALSE = "false";
 
 export const DEFAULT_ANNOTATION_LABEL_COLORS = KNOWN_CATEGORICAL_PALETTES.get(
   DEFAULT_CATEGORICAL_PALETTE_KEY
@@ -292,7 +293,7 @@ export class AnnotationData implements IAnnotationData {
     const labelData = this.labelData[labelIdx];
     switch (labelData.options.type) {
       case LabelType.BOOLEAN:
-        return BOOLEAN_VALUE;
+        return BOOLEAN_VALUE_TRUE;
       case LabelType.INTEGER:
         if (labelData.options.autoIncrement) {
           return (parseInt(labelData.lastValue ?? "-1", 10) + 1).toString();
@@ -434,9 +435,11 @@ export class AnnotationData implements IAnnotationData {
       const time = dataset.getTime(id);
 
       const row: (string | number)[] = [id, track, time];
-      for (let i = 0; i < this.labelData.length; i++) {
-        if (labels.includes(i)) {
-          row.push(this.getValueFromId(i, id) ?? "");
+      for (let labelIdx = 0; labelIdx < this.labelData.length; labelIdx++) {
+        if (labels.includes(labelIdx)) {
+          row.push(this.getValueFromId(labelIdx, id) ?? "");
+        } else if (this.labelData[labelIdx].options.type === LabelType.BOOLEAN) {
+          row.push(BOOLEAN_VALUE_FALSE);
         } else {
           row.push("");
         }

--- a/src/colorizer/AnnotationData.ts
+++ b/src/colorizer/AnnotationData.ts
@@ -288,10 +288,13 @@ export class AnnotationData implements IAnnotationData {
       case LabelType.BOOLEAN:
         return BOOLEAN_VALUE_TRUE;
       case LabelType.INTEGER:
-        if (labelData.options.autoIncrement) {
-          return (parseInt(labelData.lastValue ?? "-1", 10) + 1).toString();
+        if (labelData.lastValue === null) {
+          return "0";
+        } else if (labelData.options.autoIncrement) {
+          const lastValueInt = parseInt(labelData.lastValue, 10);
+          return (lastValueInt + 1).toString();
         } else {
-          return (labelData.lastValue ?? "0").toString();
+          return labelData.lastValue.toString();
         }
       case LabelType.CUSTOM:
         if (labelData.lastValue === null) {

--- a/src/colorizer/AnnotationData.ts
+++ b/src/colorizer/AnnotationData.ts
@@ -10,7 +10,7 @@ const CSV_COL_ID = "ID";
 const CSV_COL_TIME = "Frame";
 const CSV_COL_TRACK = "Track";
 
-export const BOOLEAN_VALUE = "TRUE";
+export const BOOLEAN_VALUE = "true";
 
 export const DEFAULT_ANNOTATION_LABEL_COLORS = KNOWN_CATEGORICAL_PALETTES.get(
   DEFAULT_CATEGORICAL_PALETTE_KEY
@@ -437,8 +437,9 @@ export class AnnotationData implements IAnnotationData {
       for (let i = 0; i < this.labelData.length; i++) {
         if (labels.includes(i)) {
           row.push(this.getValueFromId(i, id) ?? "");
+        } else {
+          row.push("");
         }
-        row.push("");
       }
       csvRows.push(row);
     }

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -421,16 +421,25 @@ export const useAnnotations = (): AnnotationState => {
     }
     const isLabeled = annotationData.isLabelOnId(currentLabelIdx, id);
 
+    const toggleRange = (range: number[]): void => {
+      const defaultValue = annotationData.getNextDefaultLabelValue(currentLabelIdx);
+      if (isLabeled) {
+        annotationData.removeLabelOnIds(currentLabelIdx, range);
+      } else {
+        annotationData.setLabelValueOnIds(currentLabelIdx, range,defaultValue);
+      }
+    };
+
     const idRange = getSelectRangeFromId(dataset, id);
     switch (selectionMode) {
       case AnnotationSelectionMode.TRACK:
         // Toggle entire track
-        annotationData.setLabelOnIds(currentLabelIdx, track.ids, !isLabeled);
+        toggleRange(track.ids);
         break;
       case AnnotationSelectionMode.RANGE:
         if (idRange !== null) {
           setLastEditedRange(idRange);
-          annotationData.setLabelOnIds(currentLabelIdx, idRange, !isLabeled);
+          toggleRange(idRange);
           setLastClickedId(null);
         } else {
           setLastClickedId(id);
@@ -438,7 +447,7 @@ export const useAnnotations = (): AnnotationState => {
         break;
       case AnnotationSelectionMode.TIME:
       default:
-        annotationData.setLabelOnIds(currentLabelIdx, [id], !isLabeled);
+        toggleRange([id]);
         setLastClickedId(id);
     }
     setDataUpdateCounter((value) => value + 1);
@@ -462,6 +471,8 @@ export const useAnnotations = (): AnnotationState => {
       isLabelOnId: annotationData.isLabelOnId,
       getNextDefaultLabelSettings: annotationData.getNextDefaultLabelSettings,
       toCsv: annotationData.toCsv,
+      getNextDefaultLabelValue: annotationData.getNextDefaultLabelValue,
+      getValueFromId: annotationData.getValueFromId,
     }),
     [dataUpdateCounter]
   );
@@ -484,7 +495,8 @@ export const useAnnotations = (): AnnotationState => {
     createNewLabel: wrapFunctionInUpdate(annotationData.createNewLabel),
     setLabelOptions: wrapFunctionInUpdate(annotationData.setLabelOptions),
     deleteLabel: wrapFunctionInUpdate(onDeleteLabel),
-    setLabelOnIds: wrapFunctionInUpdate(annotationData.setLabelOnIds),
+    setLabelValueOnIds: wrapFunctionInUpdate(annotationData.setLabelValueOnIds),
+    removeLabelOnIds: wrapFunctionInUpdate(annotationData.removeLabelOnIds),
     clear: wrapFunctionInUpdate(clear),
   };
 };

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -43,7 +43,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
     createNewLabel,
     deleteLabel,
     setLabelOptions,
-    setLabelOnIds,
+    removeLabelOnIds,
   } = props.annotationState;
 
   const [isPending, startTransition] = useTransition();
@@ -123,10 +123,10 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
   const onClickDeleteObject = useCallback(
     (record: TableDataType): void => {
       if (currentLabelIdx !== null) {
-        setLabelOnIds(currentLabelIdx, [record.id], false);
+        removeLabelOnIds(currentLabelIdx, [record.id]);
       }
     },
-    [currentLabelIdx, setLabelOnIds]
+    [currentLabelIdx, removeLabelOnIds]
   );
 
   // Options for the selection dropdown

--- a/tests/colorizer/AnnotationData.test.ts
+++ b/tests/colorizer/AnnotationData.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { Dataset, DEFAULT_CATEGORICAL_PALETTE_KEY, KNOWN_CATEGORICAL_PALETTES } from "../../src/colorizer";
 import { compareRecord } from "../state/ViewerState/utils";
 
-import { AnnotationData, BOOLEAN_VALUE } from "../../src/colorizer/AnnotationData";
+import { AnnotationData, BOOLEAN_VALUE_FALSE, BOOLEAN_VALUE_TRUE } from "../../src/colorizer/AnnotationData";
 
 describe("AnnotationData", () => {
   const defaultPalette = KNOWN_CATEGORICAL_PALETTES.get(DEFAULT_CATEGORICAL_PALETTE_KEY)!;
@@ -74,8 +74,8 @@ describe("AnnotationData", () => {
     const annotationData = new AnnotationData();
     annotationData.createNewLabel();
     annotationData.createNewLabel();
-    annotationData.setLabelValueOnIds(0, [0, 35, 458], BOOLEAN_VALUE);
-    annotationData.setLabelValueOnIds(1, [35], BOOLEAN_VALUE);
+    annotationData.setLabelValueOnIds(0, [0, 35, 458], BOOLEAN_VALUE_TRUE);
+    annotationData.setLabelValueOnIds(1, [35], BOOLEAN_VALUE_TRUE);
 
     expect(annotationData.getLabelsAppliedToId(0)).to.deep.equal([0]);
     expect(annotationData.getLabelsAppliedToId(35)).to.deep.equal([0, 1]);
@@ -91,9 +91,9 @@ describe("AnnotationData", () => {
     const annotationData = new AnnotationData();
     annotationData.createNewLabel();
     annotationData.createNewLabel();
-    annotationData.setLabelValueOnIds(0, [0], BOOLEAN_VALUE);
-    annotationData.setLabelValueOnIds(0, [0], BOOLEAN_VALUE);
-    annotationData.setLabelValueOnIds(0, [1], BOOLEAN_VALUE);
+    annotationData.setLabelValueOnIds(0, [0], BOOLEAN_VALUE_TRUE);
+    annotationData.setLabelValueOnIds(0, [0], BOOLEAN_VALUE_TRUE);
+    annotationData.setLabelValueOnIds(0, [1], BOOLEAN_VALUE_TRUE);
 
     expect(annotationData.getLabelsAppliedToId(0)).to.deep.equal([0]);
     expect(annotationData.isLabelOnId(0, 0)).toBe(true);
@@ -116,10 +116,10 @@ describe("AnnotationData", () => {
     };
     const annotationData = new AnnotationData();
     annotationData.createNewLabel();
-    annotationData.setLabelValueOnIds(0, [0, 1, 2, 3, 4, 5], BOOLEAN_VALUE);
+    annotationData.setLabelValueOnIds(0, [0, 1, 2, 3, 4, 5], BOOLEAN_VALUE_TRUE);
 
     annotationData.createNewLabel();
-    annotationData.setLabelValueOnIds(1, [2], BOOLEAN_VALUE);
+    annotationData.setLabelValueOnIds(1, [2], BOOLEAN_VALUE_TRUE);
 
     /* eslint-disable @typescript-eslint/naming-convention */
     // ESLint doesn't like "0" and "1" being property keys.
@@ -187,16 +187,18 @@ describe("AnnotationData", () => {
       annotationData.createNewLabel({ name: "Label 2" });
       annotationData.createNewLabel({ name: "Label 3" });
 
-      annotationData.setLabelValueOnIds(0, [0], BOOLEAN_VALUE);
-      annotationData.setLabelValueOnIds(1, [1], BOOLEAN_VALUE);
-      annotationData.setLabelValueOnIds(2, [2], BOOLEAN_VALUE);
+      annotationData.setLabelValueOnIds(0, [0], BOOLEAN_VALUE_TRUE);
+      annotationData.setLabelValueOnIds(1, [1], BOOLEAN_VALUE_TRUE);
+      annotationData.setLabelValueOnIds(2, [2], BOOLEAN_VALUE_TRUE);
 
       const csv = annotationData.toCsv(mockDataset);
+      const booleanTrue = BOOLEAN_VALUE_TRUE;
+      const booleanFalse = BOOLEAN_VALUE_FALSE;
       expect(csv).to.equal(
         `ID,Track,Frame,Label 1,Label 2,Label 3\r\n` +
-          `0,0,0,${BOOLEAN_VALUE},,\r\n` +
-          `1,1,1,,${BOOLEAN_VALUE},\r\n` +
-          `2,2,2,,,${BOOLEAN_VALUE}`
+          `0,0,0,${booleanTrue},${booleanFalse},${booleanFalse}\r\n` +
+          `1,1,1,${booleanFalse},${booleanTrue},${booleanFalse}\r\n` +
+          `2,2,2,${booleanFalse},${booleanFalse},${booleanTrue}`
       );
     });
 
@@ -219,21 +221,23 @@ describe("AnnotationData", () => {
       annotationData.createNewLabel({ name: 'a","fake label' });
       annotationData.createNewLabel({ name: '","' });
 
-      annotationData.setLabelValueOnIds(0, [0], BOOLEAN_VALUE);
-      annotationData.setLabelValueOnIds(1, [1], BOOLEAN_VALUE);
-      annotationData.setLabelValueOnIds(2, [2], BOOLEAN_VALUE);
-      annotationData.setLabelValueOnIds(3, [3], BOOLEAN_VALUE);
+      annotationData.setLabelValueOnIds(0, [0], BOOLEAN_VALUE_TRUE);
+      annotationData.setLabelValueOnIds(1, [1], BOOLEAN_VALUE_TRUE);
+      annotationData.setLabelValueOnIds(2, [2], BOOLEAN_VALUE_TRUE);
+      annotationData.setLabelValueOnIds(3, [3], BOOLEAN_VALUE_TRUE);
 
       const csv = annotationData.toCsv(mockDataset);
 
       // Check csv contents here.
       // Single quotes are escaped as double quotes.
+      const booleanTrue = BOOLEAN_VALUE_TRUE;
+      const booleanFalse = BOOLEAN_VALUE_FALSE;
       expect(csv).to.equal(
         `ID,Track,Frame,"""label",",,,,,","a"",""fake label",""","""\r\n` +
-          `0,0,0,${BOOLEAN_VALUE},,,\r\n` +
-          `1,1,1,,${BOOLEAN_VALUE},,\r\n` +
-          `2,2,2,,,${BOOLEAN_VALUE},\r\n` +
-          `3,3,3,,,,${BOOLEAN_VALUE}`
+          `0,0,0,${booleanTrue},${booleanFalse},${booleanFalse},${booleanFalse}\r\n` +
+          `1,1,1,${booleanFalse},${booleanTrue},${booleanFalse},${booleanFalse}\r\n` +
+          `2,2,2,${booleanFalse},${booleanFalse},${booleanTrue},${booleanFalse}\r\n` +
+          `3,3,3,${booleanFalse},${booleanFalse},${booleanFalse},${booleanTrue}`
       );
     });
 

--- a/tests/colorizer/AnnotationData.test.ts
+++ b/tests/colorizer/AnnotationData.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { Dataset, DEFAULT_CATEGORICAL_PALETTE_KEY, KNOWN_CATEGORICAL_PALETTES } from "../../src/colorizer";
 import { compareRecord } from "../state/ViewerState/utils";
 
-import { AnnotationData } from "../../src/colorizer/AnnotationData";
+import { AnnotationData, BOOLEAN_VALUE } from "../../src/colorizer/AnnotationData";
 
 describe("AnnotationData", () => {
   const defaultPalette = KNOWN_CATEGORICAL_PALETTES.get(DEFAULT_CATEGORICAL_PALETTE_KEY)!;
@@ -74,14 +74,14 @@ describe("AnnotationData", () => {
     const annotationData = new AnnotationData();
     annotationData.createNewLabel();
     annotationData.createNewLabel();
-    annotationData.setLabelOnIds(0, [0, 35, 458], true);
-    annotationData.setLabelOnIds(1, [35], true);
+    annotationData.setLabelValueOnIds(0, [0, 35, 458], BOOLEAN_VALUE);
+    annotationData.setLabelValueOnIds(1, [35], BOOLEAN_VALUE);
 
     expect(annotationData.getLabelsAppliedToId(0)).to.deep.equal([0]);
     expect(annotationData.getLabelsAppliedToId(35)).to.deep.equal([0, 1]);
     expect(annotationData.getLabelsAppliedToId(458)).to.deep.equal([0]);
 
-    annotationData.setLabelOnIds(0, [35], false);
+    annotationData.removeLabelOnIds(0, [35]);
     expect(annotationData.getLabelsAppliedToId(0)).to.deep.equal([0]);
     expect(annotationData.getLabelsAppliedToId(35)).to.deep.equal([1]);
     expect(annotationData.getLabelsAppliedToId(458)).to.deep.equal([0]);
@@ -91,18 +91,18 @@ describe("AnnotationData", () => {
     const annotationData = new AnnotationData();
     annotationData.createNewLabel();
     annotationData.createNewLabel();
-    annotationData.setLabelOnIds(0, [0], true);
-    annotationData.setLabelOnIds(0, [0], true);
-    annotationData.setLabelOnIds(0, [1], true);
+    annotationData.setLabelValueOnIds(0, [0], BOOLEAN_VALUE);
+    annotationData.setLabelValueOnIds(0, [0], BOOLEAN_VALUE);
+    annotationData.setLabelValueOnIds(0, [1], BOOLEAN_VALUE);
 
     expect(annotationData.getLabelsAppliedToId(0)).to.deep.equal([0]);
     expect(annotationData.isLabelOnId(0, 0)).toBe(true);
     expect(annotationData.getLabelsAppliedToId(1)).to.deep.equal([0]);
     expect(annotationData.isLabelOnId(0, 1)).toBe(true);
 
-    annotationData.setLabelOnIds(0, [0], false);
-    annotationData.setLabelOnIds(0, [0], false);
-    annotationData.setLabelOnIds(0, [1], false);
+    annotationData.removeLabelOnIds(0, [0]);
+    annotationData.removeLabelOnIds(0, [0]);
+    annotationData.removeLabelOnIds(0, [1]);
 
     expect(annotationData.getLabelsAppliedToId(0)).to.deep.equal([]);
     expect(annotationData.isLabelOnId(0, 0)).toBe(false);
@@ -116,10 +116,10 @@ describe("AnnotationData", () => {
     };
     const annotationData = new AnnotationData();
     annotationData.createNewLabel();
-    annotationData.setLabelOnIds(0, [0, 1, 2, 3, 4, 5], true);
+    annotationData.setLabelValueOnIds(0, [0, 1, 2, 3, 4, 5], BOOLEAN_VALUE);
 
     annotationData.createNewLabel();
-    annotationData.setLabelOnIds(1, [2], true);
+    annotationData.setLabelValueOnIds(1, [2], BOOLEAN_VALUE);
 
     /* eslint-disable @typescript-eslint/naming-convention */
     // ESLint doesn't like "0" and "1" being property keys.
@@ -147,13 +147,16 @@ describe("AnnotationData", () => {
       annotationData.createNewLabel({ name: "Label 2" });
       annotationData.createNewLabel({ name: "Label 3" });
 
-      annotationData.setLabelOnIds(0, [0], true);
-      annotationData.setLabelOnIds(1, [1], true);
-      annotationData.setLabelOnIds(2, [2], true);
+      annotationData.setLabelValueOnIds(0, [0], BOOLEAN_VALUE);
+      annotationData.setLabelValueOnIds(1, [1], BOOLEAN_VALUE);
+      annotationData.setLabelValueOnIds(2, [2], BOOLEAN_VALUE);
 
       const csv = annotationData.toCsv(mockDataset);
       expect(csv).to.equal(
-        `ID,Track,Frame,Label 1,Label 2,Label 3\r\n` + "0,0,0,1,0,0\r\n" + "1,1,1,0,1,0\r\n" + "2,2,2,0,0,1"
+        `ID,Track,Frame,Label 1,Label 2,Label 3\r\n` +
+          `0,0,0,${BOOLEAN_VALUE},,\r\n` +
+          `1,1,1,,${BOOLEAN_VALUE},\r\n` +
+          `2,2,2,,,${BOOLEAN_VALUE}`
       );
     });
 
@@ -164,10 +167,10 @@ describe("AnnotationData", () => {
       annotationData.createNewLabel({ name: 'a","fake label' });
       annotationData.createNewLabel({ name: '","' });
 
-      annotationData.setLabelOnIds(0, [0], true);
-      annotationData.setLabelOnIds(1, [1], true);
-      annotationData.setLabelOnIds(2, [2], true);
-      annotationData.setLabelOnIds(3, [3], true);
+      annotationData.setLabelValueOnIds(0, [0], BOOLEAN_VALUE);
+      annotationData.setLabelValueOnIds(1, [1], BOOLEAN_VALUE);
+      annotationData.setLabelValueOnIds(2, [2], BOOLEAN_VALUE);
+      annotationData.setLabelValueOnIds(3, [3], BOOLEAN_VALUE);
 
       const csv = annotationData.toCsv(mockDataset);
 
@@ -175,10 +178,10 @@ describe("AnnotationData", () => {
       // Single quotes are escaped as double quotes.
       expect(csv).to.equal(
         `ID,Track,Frame,"""label",",,,,,","a"",""fake label",""","""\r\n` +
-          "0,0,0,1,0,0,0\r\n" +
-          "1,1,1,0,1,0,0\r\n" +
-          "2,2,2,0,0,1,0\r\n" +
-          "3,3,3,0,0,0,1"
+          `0,0,0,${BOOLEAN_VALUE},,,\r\n` +
+          `1,1,1,,${BOOLEAN_VALUE},,\r\n` +
+          `2,2,2,,,${BOOLEAN_VALUE},\r\n` +
+          `3,3,3,,,,${BOOLEAN_VALUE}`
       );
     });
 


### PR DESCRIPTION
Problem
=======
This change refactors the internals of `AnnotationData` to include values for labels! This will eventually close #459, "multi-value labels", once more UI is implemented.

Before, labels were only boolean/binary values, where an ID could be labeled or unlabeled only. Now, labeled IDs are associated with an additional string **value** which is specified when applying the labels.

I've introduced the concept of different label types, but for now only boolean labels can be chosen from the UI. Label types just inform how user interaction with the label works, but all labels behave the same internally.

*Estimated review size: medium, 20 minutes*

Solution
========
- Updated `AnnotationData` label setters to include a string `value`. An ID can only be associated with one value at a time, and can be reassigned.
- Added API for removing IDs from labels.
- Added additional `LabelData` options for types and behavior.
- Updated unit tests.

## Type of change
* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. Open the preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview-internal/pr-648/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&feature=volume&track=77138&bg-key=max_intensity_zprojection_of_lamin_b1&t=15&tab=annotation
2. Create and select/deselect objects with an annotation label. All behavior should be the same as before.

Screenshots (optional):
-----------------------

**Video talk-through (🔊):**

https://github.com/user-attachments/assets/9415945d-db5d-4a83-ade0-d05c70eb16cc


