### PR TITLE
fix: Fix crash caused by `null` frame dimensions

### DIFF
--- a/src/colorizer/canvas/elements/scaleBar.ts
+++ b/src/colorizer/canvas/elements/scaleBar.ts
@@ -81,7 +81,7 @@ export function getScaleBarRenderer(
   style: ScaleBarStyle
 ): RenderInfo {
   const frameDims = params.dataset?.metadata.frameDims;
-  const hasFrameDims = frameDims && frameDims.width !== 0 && frameDims.height !== 0;
+  const hasFrameDims = frameDims && frameDims.width && frameDims.height;
 
   if (!hasFrameDims || !params.visible) {
     return EMPTY_RENDER_INFO;


### PR DESCRIPTION
Problem
=======
Tiny fix for a bug I noticed in one of the datasets Chantelle has been working with, where attempting to export the image would cause the viewer to crash.

*Estimated review size: tiny, 2-3 minutes*

## Type of change

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open broken build here (you'll need to be on VPN) and click Export. Export a single image frame. Attempting to start the export process will cause a crash. https://tfe.allencell.org/viewer?dataset=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fassay-dev%2Fusers%2FChantelle%2Fcolorizer_data%2F20241120_20X_P0%2Fcell_seg%2Fmanifest.json
2. Open the fixed build and repeat the same actions. The viewer will not crash.  https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-653/viewer?dataset=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fassay-dev%2Fusers%2FChantelle%2Fcolorizer_data%2F20241120_20X_P0%2Fcell_seg%2Fmanifest.json


Screenshots (optional):
-----------------------
**Video talk-through (🔊):**

https://github.com/user-attachments/assets/3ce292a4-5529-4dea-97f5-fd42582950a9

