### PR TITLE
feat: Allow more internal paths

### DIFF
--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -304,7 +304,7 @@ export type ReportErrorCallback = (message: string) => void;
 export type ReportLoadProgressCallback = (complete: number, total: number) => void;
 
 export enum LoadTroubleshooting {
-  CHECK_NETWORK = "This may be due to a network issue, the server being unreachable, or a misconfigured URL." +
+  CHECK_NETWORK = "This may be due to a network issue, the server being down or unreachable, or a misconfigured URL." +
     " Please check your network access.",
   CHECK_FILE_EXISTS = "Please check if the file exists and if you have access to it, or see the developer console for more details.",
   CHECK_FILE_OR_NETWORK = "This may be because of an unsupported format, missing files, or server and network issues. Please see the developer console for more details.",

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -61,9 +61,7 @@ export enum UrlParam {
 const ALLEN_FILE_PREFIX = "/allen/";
 const ALLEN_PREFIX_TO_HTTPS: Record<string, string> = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  "/allen/aics/assay-dev": "https://dev-aics-dtp-001.int.allencell.org/assay-dev",
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  "/allen/aics/microscopy": "https://dev-aics-dtp-001.int.allencell.org/microscopy",
+  "/allen/aics/": "https://dev-aics-dtp-001.int.allencell.org/",
 };
 
 export const DEFAULT_FETCH_TIMEOUT_MS = 2000;

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -345,6 +345,11 @@ function normalizeFilePathSlashes(input: string): string {
   input = input.replaceAll("\\", "/");
   // Replace double slashes with single
   input = input.replaceAll("//", "/");
+  if (input.startsWith("//")) {
+    // If the string still starts with double slashes, remove the first.
+    // (Usually `\\\\` for Windows paths)
+    input = input.slice(1);
+  }
   return input;
 }
 

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -210,7 +210,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
         } else if (hasConvertedAllenPath) {
           setErrorText(
             (reason.toString() || DEFAULT_URL_FAILURE_MESSAGE) +
-              "\nIf the problem is not network access, this may be an unrecognized file path. If you expect this path to work, please report an issue on GitHub from the Help menu."
+              "\nIf the problem is not network access, this may be an unrecognized file path. If you expect this path to work, please report an issue on GitHub from the Help menu or contact a developer."
           );
         } else {
           setErrorText(reason.toString() || DEFAULT_URL_FAILURE_MESSAGE);

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -16,6 +16,9 @@ import { AppThemeContext } from "./AppStyle";
 import TextButton from "./Buttons/TextButton";
 import StyledModal from "./Modals/StyledModal";
 
+const DEFAULT_URL_FAILURE_MESSAGE =
+  "The dataset(s) could not be loaded with the URL provided. Please check it and try again.";
+
 type LoadDatasetButtonProps = {
   /**
    * Callback when a dataset was successfully loaded.
@@ -155,15 +158,17 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
       return;
     }
     let formattedUrlInput = urlInput.trim();
+    let hasConvertedAllenPath = false;
     // Check if the URL is an allen resource. If so, attempt to convert it.
     if (isAllenPath(formattedUrlInput)) {
       const convertedUrl = convertAllenPathToHttps(formattedUrlInput);
       if (!convertedUrl) {
         setErrorText(
-          "The provided filestore path cannot be loaded directly. Please check that the path is correct! Alternatively, move your dataset so it is served over HTTPS."
+          "The provided filestore path cannot be loaded directly. Please check that the path is correct; if this a path you expect to work, file an issue on GitHub. Alternatively, move your dataset so it is served over HTTPS."
         );
         return;
       }
+      hasConvertedAllenPath = true;
       formattedUrlInput = convertedUrl;
     }
 
@@ -202,11 +207,13 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
           setErrorText(
             "Timeout: The server took too long to respond. Please check if the file server is online and try again."
           );
-        } else {
+        } else if (hasConvertedAllenPath) {
           setErrorText(
-            reason.toString() ||
-              "The dataset(s) could not be loaded with the URL provided. Please check it and try again."
+            (reason.toString() || DEFAULT_URL_FAILURE_MESSAGE) +
+              "\nIf the problem is not network access, this may be an unrecognized file path. If you expect this path to work, please report an issue on GitHub from the Help menu."
           );
+        } else {
+          setErrorText(reason.toString() || DEFAULT_URL_FAILURE_MESSAGE);
         }
         setIsLoading(false);
       }


### PR DESCRIPTION
Problem
=======
Scientists on new projects need to load internal-only datasets on TFE. This allows more internal paths to be loaded, while also updating error messaging in case a path cannot be loaded.

*Estimated review size: tiny, 5 minutes*

Solution
========
- Attempts to load any `/allen/aics` file path from the internal server.
- Updates error messaging to include reporting instructions for paths that may not be supported.

## Type of change
* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open PR preview: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-660/
2. From the load menu, paste in this fake path. You should see additional error messaging guiding users to report the issue: `//allen/aics/not-a-real-path/manifest.json`.
3. Paste this new path instead. It should load without issues (if you are on the internal network): `//allen/aics/endothelial/morphological_features/timelapse_feature_explorer/20241120_20X_P0/cell_seg/manifest.json`

Screenshots (optional):
-----------------------

New error messaging:
![image](https://github.com/user-attachments/assets/c7aeec38-1f63-45f2-a9be-fb9614320f72)
