### PR TITLE
fix: Enforce even dimensions on canvas when exporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "fuse.js": "^7.0.0",
         "hyparquet": "^1.0.0",
         "hyparquet-compressors": "^0.1.4",
-        "mp4-muxer": "^2.2.2",
+        "mp4-muxer": "^5.2.1",
         "papaparse": "^5.4.1",
         "plotly.js-dist-min": "^2.27.0",
         "react": "^18.2.0",
@@ -10664,9 +10664,9 @@
       }
     },
     "node_modules/mp4-muxer": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/mp4-muxer/-/mp4-muxer-2.2.2.tgz",
-      "integrity": "sha512-VYK26lPlSmtyEvnTtIYDw1j3M6iwNBWAuoVAfE/UhwsN/ldoFMASQY4zURrq3IcHi7hxOPncSFFewD6Tf4fNLw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/mp4-muxer/-/mp4-muxer-5.2.1.tgz",
+      "integrity": "sha512-O9eNqyzUivPJvNinPzBtEnPo7epPeYrryiCB+/+3/ktIXgTIeIB7o8tC+5i+8Zi3JthKGDws9jx7ceIY3PKhXw==",
       "dependencies": {
         "@types/dom-webcodecs": "^0.1.6",
         "@types/wicg-file-system-access": "^2020.9.5"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "fuse.js": "^7.0.0",
     "hyparquet": "^1.0.0",
     "hyparquet-compressors": "^0.1.4",
-    "mp4-muxer": "^2.2.2",
+    "mp4-muxer": "^5.2.1",
     "papaparse": "^5.4.1",
     "plotly.js-dist-min": "^2.27.0",
     "react": "^18.2.0",

--- a/src/Viewer.module.css
+++ b/src/Viewer.module.css
@@ -28,6 +28,7 @@
   border-radius: 5px 5px 0 0;
   flex-basis: var(--canvas-width-basis);
   flex-grow: 1;
+  overflow: hidden;
 }
 
 .canvasControlsContainer {

--- a/src/Viewer.module.css
+++ b/src/Viewer.module.css
@@ -68,7 +68,7 @@
 }
 
 .colorizeCanvas {
-  /* max-width: 100%; */
+  overflow: hidden;
 }
 
 .canvasPanel .timeControls {

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -495,7 +495,6 @@ export default class CanvasOverlay implements IRenderCanvas {
     this.headerSize = headerRenderer.sizePx;
     this.footerSize = footerRenderer.sizePx;
 
-    // TODO: Do we need devicePixelRatio here?
     const devicePixelRatio = getPixelRatio();
     const canvasWidth = toEven(Math.round(this.innerCanvasSize.x * devicePixelRatio));
     const canvasHeight = toEven(

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -24,7 +24,7 @@ import {
   getAnnotationRenderer,
 } from "./canvas/elements/annotations";
 import { BaseRenderParams, RenderInfo } from "./canvas/types";
-import { getPixelRatio } from "./canvas/utils";
+import { getPixelRatio, toEven } from "./canvas/utils";
 import { CanvasScaleInfo, CanvasType, FrameLoadResult, PixelIdInfo } from "./types";
 import { hasPropertyChanged } from "./utils/data_utils";
 
@@ -202,9 +202,11 @@ export default class CanvasOverlay implements IRenderCanvas {
   }
 
   public setResolution(width: number, height: number): void {
-    this.innerCanvasSize.x = width;
-    this.innerCanvasSize.y = height;
-    this.innerCanvas.setResolution(width, height);
+    // Enforce even resolution because some video codecs only support even
+    // dimensions.
+    this.innerCanvasSize.x = toEven(width);
+    this.innerCanvasSize.y = toEven(height);
+    this.innerCanvas.setResolution(this.innerCanvasSize.x, this.innerCanvasSize.y);
     this.render();
   }
 
@@ -440,8 +442,8 @@ export default class CanvasOverlay implements IRenderCanvas {
 
     // Update canvas resolution + size.
     const devicePixelRatio = getPixelRatio();
-    const baseCanvasWidthPx = this.innerCanvasSize.x;
-    const baseCanvasHeightPx = this.innerCanvasSize.y + this.headerSize.y + this.footerSize.y;
+    const baseCanvasWidthPx = toEven(this.innerCanvasSize.x);
+    const baseCanvasHeightPx = toEven(this.innerCanvasSize.y + this.headerSize.y + this.footerSize.y);
 
     // We use devicePixelRatio to scale the canvas with browser zoom / high-DPI
     // displays so text + graphics are sharp.
@@ -493,10 +495,11 @@ export default class CanvasOverlay implements IRenderCanvas {
     this.headerSize = headerRenderer.sizePx;
     this.footerSize = footerRenderer.sizePx;
 
+    // TODO: Do we need devicePixelRatio here?
     const devicePixelRatio = getPixelRatio();
-    const canvasWidth = Math.round(this.innerCanvasSize.x * devicePixelRatio);
-    const canvasHeight = Math.round(
-      (this.innerCanvasSize.y + this.headerSize.y + this.footerSize.y) * devicePixelRatio
+    const canvasWidth = toEven(Math.round(this.innerCanvasSize.x * devicePixelRatio));
+    const canvasHeight = toEven(
+      Math.round((this.innerCanvasSize.y + this.headerSize.y + this.footerSize.y) * devicePixelRatio)
     );
     return [canvasWidth, canvasHeight];
   }

--- a/src/colorizer/canvas/elements/footer.ts
+++ b/src/colorizer/canvas/elements/footer.ts
@@ -80,7 +80,10 @@ export function getFooterRenderer(ctx: CanvasRenderingContext2D, params: FooterP
   if (maxContentHeight === 0) {
     return EMPTY_RENDER_INFO;
   }
-  const height = Math.round(maxContentHeight + style.paddingPx.y * 2);
+
+  // Fudge height by a few pixels in case of misalignment of footer bottom and
+  // canvas bottom edges.
+  const height = Math.round(maxContentHeight + style.paddingPx.y * 2) + 2;
   const width = Math.round(params.canvasSize.x + 1);
 
   return {

--- a/src/colorizer/canvas/utils.ts
+++ b/src/colorizer/canvas/utils.ts
@@ -125,3 +125,8 @@ export function get2DCanvasScaling(
     frameToCanvasCoordinates,
   };
 }
+
+/** Rounds a number to the nearest even integer. */
+export function toEven(value: number): number {
+  return Math.round(value / 2) * 2;
+}

--- a/src/colorizer/recorders/Mp4VideoRecorder.ts
+++ b/src/colorizer/recorders/Mp4VideoRecorder.ts
@@ -83,6 +83,7 @@ export default class Mp4VideoRecorder extends CanvasRecorder {
               width: width,
               height: height,
             },
+            fastStart: "in-memory",
           });
           return;
         }


### PR DESCRIPTION
Problem
=======
Closes #701, "Downloaded MP4 video could not be played in Quicktime."

This change enforces even numbered sizing on the viewport canvas, which allows the AVC1 codec to be chosen more consistently by browsers. AVC1 is generally more widely supported by desktop viewers than VP9 and AV1.

*Estimated review size: tiny, 10 minutes*

Solution
========
- Updated `mp4-muxer` dependency.
- Changed the canvas to always choose the nearest even pixel dimensions.
- Edited some CSS to handle cases where the viewport is wider than its base container.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
Please do this on Chrome/Safari and not on Firefox, as there's a different bug: #719

1. Open the preview link here:  https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview-internal/pr-717/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small
3. Go to **Export**, then export an MP4 video of any length.
4. Open the downloaded MP4 video with your desktop viewer.