### PR TITLE
refactor: Update Ant Design to `v5.26.4`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.5.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@types/papaparse": "^5.3.15",
-        "antd": "^5.9.4",
+        "antd": "^5.26.4",
         "chroma-js": "^3.1.1",
         "d3": "^7.9.0",
         "fuse.js": "^7.0.0",
@@ -100,39 +100,64 @@
       }
     },
     "node_modules/@ant-design/colors": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.0.0.tgz",
-      "integrity": "sha512-iVm/9PfGCbC0dSMBrz7oiEXZaaGH7ceU40OJEfKmyuzR9R5CRimJYPlRiFtMQGQcbNMea/ePcoIebi4ASGYXtg==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.2.1.tgz",
+      "integrity": "sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ==",
       "dependencies": {
-        "@ctrl/tinycolor": "^3.4.0"
+        "@ant-design/fast-color": "^2.0.6"
       }
     },
     "node_modules/@ant-design/cssinjs": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.17.2.tgz",
-      "integrity": "sha512-vu7lnfEx4Mf8MPzZxn506Zen3Nt4fRr2uutwvdCuTCN5IiU0lDdQ0tiJ24/rmB8+pefwjluYsbyzbQSbgfJy+A==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.23.0.tgz",
+      "integrity": "sha512-7GAg9bD/iC9ikWatU9ym+P9ugJhi/WbsTWzcKN6T4gU0aehsprtke1UAaaSxxkjjmkJb3llet/rbUSLPgwlY4w==",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@emotion/hash": "^0.8.0",
         "@emotion/unitless": "^0.7.5",
         "classnames": "^2.3.1",
-        "csstype": "^3.0.10",
+        "csstype": "^3.1.3",
         "rc-util": "^5.35.0",
-        "stylis": "^4.0.13"
+        "stylis": "^4.3.4"
       },
       "peerDependencies": {
         "react": ">=16.0.0",
         "react-dom": ">=16.0.0"
       }
     },
+    "node_modules/@ant-design/cssinjs-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-1.1.3.tgz",
+      "integrity": "sha512-nOoQMLW1l+xR1Co8NFVYiP8pZp3VjIIzqV6D6ShYF2ljtdwWJn5WSsH+7kvCktXL/yhEtWURKOfH5Xz/gzlwsg==",
+      "dependencies": {
+        "@ant-design/cssinjs": "^1.21.0",
+        "@babel/runtime": "^7.23.2",
+        "rc-util": "^5.38.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@ant-design/fast-color": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-2.0.6.tgz",
+      "integrity": "sha512-y2217gk4NqL35giHl72o6Zzqji9O7vHh9YmhUVkPtAOpoTCH4uWxo/pr4VE8t0+ChEPs0qo4eJRC5Q1eXWo3vA==",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=8.x"
+      }
+    },
     "node_modules/@ant-design/icons": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.2.6.tgz",
-      "integrity": "sha512-4wn0WShF43TrggskBJPRqCD0fcHbzTYjnaoskdiJrVHg86yxoZ8ZUqsXvyn4WUqehRiFKnaclOhqk9w4Ui2KVw==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.6.1.tgz",
+      "integrity": "sha512-0/xS39c91WjPAZOWsvi1//zjx6kAp4kxWwctR6kuU6p133w8RU0D2dSCvZC19uQyharg/sAvYxGYWl01BbZZfg==",
       "dependencies": {
         "@ant-design/colors": "^7.0.0",
-        "@ant-design/icons-svg": "^4.3.0",
-        "@babel/runtime": "^7.11.2",
+        "@ant-design/icons-svg": "^4.4.0",
+        "@babel/runtime": "^7.24.8",
         "classnames": "^2.2.6",
         "rc-util": "^5.31.1"
       },
@@ -145,14 +170,14 @@
       }
     },
     "node_modules/@ant-design/icons-svg": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.3.1.tgz",
-      "integrity": "sha512-4QBZg8ccyC6LPIRii7A0bZUk3+lEDCLnhB+FVsflGdcWPPmV+j3fire4AwwoqHV/BibgvBmR9ZIo4s867smv+g=="
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz",
+      "integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA=="
     },
     "node_modules/@ant-design/react-slick": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-1.0.2.tgz",
-      "integrity": "sha512-Wj8onxL/T8KQLFFiCA4t8eIRGpRR+UPgOdac2sYzonv+i0n3kXHmvHLLiOYL655DQx2Umii9Y9nNgL7ssu5haQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-1.1.2.tgz",
+      "integrity": "sha512-EzlvzE6xQUBrZuuhSAFTdsr4P2bBBHGZwKFemEfq8gIGyIQCxalYfZW/T2ORbtQx5rU69o+WycP3exY/7T1hGA==",
       "dependencies": {
         "@babel/runtime": "^7.10.4",
         "classnames": "^2.2.5",
@@ -2145,14 +2170,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@ctrl/tinycolor": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
-      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz",
@@ -3128,15 +3145,26 @@
         "node": ">=18"
       }
     },
-    "node_modules/@rc-component/color-picker": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-1.4.1.tgz",
-      "integrity": "sha512-vh5EWqnsayZa/JwUznqDaPJz39jznx/YDbyBuVJntv735tKXKwEUZZb2jYEldOg+NKWZwtALjGMrNeGBmqFoEw==",
+    "node_modules/@rc-component/async-validator": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.0.4.tgz",
+      "integrity": "sha512-qgGdcVIF604M9EqjNF0hbUTz42bz/RDtxWdWuU5EQe3hi7M8ob54B6B35rOsvX5eSvIHIzT9iH1R3n+hk3CGfg==",
       "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "@ctrl/tinycolor": "^3.6.0",
+        "@babel/runtime": "^7.24.4"
+      },
+      "engines": {
+        "node": ">=14.x"
+      }
+    },
+    "node_modules/@rc-component/color-picker": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-2.0.1.tgz",
+      "integrity": "sha512-WcZYwAThV/b2GISQ8F+7650r5ZZJ043E57aVBFkQ+kSY4C6wdofXgB0hBx+GPGpIU0Z81eETNoDUJMr7oy/P8Q==",
+      "dependencies": {
+        "@ant-design/fast-color": "^2.0.6",
+        "@babel/runtime": "^7.23.6",
         "classnames": "^2.2.6",
-        "rc-util": "^5.30.0"
+        "rc-util": "^5.38.1"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -3201,14 +3229,31 @@
         "react-dom": ">=16.9.0"
       }
     },
+    "node_modules/@rc-component/qrcode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/qrcode/-/qrcode-1.0.0.tgz",
+      "integrity": "sha512-L+rZ4HXP2sJ1gHMGHjsg9jlYBX/SLN2D6OxP9Zn3qgtpMWtO2vUfxVFwiogHpAIqs54FnALxraUy/BCO1yRIgg==",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.38.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
     "node_modules/@rc-component/tour": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-1.10.0.tgz",
-      "integrity": "sha512-voV0BKaTJbewB9LLgAHQ7tAGG7rgDkKQkZo82xw2gIk542hY+o7zwoqdN16oHhIKk7eG/xi+mdXrONT62Dt57A==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-1.15.1.tgz",
+      "integrity": "sha512-Tr2t7J1DKZUpfJuDZWHxyxWpfmj8EZrqSgyMZ+BCdvKZ6r1UDsfU46M/iWAAFBy961Ssfom2kv5f3UcjIL2CmQ==",
       "dependencies": {
         "@babel/runtime": "^7.18.0",
         "@rc-component/portal": "^1.0.0-9",
-        "@rc-component/trigger": "^1.3.6",
+        "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.3.2",
         "rc-util": "^5.24.4"
       },
@@ -3221,16 +3266,16 @@
       }
     },
     "node_modules/@rc-component/trigger": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-1.17.2.tgz",
-      "integrity": "sha512-Jp3dXk/IzwHKM2Tn3ezdvQSwkPeH4v1s7QjIo7f5NFLIZVpJQ8a34FduZw8E6fT1PVgLXYd/JBIyd+YpgyQddA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.2.7.tgz",
+      "integrity": "sha512-Qggj4Z0AA2i5dJhzlfFSmg1Qrziu8dsdHOihROL5Kl18seO2Eh/ZaTYt2c8a/CyGaTChnFry7BEYew1+/fhSbA==",
       "dependencies": {
         "@babel/runtime": "^7.23.2",
         "@rc-component/portal": "^1.1.0",
         "classnames": "^2.3.2",
         "rc-motion": "^2.0.0",
         "rc-resize-observer": "^1.3.1",
-        "rc-util": "^5.38.0"
+        "rc-util": "^5.44.0"
       },
       "engines": {
         "node": ">=8.x"
@@ -5259,58 +5304,59 @@
       }
     },
     "node_modules/antd": {
-      "version": "5.9.4",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-5.9.4.tgz",
-      "integrity": "sha512-eyNn1C/Q9ESn4ktfTlRIIXBbWT5L/Rr38xP37dIvJ3FeD/a4vaVcMqqLz5ywwMPKxgWnuUxggo1mJwWdPoIdSg==",
+      "version": "5.26.4",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.26.4.tgz",
+      "integrity": "sha512-e1EnOvEkvvqcQ18dxfzChBJyJACyih13WpNf2OtnP9z2POh/SF0fXL+ynUemT1zfr+p+P1po/tmHXaMc5PMghg==",
       "dependencies": {
-        "@ant-design/colors": "^7.0.0",
-        "@ant-design/cssinjs": "^1.16.0",
-        "@ant-design/icons": "^5.2.2",
-        "@ant-design/react-slick": "~1.0.0",
-        "@babel/runtime": "^7.18.3",
-        "@ctrl/tinycolor": "^3.6.0",
-        "@rc-component/color-picker": "~1.4.1",
+        "@ant-design/colors": "^7.2.1",
+        "@ant-design/cssinjs": "^1.23.0",
+        "@ant-design/cssinjs-utils": "^1.1.3",
+        "@ant-design/fast-color": "^2.0.6",
+        "@ant-design/icons": "^5.6.1",
+        "@ant-design/react-slick": "~1.1.2",
+        "@babel/runtime": "^7.26.0",
+        "@rc-component/color-picker": "~2.0.1",
         "@rc-component/mutate-observer": "^1.1.0",
-        "@rc-component/tour": "~1.10.0",
-        "@rc-component/trigger": "^1.16.0",
-        "classnames": "^2.2.6",
-        "copy-to-clipboard": "^3.2.0",
-        "dayjs": "^1.11.1",
-        "qrcode.react": "^3.1.0",
-        "rc-cascader": "~3.17.0",
-        "rc-checkbox": "~3.1.0",
-        "rc-collapse": "~3.7.1",
-        "rc-dialog": "~9.2.0",
-        "rc-drawer": "~6.4.1",
-        "rc-dropdown": "~4.1.0",
-        "rc-field-form": "~1.38.1",
-        "rc-image": "~7.2.0",
-        "rc-input": "~1.2.1",
-        "rc-input-number": "~8.1.0",
-        "rc-mentions": "~2.8.0",
-        "rc-menu": "~9.12.0",
-        "rc-motion": "^2.9.0",
-        "rc-notification": "~5.1.1",
-        "rc-pagination": "~3.6.1",
-        "rc-picker": "~3.14.1",
-        "rc-progress": "~3.5.1",
-        "rc-rate": "~2.12.0",
-        "rc-resize-observer": "^1.3.1",
-        "rc-segmented": "~2.2.2",
-        "rc-select": "~14.9.0",
-        "rc-slider": "~10.2.1",
+        "@rc-component/qrcode": "~1.0.0",
+        "@rc-component/tour": "~1.15.1",
+        "@rc-component/trigger": "^2.2.7",
+        "classnames": "^2.5.1",
+        "copy-to-clipboard": "^3.3.3",
+        "dayjs": "^1.11.11",
+        "rc-cascader": "~3.34.0",
+        "rc-checkbox": "~3.5.0",
+        "rc-collapse": "~3.9.0",
+        "rc-dialog": "~9.6.0",
+        "rc-drawer": "~7.3.0",
+        "rc-dropdown": "~4.2.1",
+        "rc-field-form": "~2.7.0",
+        "rc-image": "~7.12.0",
+        "rc-input": "~1.8.0",
+        "rc-input-number": "~9.5.0",
+        "rc-mentions": "~2.20.0",
+        "rc-menu": "~9.16.1",
+        "rc-motion": "^2.9.5",
+        "rc-notification": "~5.6.4",
+        "rc-pagination": "~5.1.0",
+        "rc-picker": "~4.11.3",
+        "rc-progress": "~4.0.0",
+        "rc-rate": "~2.13.1",
+        "rc-resize-observer": "^1.4.3",
+        "rc-segmented": "~2.7.0",
+        "rc-select": "~14.16.8",
+        "rc-slider": "~11.1.8",
         "rc-steps": "~6.0.1",
         "rc-switch": "~4.1.0",
-        "rc-table": "~7.34.4",
-        "rc-tabs": "~12.12.1",
-        "rc-textarea": "~1.4.0",
-        "rc-tooltip": "~6.0.1",
-        "rc-tree": "~5.7.12",
-        "rc-tree-select": "~5.13.0",
-        "rc-upload": "~4.3.4",
-        "rc-util": "^5.37.0",
-        "scroll-into-view-if-needed": "^3.0.3",
-        "throttle-debounce": "^5.0.0"
+        "rc-table": "~7.51.1",
+        "rc-tabs": "~15.6.1",
+        "rc-textarea": "~1.10.0",
+        "rc-tooltip": "~6.4.0",
+        "rc-tree": "~5.13.1",
+        "rc-tree-select": "~5.27.0",
+        "rc-upload": "~4.9.2",
+        "rc-util": "^5.44.4",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "throttle-debounce": "^5.0.2"
       },
       "funding": {
         "type": "opencollective",
@@ -5471,11 +5517,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array-tree-filter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-tree-filter/-/array-tree-filter-2.1.0.tgz",
-      "integrity": "sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw=="
-    },
     "node_modules/array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -5603,11 +5644,6 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
       "dev": true
-    },
-    "node_modules/async-validator": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.2.5.tgz",
-      "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg=="
     },
     "node_modules/asynciterator.prototype": {
       "version": "1.0.0",
@@ -6212,9 +6248,9 @@
       "license": "(BSD-3-Clause AND Apache-2.0)"
     },
     "node_modules/classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -6293,9 +6329,9 @@
       }
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.0.3.tgz",
-      "integrity": "sha512-nadqwNxghAGTamwIqQSG433W6OADZx2vCo3UXHNrzTRHK/htu+7+L0zhjEoaeaQVNAi3YgqWDv8+tzf0hRfR+A=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -6531,9 +6567,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/d3": {
       "version": "7.9.0",
@@ -6971,9 +7007,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -11625,14 +11661,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/qrcode.react": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.1.0.tgz",
-      "integrity": "sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/query-selector-shadow-dom": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
@@ -11679,16 +11707,15 @@
       }
     },
     "node_modules/rc-cascader": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.17.0.tgz",
-      "integrity": "sha512-8O5Eq/NteRuBaaUIb+ZsTEkNKM3BwWKizsFlSpukCVa2ELqrdMyslbe/OdxtuFlyJIqGyWF5rS2Q+fd0Rpvmgw==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.34.0.tgz",
+      "integrity": "sha512-KpXypcvju9ptjW9FaN2NFcA2QH9E9LHKq169Y0eWtH4e/wHQ5Wh5qZakAgvb8EKZ736WZ3B0zLLOBsrsja5Dag==",
       "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "array-tree-filter": "^2.1.0",
+        "@babel/runtime": "^7.25.7",
         "classnames": "^2.3.1",
-        "rc-select": "~14.9.0",
-        "rc-tree": "~5.7.0",
-        "rc-util": "^5.35.0"
+        "rc-select": "~14.16.2",
+        "rc-tree": "~5.13.0",
+        "rc-util": "^5.43.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -11696,9 +11723,9 @@
       }
     },
     "node_modules/rc-checkbox": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-3.1.0.tgz",
-      "integrity": "sha512-PAwpJFnBa3Ei+5pyqMMXdcKYKNBMS+TvSDiLdDnARnMJHC8ESxwPfm4Ao1gJiKtWLdmGfigascnCpwrHFgoOBQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-3.5.0.tgz",
+      "integrity": "sha512-aOAQc3E98HteIIsSqm6Xk2FPKIER6+5vyEFMZfo73TqM+VVAIqOkHoPjgKLqSNtVLWScoaM7vY2ZrGEheI79yg==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.3.2",
@@ -11710,9 +11737,9 @@
       }
     },
     "node_modules/rc-collapse": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.7.1.tgz",
-      "integrity": "sha512-N/7ejyiTf3XElNJBBpxqnZBUuMsQWEOPjB2QkfNvZ/Ca54eAvJXuOD1EGbCWCk2m7v/MSxku7mRpdeaLOCd4Gg==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.9.0.tgz",
+      "integrity": "sha512-swDdz4QZ4dFTo4RAUMLL50qP0EY62N2kvmk2We5xYdRwcRn8WcYtuetCJpwpaCbUfUt5+huLpVxhvmnK+PHrkA==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -11725,9 +11752,9 @@
       }
     },
     "node_modules/rc-dialog": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.2.0.tgz",
-      "integrity": "sha512-dL2tklMou/QfK77+0CTH3FTnKCvIiYv9Df7PfFfg8YVXhYAGmuIkV4ooQYHAIR4juL3Ywcm5oQflF2vDDuGlUg==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.6.0.tgz",
+      "integrity": "sha512-ApoVi9Z8PaCQg6FsUzS8yvBEQy0ZL2PkuvAgrmohPkN3okps5WZ5WQWPc1RNuiOKaAYv8B97ACdsFU5LizzCqg==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/portal": "^1.0.0-8",
@@ -11741,15 +11768,15 @@
       }
     },
     "node_modules/rc-drawer": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-6.4.1.tgz",
-      "integrity": "sha512-QIbNMjiZy322o9uEpJHsSZ5rS/zuxqam3lYVPDzjztoqsoDzTNNxWN77QVpOfQ0UC9/87+qu25zocJ+O9bK2Tg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-7.3.0.tgz",
+      "integrity": "sha512-DX6CIgiBWNpJIMGFO8BAISFkxiuKitoizooj4BDyee8/SnBn0zwO2FHrNDpqqepj0E/TFTDpmEBCyFuTgC7MOg==",
       "dependencies": {
-        "@babel/runtime": "^7.10.1",
+        "@babel/runtime": "^7.23.9",
         "@rc-component/portal": "^1.1.1",
         "classnames": "^2.2.6",
         "rc-motion": "^2.6.1",
-        "rc-util": "^5.36.0"
+        "rc-util": "^5.38.1"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -11757,14 +11784,14 @@
       }
     },
     "node_modules/rc-dropdown": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.1.0.tgz",
-      "integrity": "sha512-VZjMunpBdlVzYpEdJSaV7WM7O0jf8uyDjirxXLZRNZ+tAC+NzD3PXPEtliFwGzVwBBdCmGuSqiS9DWcOLxQ9tw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.2.1.tgz",
+      "integrity": "sha512-YDAlXsPv3I1n42dv1JpdM7wJ+gSUBfeyPK59ZpBD9jQhK9jVuxpjj3NmWQHOBceA1zEPVX84T2wbdb2SD0UjmA==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
-        "@rc-component/trigger": "^1.7.0",
+        "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.2.6",
-        "rc-util": "^5.17.0"
+        "rc-util": "^5.44.1"
       },
       "peerDependencies": {
         "react": ">=16.11.0",
@@ -11772,12 +11799,12 @@
       }
     },
     "node_modules/rc-field-form": {
-      "version": "1.38.2",
-      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.38.2.tgz",
-      "integrity": "sha512-O83Oi1qPyEv31Sg+Jwvsj6pXc8uQI2BtIAkURr5lvEYHVggXJhdU/nynK8wY1gbw0qR48k731sN5ON4egRCROA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-2.7.0.tgz",
+      "integrity": "sha512-hgKsCay2taxzVnBPZl+1n4ZondsV78G++XVsMIJCAoioMjlMQR9YwAp7JZDIECzIu2Z66R+f4SFIRrO2DjDNAA==",
       "dependencies": {
         "@babel/runtime": "^7.18.0",
-        "async-validator": "^4.1.0",
+        "@rc-component/async-validator": "^5.0.3",
         "rc-util": "^5.32.2"
       },
       "engines": {
@@ -11789,14 +11816,14 @@
       }
     },
     "node_modules/rc-image": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.2.0.tgz",
-      "integrity": "sha512-5Ug2hCVl6VcT0osR5XaZQ4zclTMEWPnbn3b4/TS/MR1QjRpEACLNFUzBGwr5mbAVhzvLWX5YZf4vO10xUA5IUA==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.12.0.tgz",
+      "integrity": "sha512-cZ3HTyyckPnNnUb9/DRqduqzLfrQRyi+CdHjdqgsyDpI3Ln5UX1kXnAhPBSJj9pVRzwRFgqkN7p9b6HBDjmu/Q==",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "@rc-component/portal": "^1.0.2",
         "classnames": "^2.2.6",
-        "rc-dialog": "~9.2.0",
+        "rc-dialog": "~9.6.0",
         "rc-motion": "^2.6.2",
         "rc-util": "^5.34.1"
       },
@@ -11806,9 +11833,9 @@
       }
     },
     "node_modules/rc-input": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.2.1.tgz",
-      "integrity": "sha512-nQRmBvEFoGi+SNRDavccZ8ueyhFgmxkWqIt4aDyuNJgUZF12HJKIwDhAafUM7N+g7PyuW9FH3pf3zPHzdiCWbA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.8.0.tgz",
+      "integrity": "sha512-KXvaTbX+7ha8a/k+eg6SYRVERK0NddX8QX7a7AnRvUa/rEH0CNMlpcBzBkhI0wp2C8C4HlMoYl8TImSN+fuHKA==",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -11820,15 +11847,15 @@
       }
     },
     "node_modules/rc-input-number": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-8.1.0.tgz",
-      "integrity": "sha512-bdHgduOxuN0lrhzgPmoKbhRD4GLIzVcddVz972/JHPHr7oLwPX5xDb9w4bXhuMzyT2VzQy7nggRCfH3yAl09oA==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-9.5.0.tgz",
+      "integrity": "sha512-bKaEvB5tHebUURAEXw35LDcnRZLq3x1k7GxfAqBMzmpHkDGzjAtnUL8y4y5N15rIFIg5IJgwr211jInl3cipag==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/mini-decimal": "^1.0.1",
         "classnames": "^2.2.5",
-        "rc-input": "~1.2.1",
-        "rc-util": "^5.28.0"
+        "rc-input": "~1.8.0",
+        "rc-util": "^5.40.1"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -11836,16 +11863,16 @@
       }
     },
     "node_modules/rc-mentions": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.8.0.tgz",
-      "integrity": "sha512-LBMkO6bSGhEvS1CvMK978qGN82tI+mzk7l/uTiQJH+UDiwpvq+pxK4DxU5b6Q1T5LW6bn2pSua9RaZKZrDoBOw==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.20.0.tgz",
+      "integrity": "sha512-w8HCMZEh3f0nR8ZEd466ATqmXFCMGMN5UFCzEUL0bM/nGw/wOS2GgRzKBcm19K++jDyuWCOJOdgcKGXU3fXfbQ==",
       "dependencies": {
         "@babel/runtime": "^7.22.5",
-        "@rc-component/trigger": "^1.5.0",
+        "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.2.6",
-        "rc-input": "~1.2.1",
-        "rc-menu": "~9.12.0",
-        "rc-textarea": "~1.4.0",
+        "rc-input": "~1.8.0",
+        "rc-menu": "~9.16.0",
+        "rc-textarea": "~1.10.0",
         "rc-util": "^5.34.1"
       },
       "peerDependencies": {
@@ -11854,12 +11881,12 @@
       }
     },
     "node_modules/rc-menu": {
-      "version": "9.12.2",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.12.2.tgz",
-      "integrity": "sha512-NzloFH2pRUYmQ3S/YbJAvRkgCZaLvq0sRa5rgJtuIHLfPPprNHNyepeSlT64+dbVqI4qRWL44VN0lUCldCbbfg==",
+      "version": "9.16.1",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.16.1.tgz",
+      "integrity": "sha512-ghHx6/6Dvp+fw8CJhDUHFHDJ84hJE3BXNCzSgLdmNiFErWSOaZNsihDAsKq9ByTALo/xkNIwtDFGIl6r+RPXBg==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
-        "@rc-component/trigger": "^1.17.0",
+        "@rc-component/trigger": "^2.0.0",
         "classnames": "2.x",
         "rc-motion": "^2.4.3",
         "rc-overflow": "^1.3.1",
@@ -11871,13 +11898,13 @@
       }
     },
     "node_modules/rc-motion": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.0.tgz",
-      "integrity": "sha512-XIU2+xLkdIr1/h6ohPZXyPBMvOmuyFZQ/T0xnawz+Rh+gh4FINcnZmMT5UTIj6hgI0VLDjTaPeRd+smJeSPqiQ==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.5.tgz",
+      "integrity": "sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
-        "rc-util": "^5.21.0"
+        "rc-util": "^5.44.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -11885,13 +11912,13 @@
       }
     },
     "node_modules/rc-notification": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.1.1.tgz",
-      "integrity": "sha512-BPnded/WmWFE57ubqhVCgRSuedfQQNeSOYqdwppyr2B/Wt909gYFKyWAkFJVXuppAjsOGop05a93UaxjmUFdkg==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.6.4.tgz",
+      "integrity": "sha512-KcS4O6B4qzM3KH7lkwOB7ooLPZ4b6J+VMmQgT51VZCeEcmghdeR4IrMcFq0LG+RPdnbe/ArT086tGM8Snimgiw==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
-        "rc-motion": "^2.6.0",
+        "rc-motion": "^2.9.0",
         "rc-util": "^5.20.1"
       },
       "engines": {
@@ -11903,9 +11930,9 @@
       }
     },
     "node_modules/rc-overflow": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.3.2.tgz",
-      "integrity": "sha512-nsUm78jkYAoPygDAcGZeC2VwIg/IBGSodtOY3pMof4W3M9qRJgqaDYm03ZayHlde3I6ipliAxbN0RUcGf5KOzw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.4.1.tgz",
+      "integrity": "sha512-3MoPQQPV1uKyOMVNd6SZfONi+f3st0r8PksexIdBTeIYbMX0Jr+k7pHEDvsXtR4BpCv90/Pv2MovVNhktKrwvw==",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -11918,13 +11945,13 @@
       }
     },
     "node_modules/rc-pagination": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-3.6.1.tgz",
-      "integrity": "sha512-R/sUnKKXx1Nm4kZfUKS3YKa7yEPF1ZkVB/AynQaHt+nMER7h9wPTfliDJFdYo+RM/nk2JD4Yc5QpUq8fIQHeug==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-5.1.0.tgz",
+      "integrity": "sha512-8416Yip/+eclTFdHXLKTxZvn70duYVGTvUUWbckCCZoIl3jagqke3GLsFrMs0bsQBikiYpZLD9206Ej4SOdOXQ==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.32.2"
+        "classnames": "^2.3.2",
+        "rc-util": "^5.38.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -11932,14 +11959,16 @@
       }
     },
     "node_modules/rc-picker": {
-      "version": "3.14.5",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-3.14.5.tgz",
-      "integrity": "sha512-h0O8b5AYfWwHSRUUH/9F2oBXB5gZerHIyGG6z2r5rn/kfSQodyCXEO4GNqrG30iUC1qkvLFIOn/JqI4XaO0+2A==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.11.3.tgz",
+      "integrity": "sha512-MJ5teb7FlNE0NFHTncxXQ62Y5lytq6sh5nUw0iH8OkHL/TjARSEvSHpr940pWgjGANpjCwyMdvsEV55l5tYNSg==",
       "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "@rc-component/trigger": "^1.5.0",
+        "@babel/runtime": "^7.24.7",
+        "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.2.1",
-        "rc-util": "^5.30.0"
+        "rc-overflow": "^1.3.2",
+        "rc-resize-observer": "^1.4.0",
+        "rc-util": "^5.43.0"
       },
       "engines": {
         "node": ">=8.x"
@@ -11968,9 +11997,9 @@
       }
     },
     "node_modules/rc-progress": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-3.5.1.tgz",
-      "integrity": "sha512-V6Amx6SbLRwPin/oD+k1vbPrO8+9Qf8zW1T8A7o83HdNafEVvAxPV5YsgtKFP+Ud5HghLj33zKOcEHrcrUGkfw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-4.0.0.tgz",
+      "integrity": "sha512-oofVMMafOCokIUIBnZLNcOZFsABaUw8PPrf1/y0ZBvKZNpOiu5h4AO9vv11Sw0p4Hb3D0yGWuEattcQGtNJ/aw==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.6",
@@ -11982,9 +12011,9 @@
       }
     },
     "node_modules/rc-rate": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.12.0.tgz",
-      "integrity": "sha512-g092v5iZCdVzbjdn28FzvWebK2IutoVoiTeqoLTj9WM7SjA/gOJIw5/JFZMRyJYYVe1jLAU2UhAfstIpCNRozg==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.13.1.tgz",
+      "integrity": "sha512-QUhQ9ivQ8Gy7mtMZPAjLbxBt5y9GRp65VcUyGUMF3N3fhiftivPHdpuDIaWIMOTEprAjZPC08bls1dQB+I1F2Q==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
@@ -11999,13 +12028,13 @@
       }
     },
     "node_modules/rc-resize-observer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.4.0.tgz",
-      "integrity": "sha512-PnMVyRid9JLxFavTjeDXEXo65HCRqbmLBw9xX9gfC4BZiSzbLXKzW3jPz+J0P71pLbD5tBMTT+mkstV5gD0c9Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.4.3.tgz",
+      "integrity": "sha512-YZLjUbyIWox8E9i9C3Tm7ia+W7euPItNWSPX5sCcQTYbnwDb5uNpnLHQCG1f22oZWUhLw4Mv2tFmeWe68CDQRQ==",
       "dependencies": {
         "@babel/runtime": "^7.20.7",
         "classnames": "^2.2.1",
-        "rc-util": "^5.38.0",
+        "rc-util": "^5.44.1",
         "resize-observer-polyfill": "^1.5.1"
       },
       "peerDependencies": {
@@ -12014,9 +12043,9 @@
       }
     },
     "node_modules/rc-segmented": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.2.2.tgz",
-      "integrity": "sha512-Mq52M96QdHMsNdE/042ibT5vkcGcD5jxKp7HgPC2SRofpia99P5fkfHy1pEaajLMF/kj0+2Lkq1UZRvqzo9mSA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.7.0.tgz",
+      "integrity": "sha512-liijAjXz+KnTRVnxxXG2sYDGd6iLL7VpGGdR8gwoxAXy2KglviKCxLWZdjKYJzYzGSUwKDSTdYk8brj54Bn5BA==",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -12029,12 +12058,12 @@
       }
     },
     "node_modules/rc-select": {
-      "version": "14.9.2",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.9.2.tgz",
-      "integrity": "sha512-VQ15sRFgPURHb8ZcZNSDtb2rAw3+C9xlL0nDziwNHTEW1KvEpZ8y+0v5w24X/Bpl9b3cW1BOyW1F5UqSAq+7Dg==",
+      "version": "14.16.8",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.16.8.tgz",
+      "integrity": "sha512-NOV5BZa1wZrsdkKaiK7LHRuo5ZjZYMDxPP6/1+09+FB4KoNi8jcG1ZqLE3AVCxEsYMBe65OBx71wFoHRTP3LRg==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
-        "@rc-component/trigger": "^1.5.0",
+        "@rc-component/trigger": "^2.1.1",
         "classnames": "2.x",
         "rc-motion": "^2.0.1",
         "rc-overflow": "^1.3.1",
@@ -12050,13 +12079,13 @@
       }
     },
     "node_modules/rc-slider": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-10.2.1.tgz",
-      "integrity": "sha512-l355C/65iV4UFp7mXq5xBTNX2/tF2g74VWiTVlTpNp+6vjE/xaHHNiQq5Af+Uu28uUiqCuH/QXs5HfADL9KJ/A==",
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.8.tgz",
+      "integrity": "sha512-2gg/72YFSpKP+Ja5AjC5DPL1YnV8DEITDQrcc1eASrUYjl0esptaBVJBh5nLTXCCp15eD8EuGjwezVGSHhs9tQ==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
-        "rc-util": "^5.27.0"
+        "rc-util": "^5.36.0"
       },
       "engines": {
         "node": ">=8.x"
@@ -12098,16 +12127,16 @@
       }
     },
     "node_modules/rc-table": {
-      "version": "7.34.4",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.34.4.tgz",
-      "integrity": "sha512-os+i88Y2AO/6dNkOgJkKSHgXYaZZGnuOEEe+nyaq5IRgvAQNhLysUjXt2objtBeFDEZR8TqXrajwBNRUwunmdw==",
+      "version": "7.51.1",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.51.1.tgz",
+      "integrity": "sha512-5iq15mTHhvC42TlBLRCoCBLoCmGlbRZAlyF21FonFnS/DIC8DeRqnmdyVREwt2CFbPceM0zSNdEeVfiGaqYsKw==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/context": "^1.4.0",
         "classnames": "^2.2.5",
         "rc-resize-observer": "^1.1.0",
-        "rc-util": "^5.36.0",
-        "rc-virtual-list": "^3.11.1"
+        "rc-util": "^5.44.3",
+        "rc-virtual-list": "^3.14.2"
       },
       "engines": {
         "node": ">=8.x"
@@ -12118,14 +12147,14 @@
       }
     },
     "node_modules/rc-tabs": {
-      "version": "12.12.1",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-12.12.1.tgz",
-      "integrity": "sha512-e10VBjEkECdPl4XZSs9to81SE+mgclBTM7J8/LMsFqmJoi05Tci91bRnmeeDtrcOCx2PuZdJv57XUlC4d8PEIw==",
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.6.1.tgz",
+      "integrity": "sha512-/HzDV1VqOsUWyuC0c6AkxVYFjvx9+rFPKZ32ejxX0Uc7QCzcEjTA9/xMgv4HemPKwzBNX8KhGVbbumDjnj92aA==",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "classnames": "2.x",
-        "rc-dropdown": "~4.1.0",
-        "rc-menu": "~9.12.0",
+        "rc-dropdown": "~4.2.0",
+        "rc-menu": "~9.16.0",
         "rc-motion": "^2.6.2",
         "rc-resize-observer": "^1.0.0",
         "rc-util": "^5.34.1"
@@ -12139,13 +12168,13 @@
       }
     },
     "node_modules/rc-textarea": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.4.0.tgz",
-      "integrity": "sha512-CiqK+uyoJlnfufbC0kwfHJpfElhQacuDSNyNQ/xGnA/QMaJLDbgmqRT8QmX0T0KD/ws/hy6qqRaGJSsrRR5uiQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.10.0.tgz",
+      "integrity": "sha512-ai9IkanNuyBS4x6sOL8qu/Ld40e6cEs6pgk93R+XLYg0mDSjNBGey6/ZpDs5+gNLD7urQ14po3V6Ck2dJLt9SA==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1",
-        "rc-input": "~1.2.1",
+        "rc-input": "~1.8.0",
         "rc-resize-observer": "^1.0.0",
         "rc-util": "^5.27.0"
       },
@@ -12155,13 +12184,14 @@
       }
     },
     "node_modules/rc-tooltip": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.0.1.tgz",
-      "integrity": "sha512-MdvPlsD1fDSxKp9+HjXrc/CxLmA/s11QYIh1R7aExxfodKP7CZA++DG1AjrW80F8IUdHYcR43HAm0Y2BYPelHA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.4.0.tgz",
+      "integrity": "sha512-kqyivim5cp8I5RkHmpsp1Nn/Wk+1oeloMv9c7LXNgDxUpGm+RbXJGL+OPvDlcRnx9DBeOe4wyOIl4OKUERyH1g==",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
-        "@rc-component/trigger": "^1.0.4",
-        "classnames": "^2.3.1"
+        "@rc-component/trigger": "^2.0.0",
+        "classnames": "^2.3.1",
+        "rc-util": "^5.44.3"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -12169,9 +12199,9 @@
       }
     },
     "node_modules/rc-tree": {
-      "version": "5.7.12",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.7.12.tgz",
-      "integrity": "sha512-LXA5nY2hG5koIAlHW5sgXgLpOMz+bFRbnZZ+cCg0tQs4Wv1AmY7EDi1SK7iFXhslYockbqUerQan82jljoaItg==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.13.1.tgz",
+      "integrity": "sha512-FNhIefhftobCdUJshO7M8uZTA9F4OPGVXqGfZkkD/5soDeOhwO06T/aKTrg0WD8gRg/pyfq+ql3aMymLHCTC4A==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -12188,15 +12218,15 @@
       }
     },
     "node_modules/rc-tree-select": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.13.0.tgz",
-      "integrity": "sha512-g01JU9EdE7j/9KfDKtmvFqJ7ZDNIYDzkpmAXllbTBFoRNhWJBjW1x/dCZLVG+IdZeIz8SKJkgZzCf1CUZrzV/Q==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.27.0.tgz",
+      "integrity": "sha512-2qTBTzwIT7LRI1o7zLyrCzmo5tQanmyGbSaGTIf7sYimCklAToVVfpMC6OAldSKolcnjorBYPNSKQqJmN3TCww==",
       "dependencies": {
-        "@babel/runtime": "^7.10.1",
+        "@babel/runtime": "^7.25.7",
         "classnames": "2.x",
-        "rc-select": "~14.9.0",
-        "rc-tree": "~5.7.0",
-        "rc-util": "^5.16.1"
+        "rc-select": "~14.16.2",
+        "rc-tree": "~5.13.0",
+        "rc-util": "^5.43.0"
       },
       "peerDependencies": {
         "react": "*",
@@ -12204,9 +12234,9 @@
       }
     },
     "node_modules/rc-upload": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.3.5.tgz",
-      "integrity": "sha512-EHlKJbhkgFSQHliTj9v/2K5aEuFwfUQgZARzD7AmAPOneZEPiCNF3n6PEWIuqz9h7oq6FuXgdR67sC5BWFxJbA==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.9.2.tgz",
+      "integrity": "sha512-nHx+9rbd1FKMiMRYsqQ3NkXUv7COHPBo3X1Obwq9SWS6/diF/A0aJ5OHubvwUAIDs+4RMleljV0pcrNUc823GQ==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "classnames": "^2.2.5",
@@ -12218,9 +12248,9 @@
       }
     },
     "node_modules/rc-util": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.38.0.tgz",
-      "integrity": "sha512-yV/YBNdFn+edyBpBdCqkPE29Su0jWcHNgwx2dJbRqMrMfrUcMJUjCRV+ZPhcvWyKFJ63GzEerPrz9JIVo0zXmA==",
+      "version": "5.44.4",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.4.tgz",
+      "integrity": "sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "react-is": "^18.2.0"
@@ -12236,9 +12266,9 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/rc-virtual-list": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.11.2.tgz",
-      "integrity": "sha512-MTFLL2LOHr3+/+r+WjTIs6j8XmJE6EqdOsJvCH8SWig7qyik3aljCEImUtw5tdWR0tQhXUfbv7P7nZaLY91XPg==",
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.19.1.tgz",
+      "integrity": "sha512-DCapO2oyPqmooGhxBuXHM4lFuX+sshQwWqqkuyFA+4rShLe//+GEPVwiDgO+jKtKHtbeYwZoNvetwfHdOf+iUQ==",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "classnames": "^2.2.6",
@@ -12249,8 +12279,8 @@
         "node": ">=8.x"
       },
       "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
       }
     },
     "node_modules/react": {
@@ -12839,9 +12869,9 @@
       }
     },
     "node_modules/scroll-into-view-if-needed": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.0.10.tgz",
-      "integrity": "sha512-t44QCeDKAPf1mtQH3fYpWz8IM/DyvHLjs8wUvvwMYxk5moOqCzrMSxK6HQVD0QVmVjXFavoFIPRVrMuJPKAvtg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }
@@ -13490,9 +13520,9 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/stylis": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.0.tgz",
-      "integrity": "sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ=="
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -13595,9 +13625,9 @@
       "integrity": "sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ=="
     },
     "node_modules/throttle-debounce": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
-      "integrity": "sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
+      "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
       "engines": {
         "node": ">=12.22"
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@types/papaparse": "^5.3.15",
-    "antd": "^5.9.4",
+    "antd": "^5.26.4",
     "chroma-js": "^3.1.1",
     "d3": "^7.9.0",
     "fuse.js": "^7.0.0",

--- a/src/colorizer/constants.ts
+++ b/src/colorizer/constants.ts
@@ -2,12 +2,12 @@ import { Color } from "three";
 
 import { PlotRangeType, ScatterPlotConfig, VectorConfig, VectorTooltipMode } from "./types";
 
-export const FRAME_BACKGROUND_COLOR_DEFAULT = 0xffffff;
-export const CANVAS_BACKGROUND_COLOR_DEFAULT = 0xf7f7f7;
-export const OUTLINE_COLOR_DEFAULT = 0xff00ff;
-export const OUTLIER_COLOR_DEFAULT = 0xc0c0c0;
-export const OUT_OF_RANGE_COLOR_DEFAULT = 0xdddddd;
-export const EDGE_COLOR_DEFAULT = 0x000000;
+export const FRAME_BACKGROUND_COLOR_DEFAULT = "#ffffff";
+export const CANVAS_BACKGROUND_COLOR_DEFAULT = "#f7f7f7";
+export const OUTLINE_COLOR_DEFAULT = "#ff00ff";
+export const OUTLIER_COLOR_DEFAULT = "#c0c0c0";
+export const OUT_OF_RANGE_COLOR_DEFAULT = "#dddddd";
+export const EDGE_COLOR_DEFAULT = "#000000";
 export const EDGE_COLOR_ALPHA_DEFAULT = 64 / 255; // ~25%
 
 export const VECTOR_KEY_MOTION_DELTA = "_motion_";

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -287,6 +287,11 @@ const CssContainer = styled.div`
     color: ${theme.color.button.outline};
   }
 
+  // Fix a bug where the color picker inner block was not centered
+  .ant-color-picker-trigger > .ant-color-picker-color-block {
+    margin: auto;
+  }
+
   font-family: var(--default-font);
   font-style: normal;
   font-weight: 400;

--- a/src/components/CategoricalColorPicker.tsx
+++ b/src/components/CategoricalColorPicker.tsx
@@ -1,5 +1,4 @@
 import { ColorPicker, Tooltip } from "antd";
-import { Color as AntColor } from "antd/es/color-picker/color";
 import React, { ReactElement, useMemo } from "react";
 import styled from "styled-components";
 import { Color, ColorRepresentation } from "three";
@@ -58,7 +57,7 @@ export default function CategoricalColorPicker(inputProps: CategoricalColorPicke
     for (let i = 0; i < props.categories.length; i++) {
       const color = categoricalPalette[i];
       const label = props.categories[i];
-      const onChange = (_value: AntColor, hex: string): void => {
+      const onChange = (_value: any, hex: string): void => {
         const newPalette = [...categoricalPalette];
         newPalette[i] = new Color(hex as ColorRepresentation);
         setCategoricalPalette(newPalette);

--- a/src/components/Dropdowns/DropdownWithColorPicker.tsx
+++ b/src/components/Dropdowns/DropdownWithColorPicker.tsx
@@ -1,9 +1,8 @@
-import { Color as AntdColor } from "@rc-component/color-picker";
 import { ColorPicker } from "antd";
 import { PresetsItem } from "antd/es/color-picker/interface";
 import React, { ReactElement, useRef } from "react";
 import styled from "styled-components";
-import { Color as ThreeColor,ColorRepresentation } from "three";
+import { ColorRepresentation, Color as ThreeColor } from "three";
 
 import { FlexRowAlignCenter } from "../../styles/utils";
 
@@ -49,7 +48,6 @@ export default function DropdownWithColorPicker(propsInput: DropdownWithColorPic
       .toString(16)
       .padStart(2, "0");
   }
-  const propColor = new AntdColor(colorHexString);
 
   return (
     <HorizontalDiv ref={colorPickerRef}>
@@ -71,8 +69,8 @@ export default function DropdownWithColorPicker(propsInput: DropdownWithColorPic
         }}
         size="small"
         disabledAlpha={!showAlpha}
-        defaultValue={propColor}
-        color={propColor}
+        defaultValue={colorHexString}
+        value={colorHexString}
         presets={props.presets}
         // onChange returns a different color type, so must convert from hex
         onChange={(color, hex) =>

--- a/src/components/Dropdowns/HelpDropdown.tsx
+++ b/src/components/Dropdowns/HelpDropdown.tsx
@@ -33,6 +33,10 @@ const StyledLink = styled.a`
 
 const StyledButton = styled(Button)`
   ${listButtonStyling}
+
+  & > span {
+    width: 100%;
+  }
 `;
 
 export default function HelpDropdown(): ReactElement {

--- a/src/components/LabeledSlider.tsx
+++ b/src/components/LabeledSlider.tsx
@@ -235,7 +235,7 @@ export default function LabeledSlider(inputProps: LabeledSliderProps): ReactElem
   const rangeSliderProps: SliderRangeProps = {
     range: { draggableTrack: true },
     value: props.type === "range" ? [props.min, props.max] : undefined,
-    onChange: (value: [number, number]) => handleRangeChange(value[0], value[1]),
+    onChange: (value: number[]) => handleRangeChange(value[0], value[1]),
   };
 
   // Numeric input field props

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -1,6 +1,6 @@
 import { FolderOpenOutlined, UploadOutlined } from "@ant-design/icons";
 import { Button, Dropdown, Input, InputRef, MenuProps, Space } from "antd";
-import { MenuItemType } from "antd/es/menu/hooks/useItems";
+import { MenuItemType } from "antd/es/menu/interface";
 import React, { ReactElement, ReactNode, useCallback, useContext, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { useClickAnyWhere } from "usehooks-ts";

--- a/src/components/Modals/StyledModal.tsx
+++ b/src/components/Modals/StyledModal.tsx
@@ -49,11 +49,11 @@ const wrapStaticModalFunction = (
 ): AntModalApiFunction => {
   return (props: ModalFuncProps) => {
     const newProps = addContainerToModalProps(modalContainerRef, props);
-    const { destroy, update } = modalFunction(newProps);
+    const { destroy, update, then } = modalFunction(newProps);
     const wrappedUpdate: typeof update = (props: ModalUpdateMethodProps) => {
       return update(addContainerToUpdateMethodProps(modalContainerRef, props));
     };
-    return { destroy, update: wrappedUpdate };
+    return { destroy, update: wrappedUpdate, then };
   };
 };
 

--- a/src/components/Tabs/Annotation/CreateLabelForm.tsx
+++ b/src/components/Tabs/Annotation/CreateLabelForm.tsx
@@ -1,9 +1,9 @@
-import { Color as AntdColor } from "@rc-component/color-picker";
 import { Button, Checkbox, ColorPicker, ConfigProvider, Input, InputRef, Radio } from "antd";
 import React, { ReactElement, useContext, useEffect, useRef, useState } from "react";
 import { Color, ColorRepresentation } from "three";
 
 import { FlexColumn, FlexRow } from "../../../styles/utils";
+import { threeToAntColor } from "../../../utils/color_utils";
 
 import { CSV_COL_ID, CSV_COL_TIME, CSV_COL_TRACK, LabelOptions, LabelType } from "../../../colorizer/AnnotationData";
 import { AppThemeContext, Z_INDEX_POPOVER } from "../../AppStyle";
@@ -51,6 +51,7 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
     props.onColorPickerOpenChange?.(open);
   };
   const colorPickerOpen = props.colorPickerOpen ?? colorPickerOpenState;
+  const colorPickerContainerRef = useRef<HTMLDivElement>(null);
 
   const [labelType, setLabelType] = useState<LabelType>(props.initialLabelOptions.type);
   const [autoIncrement, setAutoIncrement] = useState(props.initialLabelOptions.autoIncrement);
@@ -112,15 +113,16 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
            * if it's in a modal or other element with a higher zIndex.
            */}
           <ConfigProvider theme={{ components: { Popover: { zIndexPopup: props.zIndex } } }}>
-            <div>
+            <div ref={colorPickerContainerRef}>
               <ColorPicker
                 size="small"
-                value={new AntdColor(color.getHexString())}
+                value={threeToAntColor(color)}
                 onChange={onColorPickerChange}
                 disabledAlpha={true}
                 presets={DEFAULT_LABEL_COLOR_PRESETS}
                 onOpenChange={onColorPickerOpenChange}
                 open={colorPickerOpen}
+                getPopupContainer={() => colorPickerContainerRef.current || document.body}
               />
             </div>
           </ConfigProvider>

--- a/src/components/Tabs/Settings/VectorFieldSettings.tsx
+++ b/src/components/Tabs/Settings/VectorFieldSettings.tsx
@@ -1,10 +1,10 @@
-import { Color as AntdColor } from "@rc-component/color-picker";
 import { Card, Checkbox, ColorPicker, Radio } from "antd";
 import React, { ReactElement, useMemo } from "react";
 import { Color, ColorRepresentation } from "three";
 
 import { VECTOR_KEY_MOTION_DELTA } from "../../../colorizer/constants";
 import { VectorTooltipMode } from "../../../colorizer/types";
+import { threeToAntColor } from "../../../utils/color_utils";
 import { DEFAULT_OUTLINE_COLOR_PRESETS } from "./constants";
 
 import { useViewerStateStore } from "../../../state/ViewerState";
@@ -107,7 +107,7 @@ export default function VectorFieldSettings(): ReactElement {
             disabled={!vectorOptionsEnabled}
             disabledAlpha={true}
             size="small"
-            value={new AntdColor(vectorColor.getHexString())}
+            value={threeToAntColor(vectorColor)}
             onChange={(_color, hex) => {
               setVectorColor(new Color(hex as ColorRepresentation));
             }}

--- a/src/components/Tabs/SettingsTab.tsx
+++ b/src/components/Tabs/SettingsTab.tsx
@@ -1,4 +1,3 @@
-import { Color as AntdColor } from "@rc-component/color-picker";
 import { Checkbox, ColorPicker, Switch, Tooltip } from "antd";
 import { PresetsItem } from "antd/es/color-picker/interface";
 import React, { ReactElement, useMemo } from "react";
@@ -7,6 +6,7 @@ import { Color, ColorRepresentation } from "three";
 import { OUTLINE_COLOR_DEFAULT } from "../../colorizer/constants";
 import { DrawMode, TrackPathColorMode } from "../../colorizer/types";
 import { FlexColumn, VisuallyHidden } from "../../styles/utils";
+import { threeToAntColor } from "../../utils/color_utils";
 import { SelectItem } from "../Dropdowns/types";
 import { DEFAULT_OUTLINE_COLOR_PRESETS } from "./Settings/constants";
 
@@ -199,9 +199,9 @@ export default function SettingsTab(): ReactElement {
                 style={{ width: "min-content" }}
                 size="small"
                 disabledAlpha={true}
-                defaultValue={new AntdColor(OUTLINE_COLOR_DEFAULT)}
+                defaultValue={OUTLINE_COLOR_DEFAULT}
                 onChange={(_color, hex) => setOutlineColor(new Color(hex as ColorRepresentation))}
-                value={new AntdColor(outlineColor.getHexString())}
+                value={threeToAntColor(outlineColor)}
                 presets={DEFAULT_OUTLINE_COLOR_PRESETS}
               />
             </div>

--- a/src/utils/color_utils.ts
+++ b/src/utils/color_utils.ts
@@ -1,0 +1,16 @@
+import { ColorPickerProps, GetProp } from "antd";
+import { Color } from "three";
+
+export type AntColor = Extract<GetProp<ColorPickerProps, "value">, string | { cleared: any }>;
+
+export const threeToAntColor = (color: Color): AntColor => {
+  return `#${color.getHexString()}`;
+};
+
+export const antToThreeColor = (color: AntColor): Color => {
+  if (typeof color === "string") {
+    const hex = color.startsWith("#") ? color.slice(1) : color;
+    return new Color(`#${hex}`);
+  }
+  throw new Error("Invalid color format");
+};


### PR DESCRIPTION
Problem
=======
Bumps the current Ant version.

I originally did this to access new API features in #728, but I've since removed those API calls. Because there was a non-trivial number of bugfixes, however, I decided to keep this PR.

*Estimated review size: small, 10 minutes*

Solution
========
- Bumps Ant design to `v5.26.4`.
- Various fixes for compatibility with Ant design API changes.


Steps to Verify:
----------------
1. Open preview link:
