### PR TITLE
feat: Show value as column in annotation data table (layouts pt. 1)

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -31,7 +31,7 @@ import { useAnnotations, useConstructor, useDebounce, useRecentCollections } fro
 import { showFailedUrlParseAlert } from "./components/Banner/alert_templates";
 import { SelectItem } from "./components/Dropdowns/types";
 import { SCATTERPLOT_TIME_FEATURE } from "./components/Tabs/scatter_plot_data_utils";
-import { DEFAULT_PLAYBACK_FPS } from "./constants";
+import { DEFAULT_PLAYBACK_FPS, INTERNAL_BUILD } from "./constants";
 import { getDifferingProperties } from "./state/utils/data_validation";
 import {
   loadInitialViewerStateFromParams,

--- a/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
+++ b/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
@@ -159,7 +159,7 @@ export default function AnnotationDisplayList(props: AnnotationDisplayListProps)
       </p>
       {/* Column 1 is all of the tracks displayed as an unordered list */}
       <ListLayoutContainer>
-        <FlexColumn style={{ height: "100%", width: "40%" }}>
+        <FlexColumn style={{ height: "100%", width: "45%" }}>
           <div style={{ position: "relative" }}>
             <div style={{ height: "490px", overflowY: "auto" }} ref={scrollRef} onScroll={onScrollHandler}>
               {listContents}
@@ -170,7 +170,7 @@ export default function AnnotationDisplayList(props: AnnotationDisplayListProps)
         {/* Column 2  is a side panel showing the labeled IDs for the selected track. */}
         <div
           style={{
-            width: "calc(60% + 5px)",
+            width: "calc(55% - 20px)",
             height: "calc(100% - 10px)",
             padding: "5px 10px 10px 10px",
             border: "1px solid var(--color-borders)",

--- a/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
+++ b/src/components/Tabs/Annotation/AnnotationDisplayList.tsx
@@ -15,6 +15,7 @@ import AnnotationTrackThumbnail from "./AnnotationTrackThumbnail";
 type AnnotationDisplayListProps = {
   dataset: Dataset | null;
   ids: number[];
+  idToValue: Map<number, string> | undefined;
   setFrame: (frame: number) => Promise<void>;
   onClickTrack: (trackId: number) => void;
   onClickObjectRow: (record: TableDataType) => void;
@@ -207,6 +208,7 @@ export default function AnnotationDisplayList(props: AnnotationDisplayListProps)
             onClickDeleteObject={props.onClickDeleteObject}
             dataset={props.dataset}
             ids={selectedTrackId ? trackToIds.get(selectedTrackId?.toString()) ?? [] : []}
+            idToValue={props.idToValue}
             height={410}
             selectedId={props.selectedId}
             hideTrackColumn={true}

--- a/src/components/Tabs/Annotation/AnnotationDisplayTable.tsx
+++ b/src/components/Tabs/Annotation/AnnotationDisplayTable.tsx
@@ -79,21 +79,21 @@ const AnnotationDisplayTable = memo(function AnnotationDisplayTable(inputProps: 
       title: "Object ID",
       dataIndex: "id",
       key: "id",
-      width: "30%",
+      width: "20%",
       sorter: (a, b) => a.id - b.id,
     },
     {
       title: "Time",
       dataIndex: "time",
       key: "time",
-      width: "30%",
+      width: "20%",
       sorter: (a, b) => a.time - b.time,
     },
     // Column that contains a remove button for the ID.
     {
       title: "",
       key: "action",
-      width: "10%",
+      width: "5%",
       render: (_, record) => (
         <div style={{ display: "flex", justifyContent: "right" }}>
           <IconButton
@@ -122,7 +122,7 @@ const AnnotationDisplayTable = memo(function AnnotationDisplayTable(inputProps: 
       title: "Track ID",
       dataIndex: "track",
       key: "track",
-      width: "30%",
+      width: "20%",
       sorter: (a, b) => a.track - b.track,
     });
   }
@@ -132,7 +132,7 @@ const AnnotationDisplayTable = memo(function AnnotationDisplayTable(inputProps: 
       title: "Value",
       dataIndex: "value",
       key: "value",
-      width: "30%",
+      width: "40%",
       sorter: (a, b) => a.value.localeCompare(b.value),
     });
   }

--- a/src/components/Tabs/Annotation/AnnotationDisplayTable.tsx
+++ b/src/components/Tabs/Annotation/AnnotationDisplayTable.tsx
@@ -16,6 +16,7 @@ export type TableDataType = {
   key: string;
   id: number;
   track: number;
+  value: string;
   time: number;
 };
 
@@ -53,6 +54,7 @@ type AnnotationTableProps = {
   onClickDeleteObject: (record: TableDataType) => void;
   dataset: Dataset | null;
   ids: number[];
+  idToValue?: Map<number, string>;
   height?: number | string;
   hideTrackColumn?: boolean;
   selectedId?: number;
@@ -69,7 +71,7 @@ const defaultProps = {
  * interactions.
  */
 const AnnotationDisplayTable = memo(function AnnotationDisplayTable(inputProps: AnnotationTableProps): ReactElement {
-  const props: Required<AnnotationTableProps> = { ...defaultProps, ...inputProps };
+  const props = { ...defaultProps, ...inputProps };
   const theme = useContext(AppThemeContext);
 
   const tableColumns: TableProps<TableDataType>["columns"] = [
@@ -79,13 +81,6 @@ const AnnotationDisplayTable = memo(function AnnotationDisplayTable(inputProps: 
       key: "id",
       width: "30%",
       sorter: (a, b) => a.id - b.id,
-    },
-    {
-      title: "Track ID",
-      dataIndex: "track",
-      key: "track",
-      width: "30%",
-      sorter: (a, b) => a.track - b.track,
     },
     {
       title: "Time",
@@ -122,8 +117,24 @@ const AnnotationDisplayTable = memo(function AnnotationDisplayTable(inputProps: 
     },
   ];
 
-  if (props.hideTrackColumn) {
-    tableColumns.splice(1, 1);
+  if (!props.hideTrackColumn) {
+    tableColumns.splice(1, 0, {
+      title: "Track ID",
+      dataIndex: "track",
+      key: "track",
+      width: "30%",
+      sorter: (a, b) => a.track - b.track,
+    });
+  }
+
+  if (props.idToValue) {
+    tableColumns.splice(2, 0, {
+      title: "Value",
+      dataIndex: "value",
+      key: "value",
+      width: "30%",
+      sorter: (a, b) => a.value.localeCompare(b.value),
+    });
   }
 
   const tableData: TableDataType[] = useMemo(() => {
@@ -132,11 +143,12 @@ const AnnotationDisplayTable = memo(function AnnotationDisplayTable(inputProps: 
       return props.ids.map((id) => {
         const track = dataset.getTrackId(id);
         const time = dataset.getTime(id);
-        return { key: id.toString(), id, track, time };
+        const value = props.idToValue?.get(id) ?? "";
+        return { key: id.toString(), id, track, time, value };
       });
     }
     return [];
-  }, [props.ids, props.dataset]);
+  }, [props.ids, props.dataset, props.idToValue]);
 
   return (
     <StyledAntTable

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -17,7 +17,7 @@ import TextButton from "../../Buttons/TextButton";
 import SelectionDropdown from "../../Dropdowns/SelectionDropdown";
 import LoadingSpinner from "../../LoadingSpinner";
 import AnnotationDisplayList from "./AnnotationDisplayList";
-import AnnotationTable, { TableDataType } from "./AnnotationDisplayTable";
+import AnnotationDisplayTable, { TableDataType } from "./AnnotationDisplayTable";
 import AnnotationModeButton from "./AnnotationModeButton";
 import CreateLabelForm from "./CreateLabelForm";
 import LabelEditControls from "./LabelEditControls";
@@ -151,6 +151,16 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
   const tableIds = useMemo(() => {
     return currentLabelIdx !== null ? annotationData.getLabeledIds(currentLabelIdx) : [];
   }, [currentLabelIdx, annotationData]);
+  const tableValues = useMemo(() => {
+    if (currentLabelIdx === null) {
+      return undefined;
+    }
+    const labelData = annotationData.getLabels()[currentLabelIdx];
+    if (labelData.options.type === LabelType.BOOLEAN) {
+      return undefined;
+    }
+    return labelData.idToValue;
+  }, [currentLabelIdx, annotationData]);
 
   const labelSelectionDropdown = (
     <>
@@ -267,11 +277,12 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
             display: viewType === AnnotationViewType.TABLE ? "block" : "none",
           }}
         >
-          <AnnotationTable
+          <AnnotationDisplayTable
             onClickObjectRow={onClickObjectRow}
             onClickDeleteObject={onClickDeleteObject}
             dataset={store.dataset}
             ids={tableIds}
+            idToValue={tableValues}
             height={480}
             selectedId={selectedId}
           />
@@ -301,6 +312,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
             setFrame={store.setFrame}
             dataset={store.dataset}
             ids={tableIds}
+            idToValue={tableValues}
             highlightRange={highlightedIds}
             lastClickedId={props.annotationState.lastClickedId}
             selectedTrack={store.selectedTrack}


### PR DESCRIPTION
Problem
=======
Part 1 of 3ish for #651 "Layout for multi-value annotation labels", and closes the MVP ticket, #671.

This adds columns for annotation values to the table and list layouts in the annotation tab!

*Estimated review size: small, 5-10 minutes*

Solution
========
What I/we did to solve this problem

with @pairperson1

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* This change requires a documentation update
* This change requires updated or new tests

Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
2. other important file

Thanks for contributing!
