### PR TITLE
fix: Change tab immediately on load

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -33,6 +33,7 @@ import { SCATTERPLOT_TIME_FEATURE } from "./components/Tabs/scatter_plot_data_ut
 import { DEFAULT_PLAYBACK_FPS, INTERNAL_BUILD } from "./constants";
 import { getDifferingProperties } from "./state/utils/data_validation";
 import {
+  loadInitialViewerStateFromParams,
   loadViewerStateFromParams,
   selectSerializationDependencies,
   serializeViewerState,
@@ -396,6 +397,8 @@ function Viewer(): ReactElement {
       if (isLoadingInitialDataset.current || isInitialDatasetLoaded) {
         return;
       }
+
+      loadInitialViewerStateFromParams(useViewerStateStore, searchParams);
 
       setIsDatasetLoading(true);
       setDatasetLoadProgress(null);

--- a/src/colorizer/Plotting.ts
+++ b/src/colorizer/Plotting.ts
@@ -149,6 +149,9 @@ export default class Plotting {
   }
 
   setSize(x: number, y: number): void {
+    if (!x || !y) {
+      return;
+    }
     const layout: Partial<Plotly.Layout> = {
       width: x,
       height: y,

--- a/src/components/Tabs/Settings/VectorFieldSettings.tsx
+++ b/src/components/Tabs/Settings/VectorFieldSettings.tsx
@@ -19,6 +19,7 @@ const VECTOR_OPTION_MOTION = {
 };
 
 export default function VectorFieldSettings(): ReactElement {
+  const dataset = useViewerStateStore((state) => state.dataset);
   const setVectorColor = useViewerStateStore((state) => state.setVectorColor);
   const setVectorKey = useViewerStateStore((state) => state.setVectorKey);
   const setVectorMotionTimeIntervals = useViewerStateStore((state) => state.setVectorMotionTimeIntervals);
@@ -34,31 +35,36 @@ export default function VectorFieldSettings(): ReactElement {
 
   // TODO: Add additional vectors here when support for user vector data is added.
   const vectorOptions = useMemo(() => [VECTOR_OPTION_MOTION], []);
+  const vectorOptionsEnabled = vectorVisible && dataset !== null;
 
   return (
     <>
       <SettingsItem label={"Show vector arrows"}>
         <div>
           {/* TODO: Replace with a top-level checkbox for Vector arrows when Collapse menus are removed */}
-          <Checkbox checked={vectorVisible} onChange={(e) => setVectorVisible(e.target.checked)} />
+          <Checkbox
+            checked={vectorVisible}
+            onChange={(e) => setVectorVisible(e.target.checked)}
+            disabled={dataset === null}
+          />
         </div>
       </SettingsItem>
 
       <SettingsItem label="Vector" labelStyle={{ height: "min-content", paddingTop: "2px" }}>
         <SelectionDropdown
-          disabled={!vectorVisible}
+          disabled={!vectorOptionsEnabled}
           selected={vectorKey}
           items={vectorOptions}
           onChange={setVectorKey}
         ></SelectionDropdown>
-        {vectorKey === VECTOR_KEY_MOTION_DELTA && vectorVisible && (
+        {vectorKey === VECTOR_KEY_MOTION_DELTA && vectorOptionsEnabled && (
           <Card style={{ position: "relative", width: "fit-content", marginTop: "10px" }} size="small">
             <SettingsContainer>
               <SettingsItem label="Average over # time intervals">
                 <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
                   <LabeledSlider
                     type="value"
-                    disabled={!vectorVisible}
+                    disabled={!vectorOptionsEnabled}
                     step={1}
                     minSliderBound={1}
                     maxSliderBound={20}
@@ -83,7 +89,7 @@ export default function VectorFieldSettings(): ReactElement {
       <SettingsItem label={"Scale factor"}>
         <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
           <LabeledSlider
-            disabled={!vectorVisible}
+            disabled={!vectorOptionsEnabled}
             type="value"
             minSliderBound={0}
             maxSliderBound={50}
@@ -98,7 +104,7 @@ export default function VectorFieldSettings(): ReactElement {
       <SettingsItem label="Arrow color">
         <div>
           <ColorPicker
-            disabled={!vectorVisible}
+            disabled={!vectorOptionsEnabled}
             disabledAlpha={true}
             size="small"
             value={new AntdColor(vectorColor.getHexString())}
@@ -114,7 +120,7 @@ export default function VectorFieldSettings(): ReactElement {
           <Radio.Group
             value={vectorTooltipMode}
             onChange={(e) => setVectorTooltipMode(e.target.value)}
-            disabled={!vectorVisible}
+            disabled={!vectorOptionsEnabled}
           >
             <Radio value={VectorTooltipMode.MAGNITUDE}>Magnitude and angle</Radio>
             <Radio value={VectorTooltipMode.COMPONENTS}>XY components</Radio>

--- a/src/state/utils/store_io.ts
+++ b/src/state/utils/store_io.ts
@@ -119,14 +119,21 @@ export const serializedDataToUrl = (data: SerializedStoreData): string => {
 // DESERIALIZATION ///////////////////////////////////////////////////////////////////////
 
 /**
+ * Loads only the viewer state that's not dependent on the dataset from the
+ * given URL parameters.
+ */
+export const loadInitialViewerStateFromParams = (store: Store<ViewerStore>, params: URLSearchParams): void => {
+  // Load only slices that do not depend on the dataset or collection
+  loadConfigSliceFromParams(store.getState(), params);
+};
+
+/**
  * Loads the viewer state from the given URL parameters. Note that this MUST be
  * called after the collection and dataset are loaded and set in the store.
  */
 export const loadViewerStateFromParams = (store: Store<ViewerStore>, params: URLSearchParams): void => {
   // TODO: Should each of these be wrapped in a try/catch block in case of bad inputs?
   // 1. No dependencies:
-  loadConfigSliceFromParams(store.getState(), params);
-
   // 2. Dependent on dataset object:
   loadBackdropSliceFromParams(store.getState(), params);
   loadDatasetSliceFromParams(store.getState(), params);

--- a/tests/state/store_io.test.ts
+++ b/tests/state/store_io.test.ts
@@ -19,7 +19,12 @@ import { UrlParam } from "../../src/colorizer/utils/url_utils";
 import { useViewerStateStore } from "../../src/state";
 import { ViewerStoreSerializableState } from "../../src/state/slices";
 import { SerializedStoreData } from "../../src/state/types";
-import { loadViewerStateFromParams, serializedDataToUrl, serializeViewerParams } from "../../src/state/utils/store_io";
+import {
+  loadInitialViewerStateFromParams,
+  loadViewerStateFromParams,
+  serializedDataToUrl,
+  serializeViewerParams,
+} from "../../src/state/utils/store_io";
 import { sleep } from "../test_utils";
 import {
   MOCK_COLLECTION,
@@ -194,6 +199,7 @@ describe("loadViewerStateFromParams", () => {
     });
     await setDatasetAsync(result, MOCK_DATASET);
     await act(async () => {
+      loadInitialViewerStateFromParams(useViewerStateStore, params);
       loadViewerStateFromParams(useViewerStateStore, params);
       // Fixup: Wait for frame to load fully so `currentFrame` value is correct
       await sleep(10);


### PR DESCRIPTION
Problem
=======
TFE stores the currently visible tab (and other viewer configuration) to the URL. However, currently these settings are not applied until after a dataset is loaded, which causes the tabs to jump suddenly.

This fix makes it so that state settings that aren't dataset-dependent (e.g. viewer config) are loaded and applied right away. It also includes a few small bugfixes.

Solution
========
What I/we did to solve this problem

with @pairperson1

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* This change requires a documentation update
* This change requires updated or new tests

Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
2. other important file

Thanks for contributing!
