### PR TITLE
feat: Multi-value label UI (new annotations pt. 4)

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -539,9 +539,9 @@ function Viewer(): ReactElement {
   }, [isUserDirectlyControllingFrameInput, frameInput]);
 
   const onClickId = useCallback(
-    (info: PixelIdInfo) => {
+    (info: PixelIdInfo | null) => {
       if (dataset) {
-        annotationState.handleAnnotationClick(dataset, info.globalId ?? null);
+        annotationState.handleAnnotationClick(dataset, info?.globalId ?? null);
       }
     },
     [dataset, annotationState.handleAnnotationClick]

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -540,8 +540,8 @@ function Viewer(): ReactElement {
 
   const onClickId = useCallback(
     (info: PixelIdInfo) => {
-      if (dataset && info.globalId !== undefined) {
-        annotationState.handleAnnotationClick(dataset, info.globalId);
+      if (dataset) {
+        annotationState.handleAnnotationClick(dataset, info.globalId ?? null);
       }
     },
     [dataset, annotationState.handleAnnotationClick]

--- a/src/colorizer/AnnotationData.ts
+++ b/src/colorizer/AnnotationData.ts
@@ -117,7 +117,7 @@ export interface IAnnotationDataGetters {
    */
   getNextDefaultLabelSettings(): LabelOptions;
 
-  getNextDefaultLabelValue(labelIdx: number): string;
+  getNextDefaultLabelValue(labelIdx: number, useLastValue: boolean): string;
 
   getValueFromId(labelIdx: number, id: number): string | null;
 
@@ -281,14 +281,14 @@ export class AnnotationData implements IAnnotationData {
     return { type: LabelType.BOOLEAN, name, color, autoIncrement: true };
   }
 
-  getNextDefaultLabelValue(labelIdx: number): string {
+  getNextDefaultLabelValue(labelIdx: number, useLastValue: boolean): string {
     this.validateIndex(labelIdx);
     const labelData = this.labelData[labelIdx];
     switch (labelData.options.type) {
       case LabelType.BOOLEAN:
         return BOOLEAN_VALUE_TRUE;
       case LabelType.INTEGER:
-        if (labelData.options.autoIncrement) {
+        if (labelData.options.autoIncrement && !useLastValue) {
           return (parseInt(labelData.lastValue ?? "-1", 10) + 1).toString();
         } else {
           return (labelData.lastValue ?? "0").toString();

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -345,6 +345,7 @@ export default class CanvasOverlay implements IRenderCanvas {
     this.timeToLabelIds = timeToLabelIds;
     this.selectedLabelIdx = selectedLabelIdx;
     this.lastClickedId = lastClickedId;
+    this.render(false);
   }
 
   // Rendering functions ////////////////////////////

--- a/src/colorizer/canvas/elements/annotations.ts
+++ b/src/colorizer/canvas/elements/annotations.ts
@@ -17,7 +17,8 @@ export type AnnotationParams = BaseRenderParams & {
 };
 
 export type AnnotationStyle = {
-  markerSizePx: number;
+  booleanMarkerRadiusPx: number;
+  textMarkerRadiusPx: number;
   borderColor: string;
   additionalItemsOffsetPx: number;
   /** Percentage, as a number from 0 to 1, of how much to scale the annotation
@@ -31,7 +32,8 @@ export type AnnotationStyle = {
 };
 
 export const defaultAnnotationStyle: AnnotationStyle = {
-  markerSizePx: 6,
+  booleanMarkerRadiusPx: 5,
+  textMarkerRadiusPx: 6,
   borderColor: "white",
   additionalItemsOffsetPx: 3,
   scaleWithZoomPct: 0.25,
@@ -95,7 +97,7 @@ function drawLastClickedId(
   const zoomScale = getMarkerScale(params, style);
   ctx.setLineDash([3, 2]);
   ctx.beginPath();
-  ctx.arc(pos.x, pos.y, style.markerSizePx * zoomScale, 0, 2 * Math.PI);
+  ctx.arc(pos.x, pos.y, style.booleanMarkerRadiusPx * zoomScale, 0, 2 * Math.PI);
   ctx.closePath();
   ctx.stroke();
   ctx.setLineDash([]);
@@ -132,7 +134,8 @@ function drawAnnotationMarker(
 
   // Scale markers by the zoom level.
   const dampenedZoomScale = getMarkerScale(params, style);
-  const scaledMarkerSizePx = style.markerSizePx * dampenedZoomScale;
+  const scaledBooleanMarkerRadiusPx = style.booleanMarkerRadiusPx * dampenedZoomScale;
+  const scaledTextMarkerRadiusPx = style.textMarkerRadiusPx * dampenedZoomScale;
 
   // Draw an additional marker behind the main one if there are multiple labels.
   if (labelIdx.length > 1) {
@@ -141,13 +144,13 @@ function drawAnnotationMarker(
     const offsetPos = pos.clone().addScalar(style.additionalItemsOffsetPx * dampenedZoomScale);
     ctx.beginPath();
     if (bgLabelData.options.type === LabelType.BOOLEAN) {
-      ctx.arc(offsetPos.x, offsetPos.y, scaledMarkerSizePx, 0, 2 * Math.PI);
+      ctx.arc(offsetPos.x, offsetPos.y, scaledBooleanMarkerRadiusPx, 0, 2 * Math.PI);
     } else {
       ctx.roundRect(
-        Math.round(offsetPos.x - scaledMarkerSizePx) - 0.5,
-        Math.round(offsetPos.y - scaledMarkerSizePx) - 0.5,
-        scaledMarkerSizePx * 2,
-        scaledMarkerSizePx * 2,
+        Math.round(offsetPos.x - scaledBooleanMarkerRadiusPx) - 0.5,
+        Math.round(offsetPos.y - scaledBooleanMarkerRadiusPx) - 0.5,
+        scaledBooleanMarkerRadiusPx * 2,
+        scaledBooleanMarkerRadiusPx * 2,
         style.borderRadiusPx * dampenedZoomScale
       );
     }
@@ -160,7 +163,7 @@ function drawAnnotationMarker(
   if (labelData.options.type === LabelType.BOOLEAN) {
     // Draw the main marker as a filled circle.
     ctx.beginPath();
-    ctx.arc(pos.x, pos.y, scaledMarkerSizePx, 0, 2 * Math.PI);
+    ctx.arc(pos.x, pos.y, scaledBooleanMarkerRadiusPx, 0, 2 * Math.PI);
     ctx.closePath();
     ctx.fill();
     ctx.stroke();
@@ -174,8 +177,8 @@ function drawAnnotationMarker(
         break;
       }
     }
-    const fontSizePx = scaledMarkerSizePx * 2 - style.textPaddingPx;
-    ctx.font = `${scaledMarkerSizePx * 2}px Lato, sans-serif`;
+    const fontSizePx = scaledTextMarkerRadiusPx * 2 - style.textPaddingPx;
+    ctx.font = `${scaledTextMarkerRadiusPx * 2}px Lato, sans-serif`;
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
 

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -292,7 +292,7 @@ export type AnnotationState = {
 export const useAnnotations = (): AnnotationState => {
   const annotationData = useConstructor(() => new AnnotationData());
 
-  const [currentLabelIdx, setCurrentLabelIdx] = useState<number | null>(null);
+  const [currentLabelIdx, _setCurrentLabelIdx] = useState<number | null>(null);
   const [isAnnotationEnabled, _setIsAnnotationEnabled] = useState<boolean>(false);
   const [visible, _setVisibility] = useState<boolean>(false);
 
@@ -325,6 +325,11 @@ export const useAnnotations = (): AnnotationState => {
     selectionMode = AnnotationSelectionMode.RANGE;
   }
 
+  const setCurrentLabelIdx = (labelIdx: number | null): void => {
+    _setCurrentLabelIdx(labelIdx);
+    setActiveEditRange(null);
+  }
+
   const setSelectionMode = (newMode: AnnotationSelectionMode): void => {
     if (newMode === baseSelectionMode) {
       return;
@@ -353,6 +358,7 @@ export const useAnnotations = (): AnnotationState => {
         setDataUpdateCounter((value) => value + 1);
       }
     }
+    setActiveEditRange(null);
     _setIsAnnotationEnabled(enabled);
   };
 

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -444,11 +444,14 @@ export const useAnnotations = (): AnnotationState => {
   const handleAnnotationClick = useCallback(
     (dataset: Dataset, id: number | null): void => {
       if (!isAnnotationEnabled) {
+        setLastEditedRange(null);
+        setActiveEditRange(null);
         return;
       }
       setLastClickedId(id);
       if (currentLabelIdx === null || id === null) {
         setLastEditedRange(null);
+        setActiveEditRange(null);
         return;
       }
       const track = dataset.getTrack(dataset.getTrackId(id));
@@ -462,11 +465,13 @@ export const useAnnotations = (): AnnotationState => {
         const defaultValue = annotationData.getNextDefaultLabelValue(currentLabelIdx, isReuseValueHotkeyPressed);
         if (isLabeled && labelData.options.type === LabelType.BOOLEAN) {
           annotationData.removeLabelOnIds(currentLabelIdx, range);
+          setActiveEditRange(null);
         } else if (isLabeled) {
           // Initiate editing of the label value for that range
           setActiveEditRange(range);
         }  else {
           annotationData.setLabelValueOnIds(currentLabelIdx, range, defaultValue);
+          setActiveEditRange(null);
         }
       };
 
@@ -476,24 +481,20 @@ export const useAnnotations = (): AnnotationState => {
           // Toggle entire track
           setLastEditedRange(track.ids);
           toggleRange(track.ids);
-          setLastClickedId(id);
           break;
         case AnnotationSelectionMode.RANGE:
           if (idRange !== null) {
             setLastEditedRange(idRange);
             toggleRange(idRange);
             // TODO: Change this to lastClickedRangeEndpoint?
-            setLastClickedId(null);
-          } else {
-            setLastClickedId(id);
           }
           break;
         case AnnotationSelectionMode.TIME:
         default:
           toggleRange([id]);
           setLastEditedRange([id]);
-          setLastClickedId(id);
       }
+      setLastClickedId(id);
       setDataUpdateCounter((value) => value + 1);
     },
     [selectionMode, currentLabelIdx, getSelectRangeFromId, isReuseValueHotkeyPressed]

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -1,6 +1,6 @@
 import { HomeOutlined, ZoomInOutlined, ZoomOutOutlined } from "@ant-design/icons";
 import { Tooltip } from "antd";
-import React, { ReactElement, ReactNode, useCallback, useContext, useEffect, useMemo, useRef } from "react";
+import React, { ReactElement, ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import styled from "styled-components";
 import { Vector2 } from "three";
 import { clamp } from "three/src/math/MathUtils";
@@ -20,6 +20,7 @@ import { AlertBannerProps } from "./Banner";
 import { LinkStyleButton } from "./Buttons/LinkStyleButton";
 import IconButton from "./IconButton";
 import LoadingSpinner from "./LoadingSpinner";
+import AnnotationInputPopover from "./Tabs/Annotation/AnnotationInputPopover";
 import { TooltipWithSubtitle } from "./Tooltips/TooltipWithSubtitle";
 
 const ASPECT_RATIO = 14.6 / 10;
@@ -144,6 +145,8 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
 
   const canv = props.canv;
   const canvasPlaceholderRef = useRef<HTMLDivElement>(null);
+
+  const [lastClickPosition, setLastClickPosition] = useState<[number, number]>([0, 0]);
 
   const isFrameLoading = pendingFrame !== currentFrame;
   const loadProgress = props.loading ? props.loadingProgress : null;
@@ -311,6 +314,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   /** Report clicked tracks via the passed callback. */
   const handleClick = useCallback(
     async (event: MouseEvent): Promise<void> => {
+      setLastClickPosition([event.offsetX, event.offsetY]);
       const id = canv.getIdAtPixel(event.offsetX, event.offsetY);
       // Reset track input
       if (dataset === null || id === null || id.globalId === undefined) {
@@ -709,6 +713,10 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
           </TooltipWithSubtitle>
         )}
       </CanvasControlsContainer>
+      <AnnotationInputPopover
+        annotationState={props.annotationState}
+        anchorPositionPx={lastClickPosition}
+      ></AnnotationInputPopover>
     </CanvasContainer>
   );
 }

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -426,8 +426,9 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
     // selection, but keep the behavior where focus is removed from other
     // elements.
     event.preventDefault();
-    if (document.activeElement instanceof HTMLElement && document.activeElement !== canv.domElement) {
-      document.activeElement.blur();
+    const activeElement = document.activeElement;
+    if (activeElement instanceof HTMLElement && !containerRef.current?.contains(activeElement)) {
+      activeElement.blur();
     }
 
     isMouseDragging.current = false;

--- a/src/components/Dropdowns/SelectionDropdown.tsx
+++ b/src/components/Dropdowns/SelectionDropdown.tsx
@@ -53,6 +53,7 @@ type SelectionDropdownProps = {
 };
 
 const defaultProps: Partial<SelectionDropdownProps> = {
+  buttonType: "outlined",
   showSelectedItemTooltip: true,
   controlTooltipPlacement: "right",
 };

--- a/src/components/Tabs/Annotation/AnnotationInputPopover.tsx
+++ b/src/components/Tabs/Annotation/AnnotationInputPopover.tsx
@@ -1,5 +1,5 @@
-import { SaveOutlined } from "@ant-design/icons";
-import { Card, Input } from "antd";
+import { DeleteOutlined } from "@ant-design/icons";
+import { Card, Input, InputRef } from "antd";
 import React, { ReactElement, useEffect, useState } from "react";
 import styled from "styled-components";
 
@@ -7,7 +7,6 @@ import { AnnotationState } from "../../../colorizer/utils/react_utils";
 import { useViewerStateStore } from "../../../state";
 import { FlexRow } from "../../../styles/utils";
 
-import { LabelType } from "../../../colorizer/AnnotationData";
 import IconButton from "../../IconButton";
 
 type AnnotationInputPopoverProps = {
@@ -30,34 +29,40 @@ export default function AnnotationInputPopover(props: AnnotationInputPopoverProp
   const [visible, setVisible] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const anchorRef = React.useRef<HTMLDivElement>(null);
-  const prevLastClickedId = React.useRef(props.annotationState.lastClickedId);
+  const inputRef = React.useRef<InputRef>(null);
 
-  const { lastClickedId, currentLabelIdx, data: annotationData, isAnnotationModeEnabled } = props.annotationState;
+  const {
+    lastClickedId,
+    currentLabelIdx,
+    data: annotationData,
+    isAnnotationModeEnabled,
+    activeEditRange,
+    clearActiveEditRange,
+  } = props.annotationState;
 
   useEffect(() => {
     if (!isAnnotationModeEnabled) {
       setVisible(false);
     }
-  });
+  }, [isAnnotationModeEnabled]);
 
   useEffect(() => {
-    if (lastClickedId !== null && currentLabelIdx !== null && dataset) {
-      const labelData = annotationData.getLabels()[currentLabelIdx];
-      // Check if the last clicked ID is labeled-- this means that the ID(s)
-      // were added to the label data instead of being removed.
-      const isLastClickedIdLabeled = labelData.ids.has(lastClickedId);
-      if (anchorRef.current && isLastClickedIdLabeled && labelData.options.type !== LabelType.BOOLEAN) {
-        setInputValue(annotationData.getValueFromId(currentLabelIdx, lastClickedId) ?? "");
-        anchorRef.current.style.left = `${props.anchorPositionPx[0] + 10}px`;
-        anchorRef.current.style.top = `${props.anchorPositionPx[1] + 10}px`;
-        setVisible(true);
-      } else {
-        setVisible(false);
-      }
+    if (activeEditRange === null || lastClickedId === null || currentLabelIdx === null || !dataset) {
+      setVisible(false);
+      return;
+    }
+    // Check if the last clicked ID is labeled-- this means that the ID(s)
+    // were added to the label data instead of being removed.
+    if (anchorRef.current && activeEditRange) {
+      setInputValue(annotationData.getValueFromId(currentLabelIdx, lastClickedId) ?? "");
+      anchorRef.current.style.left = `${props.anchorPositionPx[0] + 10}px`;
+      anchorRef.current.style.top = `${props.anchorPositionPx[1] + 10}px`;
+      setVisible(true);
+      inputRef.current?.focus({ preventScroll: true });
     } else {
       setVisible(false);
     }
-  }, [lastClickedId, currentLabelIdx]);
+  }, [activeEditRange]);
 
   const handleInputConfirm = () => {
     const lastEditedRange = props.annotationState.activeEditRange;
@@ -67,14 +72,26 @@ export default function AnnotationInputPopover(props: AnnotationInputPopoverProp
       props.annotationState.setLabelValueOnIds(currentLabelIdx, lastEditedRange, newValue);
     }
     setVisible(false);
+    clearActiveEditRange();
   };
 
-  useEffect(() => {
-    // When last clicked ID changes, that means the user clicked on a new object or on the
-    // background. Save the current input value to the last clicked ID's label data.
-    if (visible) {
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // Editing the input value directly updates the label value in the annotation state.
+    if (currentLabelIdx !== null && activeEditRange !== null) {
+      setInputValue(e.target.value);
+      props.annotationState.setLabelValueOnIds(currentLabelIdx, activeEditRange, e.target.value);
     }
-  }, [lastClickedId]);
+  };
+
+  const handleDelete = () => {
+    if (currentLabelIdx !== null && activeEditRange !== null) {
+      props.annotationState.removeLabelOnIds(currentLabelIdx, activeEditRange);
+    }
+    setVisible(false);
+    clearActiveEditRange();
+  };
+
+  // TODO: Pressing escape should reset the input value to the original value.
 
   return (
     <div ref={anchorRef} style={{ position: "absolute", width: "1px", height: "1px", zIndex: 102 }}>
@@ -82,16 +99,17 @@ export default function AnnotationInputPopover(props: AnnotationInputPopoverProp
         <FlexRow $gap={6}>
           {/* TODO: Change width based on field type? */}
           <Input
+            ref={inputRef}
             size="small"
             defaultValue={inputValue}
             style={{ pointerEvents: "auto" }}
             value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
+            onChange={handleInputChange}
             onPressEnter={handleInputConfirm}
             width={"50px"}
           ></Input>
-          <IconButton type="link" onClick={handleInputConfirm}>
-            <SaveOutlined />
+          <IconButton type="link" onClick={handleDelete}>
+            <DeleteOutlined />
           </IconButton>
         </FlexRow>
       </InputWrapper>

--- a/src/components/Tabs/Annotation/AnnotationInputPopover.tsx
+++ b/src/components/Tabs/Annotation/AnnotationInputPopover.tsx
@@ -19,10 +19,13 @@ const InputWrapper = styled(Card)`
   position: relative;
   transform: translateX(-50%) translateY(-150%);
   width: 200px;
+  z-index: 1;
   & .ant-card-body {
     padding: 4px;
   }
-  z-index: 1;
+  & * {
+    transition: all 0.2s, visibility 0s;
+  }
 `;
 
 export default function AnnotationInputPopover(props: AnnotationInputPopoverProps): ReactElement {
@@ -120,7 +123,8 @@ export default function AnnotationInputPopover(props: AnnotationInputPopoverProp
     clearActiveEditRange();
   };
 
-  // TODO: Pressing escape should reset the input value to the original value.
+  // TODO: Pressing escape should reset the input value to the original value and close the popover.
+  // TODO: Use the actual popover component from Antd?
 
   const editCount = activeEditRange?.length ?? 0;
 

--- a/src/components/Tabs/Annotation/AnnotationInputPopover.tsx
+++ b/src/components/Tabs/Annotation/AnnotationInputPopover.tsx
@@ -30,6 +30,7 @@ export default function AnnotationInputPopover(props: AnnotationInputPopoverProp
   const [visible, setVisible] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const anchorRef = React.useRef<HTMLDivElement>(null);
+  const prevLastClickedId = React.useRef(props.annotationState.lastClickedId);
 
   const { lastClickedId, currentLabelIdx, data: annotationData, isAnnotationModeEnabled } = props.annotationState;
 
@@ -59,7 +60,7 @@ export default function AnnotationInputPopover(props: AnnotationInputPopoverProp
   }, [lastClickedId, currentLabelIdx]);
 
   const handleInputConfirm = () => {
-    const lastEditedRange = props.annotationState.lastEditedRange;
+    const lastEditedRange = props.annotationState.activeEditRange;
     console.log("lastEditedRange", lastEditedRange);
     if (lastEditedRange !== null && currentLabelIdx !== null) {
       const newValue = inputValue;
@@ -67,6 +68,13 @@ export default function AnnotationInputPopover(props: AnnotationInputPopoverProp
     }
     setVisible(false);
   };
+
+  useEffect(() => {
+    // When last clicked ID changes, that means the user clicked on a new object or on the
+    // background. Save the current input value to the last clicked ID's label data.
+    if (visible) {
+    }
+  }, [lastClickedId]);
 
   return (
     <div ref={anchorRef} style={{ position: "absolute", width: "1px", height: "1px", zIndex: 102 }}>

--- a/src/components/Tabs/Annotation/AnnotationInputPopover.tsx
+++ b/src/components/Tabs/Annotation/AnnotationInputPopover.tsx
@@ -1,0 +1,92 @@
+import { SaveOutlined } from "@ant-design/icons";
+import { Card, Input } from "antd";
+import React, { ReactElement, useEffect, useState } from "react";
+import styled from "styled-components";
+
+import { AnnotationState } from "../../../colorizer/utils/react_utils";
+import { useViewerStateStore } from "../../../state";
+import { FlexRow } from "../../../styles/utils";
+
+import { LabelType } from "../../../colorizer/AnnotationData";
+import IconButton from "../../IconButton";
+
+type AnnotationInputPopoverProps = {
+  annotationState: AnnotationState;
+  anchorPositionPx: [number, number];
+};
+
+const InputWrapper = styled(Card)`
+  position: relative;
+  width: 200px;
+  & .ant-card-body {
+    padding: 4px;
+  }
+  z-index: 1;
+`;
+
+export default function AnnotationInputPopover(props: AnnotationInputPopoverProps): ReactElement {
+  const dataset = useViewerStateStore((state) => state.dataset);
+
+  const [visible, setVisible] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const anchorRef = React.useRef<HTMLDivElement>(null);
+
+  const { lastClickedId, currentLabelIdx, data: annotationData, isAnnotationModeEnabled } = props.annotationState;
+
+  useEffect(() => {
+    if (!isAnnotationModeEnabled) {
+      setVisible(false);
+    }
+  });
+
+  useEffect(() => {
+    if (lastClickedId !== null && currentLabelIdx !== null && dataset) {
+      const labelData = annotationData.getLabels()[currentLabelIdx];
+      // Check if the last clicked ID is labeled-- this means that the ID(s)
+      // were added to the label data instead of being removed.
+      const isLastClickedIdLabeled = labelData.ids.has(lastClickedId);
+      if (anchorRef.current && isLastClickedIdLabeled && labelData.options.type !== LabelType.BOOLEAN) {
+        setInputValue(annotationData.getValueFromId(currentLabelIdx, lastClickedId) ?? "");
+        anchorRef.current.style.left = `${props.anchorPositionPx[0] + 10}px`;
+        anchorRef.current.style.top = `${props.anchorPositionPx[1] + 10}px`;
+        setVisible(true);
+      } else {
+        setVisible(false);
+      }
+    } else {
+      setVisible(false);
+    }
+  }, [lastClickedId, currentLabelIdx]);
+
+  const handleInputConfirm = () => {
+    const lastEditedRange = props.annotationState.lastEditedRange;
+    console.log("lastEditedRange", lastEditedRange);
+    if (lastEditedRange !== null && currentLabelIdx !== null) {
+      const newValue = inputValue;
+      props.annotationState.setLabelValueOnIds(currentLabelIdx, lastEditedRange, newValue);
+    }
+    setVisible(false);
+  };
+
+  return (
+    <div ref={anchorRef} style={{ position: "absolute", width: "1px", height: "1px", zIndex: 102 }}>
+      <InputWrapper size="small" style={{ visibility: visible ? "visible" : "hidden" }}>
+        <FlexRow $gap={6}>
+          {/* TODO: Change width based on field type? */}
+          <Input
+            size="small"
+            defaultValue={inputValue}
+            style={{ pointerEvents: "auto" }}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onPressEnter={handleInputConfirm}
+            width={"50px"}
+          ></Input>
+          <IconButton type="link" onClick={handleInputConfirm}>
+            <SaveOutlined />
+          </IconButton>
+        </FlexRow>
+      </InputWrapper>
+    </div>
+  );
+}

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -49,6 +49,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
   const [isPending, startTransition] = useTransition();
   const [viewType, setViewType] = useState<AnnotationViewType>(AnnotationViewType.LIST);
   const [showCreateLabelModal, setShowCreateLabelModal] = useState(false);
+  const modalContainerRef = React.useRef<HTMLDivElement>(null);
 
   const store = useViewerStateStore(
     useShallow((state) => ({
@@ -146,7 +147,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
 
   return (
     <FlexColumnAlignCenter $gap={10}>
-      <FlexRow style={{ width: "100%", justifyContent: "space-between" }}>
+      <FlexRow style={{ width: "100%", justifyContent: "space-between" }} ref={modalContainerRef}>
         <AnnotationModeButton active={isAnnotationModeEnabled} onClick={onClickEnableAnnotationMode} />
 
         {/* Appears when the user activates annotations for the first time and should define a label. */}
@@ -154,10 +155,11 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
           open={showCreateLabelModal}
           footer={null}
           closable={true}
-          width={300}
+          width={360}
           title="Create new label"
           onCancel={() => setShowCreateLabelModal(false)}
           destroyOnClose={true}
+          getContainer={() => modalContainerRef.current ?? document.body}
         >
           <div style={{ marginTop: "15px" }}>
             <CreateLabelForm
@@ -186,8 +188,8 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
       </FlexRow>
 
       {/* Label selection and edit/create/delete buttons */}
-      <FlexRow $gap={6} style={{ width: "100%" }}>
-        <FlexRow $gap={6}>
+      <FlexRow $gap={6} style={{ width: "100%", flexWrap: "wrap" }}>
+        <FlexRow $gap={6} style={{ flexWrap: "wrap" }}>
           <VisuallyHidden id={LABEL_DROPDOWN_LABEL_ID}>Current label</VisuallyHidden>
           <SelectionDropdown
             selected={(currentLabelIdx ?? -1).toString()}

--- a/src/components/Tabs/Annotation/CreateLabelForm.tsx
+++ b/src/components/Tabs/Annotation/CreateLabelForm.tsx
@@ -1,13 +1,14 @@
 import { Color as AntdColor } from "@rc-component/color-picker";
-import { Button, ColorPicker, ConfigProvider, Input, InputRef } from "antd";
-import React, { ReactElement, useEffect, useRef, useState } from "react";
+import { Button, Checkbox, ColorPicker, ConfigProvider, Input, InputRef, Radio } from "antd";
+import React, { ReactElement, useContext, useEffect, useRef, useState } from "react";
 import { Color, ColorRepresentation } from "three";
 
 import { FlexColumn, FlexRow } from "../../../styles/utils";
 
-import { LabelOptions } from "../../../colorizer/AnnotationData";
-import { Z_INDEX_POPOVER } from "../../AppStyle";
+import { LabelOptions, LabelType } from "../../../colorizer/AnnotationData";
+import { AppThemeContext, Z_INDEX_POPOVER } from "../../AppStyle";
 import { SettingsContainer, SettingsItem } from "../../SettingsContainer";
+import { TooltipWithSubtitle } from "../../Tooltips/TooltipWithSubtitle";
 import { DEFAULT_LABEL_COLOR_PRESETS } from "./LabelEditControls";
 
 type CreateLabelFormProps = {
@@ -18,6 +19,7 @@ type CreateLabelFormProps = {
   confirmText?: string;
   focusNameInput?: boolean;
   zIndex?: number;
+  allowTypeSelection?: boolean;
 };
 
 const defaultProps: Partial<CreateLabelFormProps> = {
@@ -25,14 +27,25 @@ const defaultProps: Partial<CreateLabelFormProps> = {
   focusNameInput: true,
   onColorChanged: () => {},
   zIndex: Z_INDEX_POPOVER,
+  allowTypeSelection: true,
+};
+
+const labelTypeToDisplayName: Record<LabelType, string> = {
+  [LabelType.BOOLEAN]: "Boolean",
+  [LabelType.INTEGER]: "Integer",
+  [LabelType.CUSTOM]: "Custom",
 };
 
 export default function CreateLabelForm(inputProps: CreateLabelFormProps): ReactElement {
   const props = { ...defaultProps, ...inputProps } as Required<CreateLabelFormProps>;
 
+  const [labelType, setLabelType] = useState<LabelType>(props.initialLabelOptions.type);
+  const [autoIncrement, setAutoIncrement] = useState(false);
   const [color, setColor] = useState(props.initialLabelOptions.color);
   const [nameInput, setNameInput] = useState(props.initialLabelOptions.name);
   const nameInputRef = useRef<InputRef>(null);
+
+  const theme = useContext(AppThemeContext);
 
   useEffect(() => {
     if (nameInputRef.current && props.focusNameInput) {
@@ -44,6 +57,8 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
     props.onConfirm({
       color: color,
       name: nameInput.trim(),
+      type: labelType,
+      autoIncrement: autoIncrement,
     });
   };
 
@@ -54,8 +69,8 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
   };
 
   return (
-    <FlexColumn style={{ width: "250px" }} $gap={10}>
-      <SettingsContainer>
+    <FlexColumn style={{ width: "300px" }} $gap={10}>
+      <SettingsContainer gapPx={8}>
         <SettingsItem label="Name">
           <Input
             value={nameInput}
@@ -81,6 +96,45 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
             </div>
           </ConfigProvider>
         </SettingsItem>
+        <SettingsItem label="Type" labelStyle={{ marginBottom: "auto" }}>
+          {props.allowTypeSelection ? (
+            <Radio.Group
+              value={labelType}
+              onChange={(e) => setLabelType(e.target.value)}
+              style={{ width: "100%", position: "relative" }}
+              disabled={!props.allowTypeSelection}
+            >
+              <Radio value={LabelType.BOOLEAN}>Boolean</Radio>
+              <Radio value={LabelType.INTEGER}>Integer</Radio>
+              <Radio value={LabelType.CUSTOM}>Custom</Radio>
+            </Radio.Group>
+          ) : (
+            <p style={{ margin: 0, color: theme.color.text.hint }}>{labelTypeToDisplayName[labelType]}</p>
+          )}
+        </SettingsItem>
+        {labelType === LabelType.INTEGER && (
+          <SettingsItem label="">
+            <TooltipWithSubtitle
+              trigger={["hover", "focus"]}
+              title="Increments the label value on each click"
+              subtitle="Hold Shift to reuse last value"
+              placement="right"
+            >
+              <div>
+                <Checkbox
+                  checked={autoIncrement}
+                  onChange={(e) => {
+                    setAutoIncrement(e.target.checked);
+                  }}
+                  disabled={labelType !== LabelType.INTEGER}
+                  style={{ height: "fit-content" }}
+                >
+                  Auto-increment on click
+                </Checkbox>
+              </div>
+            </TooltipWithSubtitle>
+          </SettingsItem>
+        )}
       </SettingsContainer>
       <FlexRow style={{ marginLeft: "auto" }} $gap={10}>
         <Button onClick={props.onCancel}>Cancel</Button>

--- a/src/components/Tabs/Annotation/CreateLabelForm.tsx
+++ b/src/components/Tabs/Annotation/CreateLabelForm.tsx
@@ -49,7 +49,7 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
 
   useEffect(() => {
     if (nameInputRef.current && props.focusNameInput) {
-      nameInputRef.current.focus();
+      nameInputRef.current.focus({ preventScroll: true });
     }
   }, [props.focusNameInput]);
 

--- a/src/components/Tabs/Annotation/LabelEditControls.tsx
+++ b/src/components/Tabs/Annotation/LabelEditControls.tsx
@@ -5,7 +5,6 @@ import React, { ReactElement, useContext, useEffect, useRef, useState } from "re
 import { TagAddIconSVG } from "../../../assets";
 import { AnnotationSelectionMode } from "../../../colorizer";
 import { StyledRadioGroup } from "../../../styles/components";
-import { FlexRow } from "../../../styles/utils";
 
 import { DEFAULT_ANNOTATION_LABEL_COLORS, LabelData, LabelOptions } from "../../../colorizer/AnnotationData";
 import { AppThemeContext } from "../../AppStyle";
@@ -106,7 +105,7 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
   }, [props.selectedLabelIdx]);
 
   return (
-    <FlexRow $gap={6}>
+    <>
       <Popover
         title={<p style={{ fontSize: theme.font.size.label }}>Create label</p>}
         trigger={["click"]}
@@ -147,6 +146,7 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
               props.setLabelOptions({ color });
             }}
             confirmText="Save"
+            allowTypeSelection={false}
           />
         }
         open={showEditPopover}
@@ -180,7 +180,7 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
       </Popconfirm>
 
       <label style={{ display: "flex", flexDirection: "row", gap: "6px", marginLeft: "8px" }}>
-        <span style={{ fontSize: theme.font.size.label }}>Select by </span>
+        <span style={{ fontSize: theme.font.size.label, width: "max-content" }}>Select by </span>
         <StyledRadioGroup
           style={{ display: "flex", flexDirection: "row" }}
           value={props.selectionMode}
@@ -208,6 +208,6 @@ export default function LabelEditControls(props: LabelEditControlsProps): ReactE
           </Tooltip>
         </StyledRadioGroup>
       </label>
-    </FlexRow>
+    </>
   );
 }

--- a/src/components/Tooltips/CanvasHoverTooltip.tsx
+++ b/src/components/Tooltips/CanvasHoverTooltip.tsx
@@ -37,45 +37,6 @@ const DebugText = styled.p`
   color: var(--color-text-hint);
 `;
 
-const TagGroup = styled.div<{ $color: string }>`
-  display: flex;
-  flex-direction: row;
-  border-radius: calc(var(--radius-control-small) + 1) px;
-  --border-radius: var(--radius-control-small);
-  font-size: var(--font-size-label-small);
-  line-height: calc(var(--font-size-label-small) + 6px);
-  height: calc(var(--font-size-label-small) + 10px);
-  margin-right: 8px;
-
-  & * {
-    text-wrap-mode: nowrap;
-  }
-
-  & > :first-child {
-    width: max-content;
-    background-color: ${(props) => props.$color};
-    color: var(--color-text-button);
-    padding: 2px 8px 0px 8px;
-    border-top-left-radius: var(--border-radius);
-    border-bottom-left-radius: var(--border-radius);
-  }
-
-  & > :last-child {
-    border-top-right-radius: var(--border-radius);
-    border-bottom-right-radius: var(--border-radius);
-  }
-
-  & > :not(:first-child) {
-    width: fit-content;
-    background-color: var(--color-background);
-    border: 1px solid ${(props) => props.$color};
-    padding: 1px 4px 0px 6px;
-    max-width: 60px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-`;
-
 /**
  * Sets up and configures the hover tooltip for the main viewport canvas.
  * By default, displays the track ID and the value of the feature at the hovered point.
@@ -187,10 +148,14 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
               // TODO: Tags do not change their text color based on the background color.
               // Make a custom wrapper for Tag that does this; see
               // https://stackoverflow.com/questions/3942878/how-to-decide-font-color-in-white-or-black-depending-on-background-color
-              <TagGroup key={labelIdx} style={{ margin: "0 2px" }} $color={"#" + label.options.color.getHexString()}>
-                <span>{label.options.name}</span>
-                <span>{value}</span>
-              </TagGroup>
+              <Tag
+                key={labelIdx}
+                style={{ width: "fit-content", margin: "0 2px" }}
+                color={"#" + label.options.color.getHexString()}
+              >
+                {label.options.name}
+                {value ? " - " + value : ""}
+              </Tag>
             );
           })}
         </div>
@@ -204,17 +169,20 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
   if (props.annotationState.isAnnotationModeEnabled && currentLabelIdx !== null) {
     const currentLabelData = labelData[currentLabelIdx];
 
-    let currentValue = null;
-    if (currentLabelData.options.type !== "boolean") {
-      currentValue = props.annotationState.nextDefaultLabelValue;
+    let value = null;
+    if (currentLabelData.options.type !== LabelType.BOOLEAN) {
+      value = props.annotationState.nextDefaultLabelValue;
     }
 
     annotationLabel = (
       <>
-        <TagGroup $color={"#" + currentLabelData.options.color.getHexString()}>
-          <span>{currentLabelData.options.name}</span>
-          <span>{currentValue}</span>
-        </TagGroup>
+        <Tag
+          style={{ width: "fit-content", margin: "0 2px" }}
+          color={"#" + currentLabelData.options.color.getHexString()}
+        >
+          {currentLabelData.options.name}
+          {value ? " - " + value : ""}
+        </Tag>
       </>
     );
 

--- a/src/components/Tooltips/CanvasHoverTooltip.tsx
+++ b/src/components/Tooltips/CanvasHoverTooltip.tsx
@@ -1,4 +1,4 @@
-import { Space, Tag } from "antd";
+import { Tag } from "antd";
 import React, { PropsWithChildren, ReactElement, useCallback } from "react";
 import styled from "styled-components";
 import { useShallow } from "zustand/shallow";
@@ -220,8 +220,9 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
 
     if (lastHoveredId.globalId !== undefined) {
       const isHoveredIdLabeled = props.annotationState.data.isLabelOnId(currentLabelIdx, lastHoveredId.globalId);
+      const isLabelBoolean = currentLabelData.options.type === LabelType.BOOLEAN;
+      const verb = isHoveredIdLabeled ? (isLabelBoolean ? "unlabel" : "edit") : "label";
       if (props.annotationState.selectionMode === AnnotationSelectionMode.TRACK) {
-        const verb = isHoveredIdLabeled ? "unlabel" : "label";
         annotationLabel = (
           <FlexRow>
             {annotationLabel}
@@ -239,7 +240,6 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
             const id1 = hoveredRange[hoveredRange.length - 1];
             const t0 = dataset.getTime(id0);
             const t1 = dataset.getTime(id1);
-            const verb = isHoveredIdLabeled ? "unlabel" : "label";
             annotationLabel = (
               <FlexRow>
                 {annotationLabel}


### PR DESCRIPTION
Problem
=======
Closes #652, "Annotation - multi-value labels UI MVP."

This PR adds in the basic UI for interacting with multi-value labels. Users can set the type of an annotation label to boolean, integer, or custom. The latter two are rendered differently onscreen and can be edited by clicking an annotated cell, which pops up an input field.



Solution
========
What I/we did to solve this problem

with @pairperson1

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open PR preview:
2. Create a new Integer 

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
3. other important file

Thanks for contributing!
