### PR TITLE
feat: Release internal-only tabs

### DIFF
--- a/src/Viewer.module.css
+++ b/src/Viewer.module.css
@@ -138,3 +138,10 @@
   height: var(--height);
   overflow-y: scroll;
 }
+
+.plotAndFiltersPanel :global(.ant-tabs-nav-operations) {
+  &&&& > button {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -1,6 +1,7 @@
 import {
   CaretRightOutlined,
   CheckCircleOutlined,
+  EllipsisOutlined,
   LinkOutlined,
   PauseOutlined,
   StepBackwardFilled,
@@ -933,6 +934,7 @@ function Viewer(): ReactElement {
                 activeKey={openTab}
                 onChange={(key) => setOpenTab(key as TabType)}
                 items={tabItems}
+                moreIcon={<EllipsisOutlined style={{ fontSize: theme.font.size.section }} />}
               />
             </div>
           </div>

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -30,7 +30,7 @@ import { useAnnotations, useConstructor, useDebounce, useRecentCollections } fro
 import { showFailedUrlParseAlert } from "./components/Banner/alert_templates";
 import { SelectItem } from "./components/Dropdowns/types";
 import { SCATTERPLOT_TIME_FEATURE } from "./components/Tabs/scatter_plot_data_utils";
-import { DEFAULT_PLAYBACK_FPS, INTERNAL_BUILD } from "./constants";
+import { DEFAULT_PLAYBACK_FPS } from "./constants";
 import { getDifferingProperties } from "./state/utils/data_validation";
 import {
   loadViewerStateFromParams,
@@ -78,6 +78,13 @@ import { useViewerStateStore } from "./state/ViewerState";
 
 // TODO: Refactor with styled-components
 import styles from "./Viewer.module.css";
+
+type TabItem = {
+  label: string;
+  key: string;
+  visible?: boolean;
+  children: ReactNode;
+};
 
 function Viewer(): ReactElement {
   // STATE INITIALIZATION /////////////////////////////////////////////////////////
@@ -605,7 +612,7 @@ function Viewer(): ReactElement {
     return [threshold.min, threshold.max];
   };
 
-  const allTabItems = [
+  const allTabItems: TabItem[] = [
     {
       label: "Track plot",
       key: TabType.TRACK_PLOT,
@@ -631,7 +638,6 @@ function Viewer(): ReactElement {
     {
       label: "Correlation plot",
       key: TabType.CORRELATION_PLOT,
-      visible: INTERNAL_BUILD,
       children: (
         <div className={styles.tabContent}>
           <CorrelationPlotTab openScatterPlotTab={openScatterPlotTab} workerPool={workerPool} dataset={dataset} />
@@ -650,7 +656,6 @@ function Viewer(): ReactElement {
     {
       label: "Annotations",
       key: TabType.ANNOTATION,
-      visible: INTERNAL_BUILD,
       children: (
         <div className={styles.tabContent}>
           <AnnotationTab annotationState={annotationState} hoveredId={currentHoveredId?.globalId ?? null} />

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -408,6 +408,7 @@ export default function AppStyle(props: PropsWithChildren<AppStyleProps>): React
               cardBg: theme.color.layout.tabBackground,
               colorBorder: theme.color.layout.borders,
               colorBorderSecondary: theme.color.layout.borders,
+              fontSizeLG: theme.font.size.content,
             },
             Divider: {
               colorSplit: theme.color.layout.dividers,


### PR DESCRIPTION
Problem
=======
Closes #675, "show annotation + correlation plot in public build."

*Estimated review size: tiny, 5 minutes*

Solution
========
- Made the correlation plot and annotation tab visible in the public-facing build of TFE.
- Slightly adjusted padding + sizing on the overflow menu ellipsis button.
- Made font in tabs slightly smaller.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open PR preview. The annotation tab + correlation plot tabs should appear: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-676/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json

Screenshots (optional):
-----------------------
![image](https://github.com/user-attachments/assets/2df5a9cb-7cb4-4081-a711-94526df5682b)

![image](https://github.com/user-attachments/assets/becad727-dc32-447c-a850-16cfcda294be)
