### PR TITLE
refactor: Changed label data to use an options object (new annotations pt. 2)

### DIFF
--- a/src/colorizer/AnnotationData.ts
+++ b/src/colorizer/AnnotationData.ts
@@ -165,6 +165,7 @@ export class AnnotationData implements IAnnotationData {
     this.isLabelOnId = this.isLabelOnId.bind(this);
     this.setLabelOnId = this.setLabelOnId.bind(this);
     this.setLabelOnIds = this.setLabelOnIds.bind(this);
+    this.setLabelOptions = this.setLabelOptions.bind(this);
     this.toCsv = this.toCsv.bind(this);
   }
 

--- a/src/colorizer/canvas/elements/annotations.ts
+++ b/src/colorizer/canvas/elements/annotations.ts
@@ -132,7 +132,7 @@ function drawAnnotationMarker(
 
   // Draw an additional marker behind the main one if there are multiple labels.
   if (labelIdx.length > 1) {
-    ctx.fillStyle = "#" + params.labelData[labelIdx[1]].color.getHexString();
+    ctx.fillStyle = "#" + params.labelData[labelIdx[1]].options.color.getHexString();
     const offsetPos = pos.clone().addScalar(style.additionalItemsOffsetPx * dampenedZoomScale);
     ctx.beginPath();
     ctx.arc(offsetPos.x, offsetPos.y, scaledMarkerSizePx, 0, 2 * Math.PI);
@@ -142,7 +142,7 @@ function drawAnnotationMarker(
   }
 
   // Draw the main marker.
-  ctx.fillStyle = "#" + labelData.color.getHexString();
+  ctx.fillStyle = "#" + labelData.options.color.getHexString();
   ctx.beginPath();
   ctx.arc(pos.x, pos.y, scaledMarkerSizePx, 0, 2 * Math.PI);
   ctx.closePath();

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -482,8 +482,7 @@ export const useAnnotations = (): AnnotationState => {
     getSelectRangeFromId,
     // Wrap state mutators
     createNewLabel: wrapFunctionInUpdate(annotationData.createNewLabel),
-    setLabelName: wrapFunctionInUpdate(annotationData.setLabelName),
-    setLabelColor: wrapFunctionInUpdate(annotationData.setLabelColor),
+    setLabelOptions: wrapFunctionInUpdate(annotationData.setLabelOptions),
     deleteLabel: wrapFunctionInUpdate(onDeleteLabel),
     setLabelOnIds: wrapFunctionInUpdate(annotationData.setLabelOnIds),
     clear: wrapFunctionInUpdate(clear),

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -1,7 +1,6 @@
 import { MenuOutlined, TableOutlined } from "@ant-design/icons";
 import { Modal, Radio, Tooltip } from "antd";
 import React, { ReactElement, useCallback, useMemo, useState, useTransition } from "react";
-import { Color } from "three";
 import { useShallow } from "zustand/shallow";
 
 import { AnnotationSelectionMode } from "../../../colorizer";
@@ -43,8 +42,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
     data: annotationData,
     createNewLabel,
     deleteLabel,
-    setLabelName,
-    setLabelColor,
+    setLabelOptions,
     setLabelOnIds,
   } = props.annotationState;
 
@@ -97,7 +95,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
     });
   };
 
-  const onCreateNewLabel = (options: LabelOptions): void => {
+  const onCreateNewLabel = (options: Partial<LabelOptions>): void => {
     const index = createNewLabel(options);
     setCurrentLabelIdx(index);
   };
@@ -136,8 +134,8 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
     () =>
       labels.map((label, index) => ({
         value: index.toString(),
-        label: label.ids.size ? `${label.name} (${label.ids.size})` : label.name,
-        color: label.color,
+        label: label.ids.size ? `${label.options.name} (${label.ids.size})` : label.options.name,
+        color: label.options.color,
       })),
     [annotationData]
   );
@@ -164,7 +162,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
           <div style={{ marginTop: "15px" }}>
             <CreateLabelForm
               initialLabelOptions={annotationData.getNextDefaultLabelSettings()}
-              onConfirm={(options: LabelOptions) => {
+              onConfirm={(options: Partial<LabelOptions>) => {
                 onCreateNewLabel(options);
                 setShowCreateLabelModal(false);
                 setIsAnnotationModeEnabled(true);
@@ -208,8 +206,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
             <LabelEditControls
               onCreateNewLabel={onCreateNewLabel}
               onDeleteLabel={onDeleteLabel}
-              setLabelColor={(color: Color) => setLabelColor(currentLabelIdx, color)}
-              setLabelName={(name: string) => setLabelName(currentLabelIdx, name)}
+              setLabelOptions={(options) => setLabelOptions(currentLabelIdx, options)}
               selectedLabel={selectedLabel}
               selectedLabelIdx={currentLabelIdx}
               selectionMode={props.annotationState.selectionMode}
@@ -292,7 +289,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
             selectedTrack={store.selectedTrack}
             selectedId={selectedId}
             frame={store.frame}
-            labelColor={selectedLabel?.color}
+            labelColor={selectedLabel?.options.color}
           ></AnnotationDisplayList>
         </div>
       </LoadingSpinner>

--- a/src/components/Tabs/Annotation/CreateLabelForm.tsx
+++ b/src/components/Tabs/Annotation/CreateLabelForm.tsx
@@ -12,7 +12,7 @@ import { DEFAULT_LABEL_COLOR_PRESETS } from "./LabelEditControls";
 
 type CreateLabelFormProps = {
   initialLabelOptions: LabelOptions;
-  onConfirm: (options: LabelOptions) => void;
+  onConfirm: (options: Partial<LabelOptions>) => void;
   onCancel: () => void;
   onColorChanged?: (color: Color) => void;
   confirmText?: string;

--- a/src/components/Tabs/Annotation/LabelEditControls.tsx
+++ b/src/components/Tabs/Annotation/LabelEditControls.tsx
@@ -1,7 +1,6 @@
 import { DeleteOutlined, EditOutlined } from "@ant-design/icons";
 import { Popconfirm, Popover, Radio, Tooltip } from "antd";
 import React, { ReactElement, useContext, useEffect, useRef, useState } from "react";
-import { Color } from "three";
 
 import { TagAddIconSVG } from "../../../assets";
 import { AnnotationSelectionMode } from "../../../colorizer";
@@ -22,10 +21,9 @@ export const DEFAULT_LABEL_COLOR_PRESETS = [
 ];
 
 type LabelEditControlsProps = {
-  onCreateNewLabel: (options: LabelOptions) => void;
+  onCreateNewLabel: (options: Partial<LabelOptions>) => void;
   onDeleteLabel: () => void;
-  setLabelColor: (color: Color) => void;
-  setLabelName: (name: string) => void;
+  setLabelOptions: (options: Partial<LabelOptions>) => void;
   defaultLabelOptions: LabelOptions;
   selectedLabel: LabelData;
   selectedLabelIdx: number;
@@ -43,15 +41,15 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
 
   const [showDeletePopup, setShowDeletePopup] = useState(false);
 
-  const savedLabelOptions = useRef<LabelOptions | null>(null);
+  const savedLabelOptions = useRef<Partial<LabelOptions> | null>(null);
 
   // Edit button popover handlers
 
   const onClickEditButton = (): void => {
     setShowEditPopover(!showEditPopover);
     savedLabelOptions.current = {
-      color: props.selectedLabel.color.clone(),
-      name: props.selectedLabel.name,
+      color: props.selectedLabel.options.color.clone(),
+      name: props.selectedLabel.options.name,
     };
   };
 
@@ -59,13 +57,12 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
     setShowEditPopover(false);
     // Restore saved label options
     if (savedLabelOptions.current) {
-      props.setLabelName(savedLabelOptions.current.name);
-      props.setLabelColor(savedLabelOptions.current.color);
+      props.setLabelOptions(savedLabelOptions.current);
     }
   };
 
-  const onClickEditSave = (options: LabelOptions): void => {
-    props.setLabelName(options.name);
+  const onClickEditSave = (options: Partial<LabelOptions>): void => {
+    props.setLabelOptions(options);
     setShowEditPopover(false);
   };
 
@@ -141,12 +138,14 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
         placement="bottom"
         content={
           <CreateLabelForm
-            initialLabelOptions={props.selectedLabel}
+            initialLabelOptions={props.selectedLabel.options}
             onConfirm={onClickEditSave}
             onCancel={onClickEditCancel}
             // Sync label color with color picker. If operation is cancelled,
             // the color will be reset to the original label color.
-            onColorChanged={props.setLabelColor}
+            onColorChanged={(color) => {
+              props.setLabelOptions({ color });
+            }}
             confirmText="Save"
           />
         }

--- a/src/components/Tooltips/CanvasHoverTooltip.tsx
+++ b/src/components/Tooltips/CanvasHoverTooltip.tsx
@@ -135,9 +135,9 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
             <Tag
               key={labelIdx}
               style={{ width: "fit-content", margin: "0 2px" }}
-              color={"#" + label.color.getHexString()}
+              color={"#" + label.options.color.getHexString()}
             >
-              {label.name}
+              {label.options.name}
             </Tag>
           );
         })}
@@ -151,8 +151,8 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
   if (props.annotationState.isAnnotationModeEnabled && currentLabelIdx !== null) {
     const currentLabelData = labelData[currentLabelIdx];
     annotationLabel = (
-      <Tag style={{ width: "fit-content" }} color={"#" + currentLabelData.color.getHexString()} bordered={true}>
-        {currentLabelData.name}
+      <Tag style={{ width: "fit-content" }} color={"#" + currentLabelData.options.color.getHexString()} bordered={true}>
+        {currentLabelData.options.name}
       </Tag>
     );
 

--- a/tests/colorizer/AnnotationData.test.ts
+++ b/tests/colorizer/AnnotationData.test.ts
@@ -2,6 +2,7 @@ import { Color } from "three";
 import { describe, expect, it } from "vitest";
 
 import { Dataset, DEFAULT_CATEGORICAL_PALETTE_KEY, KNOWN_CATEGORICAL_PALETTES } from "../../src/colorizer";
+import { compareRecord } from "../state/ViewerState/utils";
 
 import { AnnotationData } from "../../src/colorizer/AnnotationData";
 
@@ -24,11 +25,11 @@ describe("AnnotationData", () => {
     annotationData.createNewLabel();
     annotationData.createNewLabel();
 
-    expect(annotationData.getLabels()).to.deep.equal([
-      { name: "Label 1", color: defaultPalette.colors[0], ids: new Set() },
-      { name: "Label 2", color: defaultPalette.colors[1], ids: new Set() },
-      { name: "Label 3", color: defaultPalette.colors[2], ids: new Set() },
-    ]);
+    const labels = annotationData.getLabels();
+    expect(labels.length).toBe(3);
+    compareRecord(labels[0].options, { name: "Label 1", color: defaultPalette.colors[0] });
+    compareRecord(labels[1].options, { name: "Label 2", color: defaultPalette.colors[1] });
+    compareRecord(labels[2].options, { name: "Label 3", color: defaultPalette.colors[2] });
   });
 
   it("allows updating of label names and colors", () => {
@@ -37,16 +38,15 @@ describe("AnnotationData", () => {
     annotationData.createNewLabel();
     annotationData.createNewLabel();
 
-    annotationData.setLabelName(0, "New Label Name");
-    annotationData.setLabelColor(1, new Color("#FF0000"));
-    annotationData.setLabelName(2, "Another New Label Name");
-    annotationData.setLabelColor(2, new Color("#00FF00"));
+    annotationData.setLabelOptions(0, { name: "New Label Name" });
+    annotationData.setLabelOptions(1, { color: new Color("#FF0000") });
+    annotationData.setLabelOptions(2, { name: "Another New Label Name", color: new Color("#00FF00") });
 
-    expect(annotationData.getLabels()).to.deep.equal([
-      { name: "New Label Name", color: defaultPalette.colors[0], ids: new Set() },
-      { name: "Label 2", color: new Color("#FF0000"), ids: new Set() },
-      { name: "Another New Label Name", color: new Color("#00FF00"), ids: new Set() },
-    ]);
+    const labels = annotationData.getLabels();
+    expect(labels.length).toBe(3);
+    compareRecord(labels[0].options, { name: "New Label Name", color: defaultPalette.colors[0] });
+    compareRecord(labels[1].options, { name: "Label 2", color: new Color("#FF0000") });
+    compareRecord(labels[2].options, { name: "Another New Label Name", color: new Color("#00FF00") });
   });
 
   it("deletes labels", () => {
@@ -56,18 +56,18 @@ describe("AnnotationData", () => {
     annotationData.createNewLabel();
 
     annotationData.deleteLabel(1);
-    expect(annotationData.getLabels()).to.deep.equal([
-      { name: "Label 1", color: defaultPalette.colors[0], ids: new Set() },
-      { name: "Label 3", color: defaultPalette.colors[2], ids: new Set() },
-    ]);
+    let labels = annotationData.getLabels();
+    expect(labels.length).toBe(2);
+    compareRecord(labels[0].options, { name: "Label 1", color: defaultPalette.colors[0] });
+    compareRecord(labels[1].options, { name: "Label 3", color: defaultPalette.colors[2] });
 
     // Creating new label should reuse deleted index and increment name by 1
     annotationData.createNewLabel();
-    expect(annotationData.getLabels()).to.deep.equal([
-      { name: "Label 1", color: defaultPalette.colors[0], ids: new Set() },
-      { name: "Label 3", color: defaultPalette.colors[2], ids: new Set() },
-      { name: "Label 4", color: defaultPalette.colors[3], ids: new Set() },
-    ]);
+    labels = annotationData.getLabels();
+    expect(labels.length).toBe(3);
+    compareRecord(labels[0].options, { name: "Label 1", color: defaultPalette.colors[0] });
+    compareRecord(labels[1].options, { name: "Label 3", color: defaultPalette.colors[2] });
+    compareRecord(labels[2].options, { name: "Label 4", color: defaultPalette.colors[3] });
   });
 
   it("can apply and remove labels from an ID", () => {

--- a/tests/state/ViewerState/utils.ts
+++ b/tests/state/ViewerState/utils.ts
@@ -33,7 +33,7 @@ export const clearDatasetAsync = async (result: { current: ViewerStore }): Promi
  * Note that `actual` may contain additional key-value pairs not present in
  * `expected` and still pass this check.
  */
-export const compareRecord = <T extends Record<string, unknown>>(actual: T, expected: T): void => {
+export const compareRecord = <T extends Record<string, unknown>>(actual: T, expected: Partial<T>): void => {
   for (const key in expected) {
     expect(actual[key], `compareRecord: Found different values for field '${key}'.`).toEqual(expected[key]);
   }


### PR DESCRIPTION
Problem
=======
Mini refactor before #459, "multi-value labels in annotations."

This change moves the label options into an object in `LabelData`. Eventually, more options will be added to control user interactions with labels as part of the multi-value label feature!

*Estimated review size: small, <10-15 minutes*

Solution
========
- Moved label name and color into an `options` object inside of the `LabelData` type.
- Updated usage of `LabelData` options.

Steps to Verify:
----------------
1. Open preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview-internal/pr-649/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&feature=volume&bg-key=max_intensity_zprojection_of_lamin_b1&t=15&color=matplotlib-cool&tab=annotation
2. Create and edit an annotation. You should be able to set the name and color.

Screenshots (optional):
-----------------------


https://github.com/user-attachments/assets/b5cb30ac-39fb-4db1-a776-dc7ec7a068e8

