### PR TITLE
feat: Show visual indicator of label type in dropdown (annotations pt. 5)

### DIFF
--- a/src/components/Dropdowns/StyledSelect.tsx
+++ b/src/components/Dropdowns/StyledSelect.tsx
@@ -19,24 +19,47 @@ type AntStyledSelectProps<
   styles?: StylesConfig<SelectItem, IsMulti, Group>;
 };
 
+const COLOR_INDICATOR_BASE_STYLE = {
+  borderRadius: 10,
+  display: "block",
+  marginLeft: 1,
+  marginRight: 6,
+  height: 11,
+  width: 11,
+};
+
+const LABELED_COLOR_INDICATOR_BASE_STYLE = {
+  ...COLOR_INDICATOR_BASE_STYLE,
+  borderRadius: 2,
+  color: "white",
+  width: 12,
+  height: 12,
+  fontSize: 8,
+  marginLeft: 0,
+  marginRight: 6,
+  textAlign: "center",
+  position: "relative",
+};
+
 /**
  * If `color` is defined, adds style config properties  that add a colored
  * pseudo-element indicator to the left of an option text in the dropdown.
  */
-const addOptionalColorIndicator = (color: Color | undefined): Partial<StylesConfig["option"]> => {
+const addOptionalColorIndicator = (
+  color: Color | undefined,
+  label: string | undefined
+): Partial<StylesConfig["option"]> => {
   if (color) {
+    const baseStyle = label ? LABELED_COLOR_INDICATOR_BASE_STYLE : COLOR_INDICATOR_BASE_STYLE;
     return {
       alignItems: "center",
       display: "flex",
+      flexDirection: "row",
       // eslint-disable-next-line @typescript-eslint/naming-convention
       ":before": {
+        ...baseStyle,
         backgroundColor: "#" + color.getHexString(),
-        borderRadius: 10,
-        content: '" "',
-        display: "block",
-        marginRight: 8,
-        height: 10,
-        width: 10,
+        content: `"${label ?? " "}"`,
       },
     };
   }
@@ -218,11 +241,11 @@ const getCustomStyles = (theme: AppTheme, width: string): StylesConfig<SelectIte
           : theme.color.dropdown.backgroundHover
         : undefined,
     },
-    ...addOptionalColorIndicator(data?.color),
+    ...addOptionalColorIndicator(data?.color, data?.colorLabel),
   }),
   singleValue: (styles, { data }) => ({
     ...styles,
-    ...addOptionalColorIndicator(data?.color),
+    ...addOptionalColorIndicator(data?.color, data?.colorLabel),
   }),
 });
 

--- a/src/components/Dropdowns/StyledSelect.tsx
+++ b/src/components/Dropdowns/StyledSelect.tsx
@@ -35,9 +35,14 @@ const LABELED_COLOR_INDICATOR_BASE_STYLE = {
   height: 12,
   width: 12,
   borderRadius: 2,
-  fontSize: 8,
+  fontSize: 9,
   textAlign: "center",
+  // Use serif font to make certain characters (`I`) more legible but keep
+  // default fonts as fallback
+  fontFamily: "Garamond,var(--default-font)",
+  lineHeight: "13px", // Vertically centers text
   color: "var(--color-text-button)",
+  fontWeight: 800,
 };
 
 /**

--- a/src/components/Dropdowns/StyledSelect.tsx
+++ b/src/components/Dropdowns/StyledSelect.tsx
@@ -20,25 +20,24 @@ type AntStyledSelectProps<
 };
 
 const COLOR_INDICATOR_BASE_STYLE = {
-  borderRadius: 10,
   display: "block",
   marginLeft: 1,
   marginRight: 6,
   height: 11,
   width: 11,
+  borderRadius: 11,
 };
 
 const LABELED_COLOR_INDICATOR_BASE_STYLE = {
   ...COLOR_INDICATOR_BASE_STYLE,
-  borderRadius: 2,
-  color: "white",
-  width: 12,
-  height: 12,
-  fontSize: 8,
   marginLeft: 0,
   marginRight: 6,
+  height: 12,
+  width: 12,
+  borderRadius: 2,
+  fontSize: 8,
   textAlign: "center",
-  position: "relative",
+  color: "var(--color-text-button)",
 };
 
 /**

--- a/src/components/Dropdowns/types.ts
+++ b/src/components/Dropdowns/types.ts
@@ -15,6 +15,8 @@ export type SelectItem = {
    * shown next to the label in the dropdown.
    */
   color?: Color;
+  /** Optional one-character label that will be rendered in the color indicator. */
+  colorLabel?: string;
   /** Optional tooltip for an option. If set, a tooltip will be shown when
    * the option is hovered or focused in the dropdown. */
   tooltip?: string | ReactNode;

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -11,7 +11,7 @@ import { FlexColumnAlignCenter, FlexRow, VisuallyHidden } from "../../../styles/
 import { download } from "../../../utils/file_io";
 import { SelectItem } from "../../Dropdowns/types";
 
-import { LabelData, LabelOptions } from "../../../colorizer/AnnotationData";
+import { LabelData, LabelOptions, LabelType } from "../../../colorizer/AnnotationData";
 import { Z_INDEX_MODAL } from "../../AppStyle";
 import TextButton from "../../Buttons/TextButton";
 import SelectionDropdown from "../../Dropdowns/SelectionDropdown";
@@ -131,12 +131,19 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
   );
 
   // Options for the selection dropdown
+  const labelTypeToLabel: Record<LabelType, string> = {
+    [LabelType.BOOLEAN]: "",
+    [LabelType.INTEGER]: "I",
+    [LabelType.CUSTOM]: "C",
+  };
+
   const selectLabelOptions: SelectItem[] = useMemo(
     () =>
       labels.map((label, index) => ({
         value: index.toString(),
         label: label.ids.size ? `${label.options.name} (${label.ids.size})` : label.options.name,
         color: label.options.color,
+        colorLabel: labelTypeToLabel[label.options.type],
       })),
     [annotationData]
   );


### PR DESCRIPTION
Problem
=======
Small improvement extension off of annotations pt. 4! This adds a small indicator of a label's type to the label dropdown.

*Estimated review size: small, 5-10 minutes*

Solution
========
- Updates the `SelectItem` type to accept a single character label, which is displayed by the `StyledSelect` and `SelectionDropdown`.
- Annotation labels now change their shape + show a character label based on the type of the label.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview-internal/pr-664/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&tab=annotation
2. Activate annotation edit mode. Create a label of each type. You should see a small colored indicator appear next to each.

Screenshots (optional):
-----------------------

Note that the circle/square format is designed to mimic how different labels are shown onscreen.

![image](https://github.com/user-attachments/assets/0d7fc1a6-903c-438e-a5e0-b36cad49e2b3)

![image](https://github.com/user-attachments/assets/d215a6f7-b1ee-415f-b0b9-ed8c676e0675)
