### PR TITLE
fix: Fixed use of `label` tag, accessibility improvements in settings

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -61,7 +61,7 @@ import Export from "./components/Export";
 import GlossaryPanel from "./components/GlossaryPanel";
 import Header from "./components/Header";
 import IconButton from "./components/IconButton";
-import LabeledSlider from "./components/LabeledSlider";
+import LabeledSlider from "./components/Inputs/LabeledSlider";
 import LoadDatasetButton from "./components/LoadDatasetButton";
 import SmallScreenWarning from "./components/Modals/SmallScreenWarning";
 import PlaybackSpeedControl from "./components/PlaybackSpeedControl";

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -92,7 +92,7 @@ const theme = {
       innerOutline: palette.gray30,
       hover: palette.themeLight,
       active: palette.themeDark,
-      focusShadow: "#efe9f7",
+      focusShadow: palette.themeGray,
       success: {
         background: palette.success,
         hover: palette.successMediumDark,
@@ -205,6 +205,7 @@ const CssContainer = styled.div`
   --color-button-disabled: ${theme.color.button.backgroundDisabled};
   --color-button-outline: ${theme.color.button.outline};
   --color-button-outline-active: ${theme.color.button.outlineActive};
+  --color-button-focus-shadow: ${theme.color.button.focusShadow};
 
   --color-button-success-bg: ${theme.color.button.success.background};
   --color-button-success-hover: ${theme.color.button.success.hover};

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -89,9 +89,10 @@ const theme = {
       backgroundDisabled: palette.gray10,
       outline: palette.theme,
       outlineActive: palette.themeDark,
+      innerOutline: palette.gray30,
       hover: palette.themeLight,
       active: palette.themeDark,
-      focusShadow: "rgba(137, 98, 211, 0.06)",
+      focusShadow: "#efe9f7",
       success: {
         background: palette.success,
         hover: palette.successMediumDark,

--- a/src/components/CategoricalColorPicker.tsx
+++ b/src/components/CategoricalColorPicker.tsx
@@ -1,10 +1,9 @@
 import { Tooltip } from "antd";
-import React, { ReactElement, useMemo } from "react";
+import React, { ReactElement, useMemo, useRef } from "react";
 import styled from "styled-components";
 import { Color, ColorRepresentation } from "three";
 
 import { FlexRow, FlexRowAlignCenter } from "../styles/utils";
-import { DEFAULT_LABEL_COLOR_PRESETS } from "../utils/color_utils";
 
 import { useViewerStateStore } from "../state/ViewerState";
 import WrappedColorPicker from "./Inputs/WrappedColorPicker";
@@ -40,7 +39,8 @@ const ColorPickerContainer = styled(FlexRow)<{
     height: fit-content;
   }
 
-  & > div > span {
+  & > div > label,
+  & > div > label > span {
     // Text label, hide overflow as ellipsis
     white-space: nowrap;
     overflow: hidden;
@@ -53,6 +53,7 @@ export default function CategoricalColorPicker(inputProps: CategoricalColorPicke
 
   const categoricalPalette = useViewerStateStore((state) => state.categoricalPalette);
   const setCategoricalPalette = useViewerStateStore((state) => state.setCategoricalPalette);
+  const colorPickerContainerRef = useRef<HTMLDivElement>(null);
 
   const colorPickers = useMemo(() => {
     const elements = [];
@@ -64,21 +65,25 @@ export default function CategoricalColorPicker(inputProps: CategoricalColorPicke
         newPalette[i] = new Color(hex as ColorRepresentation);
         setCategoricalPalette(newPalette);
       };
+      const colorPickerId = `categorical-color-picker-${i}`;
 
       // Make the color picker component
       elements.push(
         <FlexRowAlignCenter key={i}>
           <WrappedColorPicker
+            id={colorPickerId}
             value={color.getHexString()}
             onChange={onChange}
             size={"small"}
             disabledAlpha={true}
-            presets={DEFAULT_LABEL_COLOR_PRESETS}
-            placement="bottom"
-            disablePopupContainer={true}
+            // Necessary to prevent the color picker from going off the screen
+            // TODO: Fix this? This prevents tab navigation from working.
+            getPopupContainer={undefined}
           />
           <Tooltip title={label} placement="top">
-            <span>{label}</span>
+            <label htmlFor={colorPickerId}>
+              <span>{label}</span>
+            </label>
           </Tooltip>
         </FlexRowAlignCenter>
       );
@@ -87,7 +92,7 @@ export default function CategoricalColorPicker(inputProps: CategoricalColorPicke
   }, [props]);
 
   return (
-    <ColorPickerContainer $itemGap="8px" $maxItemsPerRow="6" $itemWidth="110px">
+    <ColorPickerContainer $itemGap="8px" $maxItemsPerRow="6" $itemWidth="110px" ref={colorPickerContainerRef}>
       {colorPickers}
     </ColorPickerContainer>
   );

--- a/src/components/CategoricalColorPicker.tsx
+++ b/src/components/CategoricalColorPicker.tsx
@@ -76,8 +76,7 @@ export default function CategoricalColorPicker(inputProps: CategoricalColorPicke
             size={"small"}
             disabledAlpha={true}
             // Necessary to prevent the color picker from going off the screen
-            // TODO: Fix this? This prevents tab navigation from working.
-            getPopupContainer={undefined}
+            placement="right"
           />
           <Tooltip title={label} placement="top">
             <label htmlFor={colorPickerId}>

--- a/src/components/CategoricalColorPicker.tsx
+++ b/src/components/CategoricalColorPicker.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from "antd";
-import React, { ReactElement, useMemo, useRef } from "react";
+import React, { ReactElement, useMemo } from "react";
 import styled from "styled-components";
 import { Color, ColorRepresentation } from "three";
 
@@ -53,7 +53,6 @@ export default function CategoricalColorPicker(inputProps: CategoricalColorPicke
 
   const categoricalPalette = useViewerStateStore((state) => state.categoricalPalette);
   const setCategoricalPalette = useViewerStateStore((state) => state.setCategoricalPalette);
-  const colorPickerContainerRef = useRef<HTMLDivElement>(null);
 
   const colorPickers = useMemo(() => {
     const elements = [];
@@ -92,7 +91,7 @@ export default function CategoricalColorPicker(inputProps: CategoricalColorPicke
   }, [props]);
 
   return (
-    <ColorPickerContainer $itemGap="8px" $maxItemsPerRow="6" $itemWidth="110px" ref={colorPickerContainerRef}>
+    <ColorPickerContainer $itemGap="8px" $maxItemsPerRow="6" $itemWidth="110px">
       {colorPickers}
     </ColorPickerContainer>
   );

--- a/src/components/CategoricalColorPicker.tsx
+++ b/src/components/CategoricalColorPicker.tsx
@@ -1,11 +1,13 @@
-import { ColorPicker, Tooltip } from "antd";
+import { Tooltip } from "antd";
 import React, { ReactElement, useMemo } from "react";
 import styled from "styled-components";
 import { Color, ColorRepresentation } from "three";
 
 import { FlexRow, FlexRowAlignCenter } from "../styles/utils";
+import { DEFAULT_LABEL_COLOR_PRESETS } from "../utils/color_utils";
 
 import { useViewerStateStore } from "../state/ViewerState";
+import WrappedColorPicker from "./Inputs/WrappedColorPicker";
 
 type CategoricalColorPickerProps = {
   categories: string[];
@@ -66,7 +68,15 @@ export default function CategoricalColorPicker(inputProps: CategoricalColorPicke
       // Make the color picker component
       elements.push(
         <FlexRowAlignCenter key={i}>
-          <ColorPicker value={color.getHexString()} onChange={onChange} size={"small"} disabledAlpha={true} />
+          <WrappedColorPicker
+            value={color.getHexString()}
+            onChange={onChange}
+            size={"small"}
+            disabledAlpha={true}
+            presets={DEFAULT_LABEL_COLOR_PRESETS}
+            placement="bottom"
+            disablePopupContainer={true}
+          />
           <Tooltip title={label} placement="top">
             <span>{label}</span>
           </Tooltip>

--- a/src/components/Dropdowns/DropdownWithColorPicker.tsx
+++ b/src/components/Dropdowns/DropdownWithColorPicker.tsx
@@ -11,8 +11,7 @@ import SelectionDropdown from "./SelectionDropdown";
 type DropdownWithColorPickerProps = {
   selected: string;
   items: { value: string; label: string }[];
-  /** HTML ID that the selection dropdown is labelled by. */
-  htmlLabelId: string;
+  id?: string;
   onValueChange: (mode: string) => void;
   color: ThreeColor;
   disabled?: boolean;
@@ -53,7 +52,7 @@ export default function DropdownWithColorPicker(propsInput: DropdownWithColorPic
     <HorizontalDiv ref={colorPickerRef}>
       <SelectionDropdown
         label={null}
-        htmlLabelId={props.htmlLabelId}
+        id={props.id}
         selected={props.selected.toString()}
         items={props.items}
         showSelectedItemTooltip={false}

--- a/src/components/Dropdowns/DropdownWithColorPicker.tsx
+++ b/src/components/Dropdowns/DropdownWithColorPicker.tsx
@@ -1,11 +1,11 @@
-import { ColorPicker } from "antd";
 import { PresetsItem } from "antd/es/color-picker/interface";
 import React, { ReactElement, useRef } from "react";
 import styled from "styled-components";
-import { ColorRepresentation, Color as ThreeColor } from "three";
+import { Color as ThreeColor } from "three";
 
 import { FlexRowAlignCenter } from "../../styles/utils";
 
+import WrappedColorPicker from "../Inputs/WrappedColorPicker";
 import SelectionDropdown from "./SelectionDropdown";
 
 type DropdownWithColorPickerProps = {
@@ -61,7 +61,7 @@ export default function DropdownWithColorPicker(propsInput: DropdownWithColorPic
         disabled={props.disabled}
         width={"105px"}
       ></SelectionDropdown>
-      <ColorPicker
+      <WrappedColorPicker
         // Uses the default 1s transition animation
         style={{
           visibility: props.showColorPicker ? "visible" : "hidden",
@@ -73,9 +73,11 @@ export default function DropdownWithColorPicker(propsInput: DropdownWithColorPic
         value={colorHexString}
         presets={props.presets}
         // onChange returns a different color type, so must convert from hex
-        onChange={(color, hex) =>
-          props.onColorChange(new ThreeColor(hex.slice(0, 7) as ColorRepresentation), color.toRgb().a)
-        }
+        onChange={(color, _cssColor) => {
+          const rgb = color.toRgb();
+          const hex = color.toHexString().slice(0, 7); // Remove alpha if present
+          props.onColorChange(new ThreeColor(hex), rgb.a);
+        }}
         disabled={props.disabled}
       />
     </HorizontalDiv>

--- a/src/components/Dropdowns/DropdownWithColorPicker.tsx
+++ b/src/components/Dropdowns/DropdownWithColorPicker.tsx
@@ -17,6 +17,7 @@ type DropdownWithColorPickerProps = {
   disabled?: boolean;
   showColorPicker?: boolean;
   presets?: PresetsItem[];
+  /** Alpha value, in the [0, 1] range. */
   alpha?: number;
   onColorChange: (color: ThreeColor, alpha: number) => void;
 };
@@ -73,9 +74,9 @@ export default function DropdownWithColorPicker(propsInput: DropdownWithColorPic
         presets={props.presets}
         // onChange returns a different color type, so must convert from hex
         onChange={(color, _cssColor) => {
-          const rgb = color.toRgb();
           const hex = color.toHexString().slice(0, 7); // Remove alpha if present
-          props.onColorChange(new ThreeColor(hex), rgb.a);
+          const alpha = color.toRgb().a;
+          props.onColorChange(new ThreeColor(hex), alpha);
         }}
         disabled={props.disabled}
       />

--- a/src/components/Dropdowns/SelectionDropdown.tsx
+++ b/src/components/Dropdowns/SelectionDropdown.tsx
@@ -21,6 +21,7 @@ type SelectionDropdownProps = {
    * Ignored if `label` is provided.
    */
   htmlLabelId?: string;
+  id?: string;
   /** The value of the item that is currently selected. */
   selected: string | SelectItem | undefined;
   /** An array of SelectItems that describes the item properties (`{value,
@@ -196,13 +197,14 @@ export default function SelectionDropdown(inputProps: SelectionDropdownProps): R
   );
 
   // Create an ID for the HTML label element if one is provided.
-  const id = props.label ? `dropdown-label-${props.label.toLowerCase().replaceAll(" ", "_")}` : undefined;
+  const labelId = props.label ? `dropdown-label-${props.label.toLowerCase().replaceAll(" ", "_")}` : undefined;
 
   return (
     <FlexRowAlignCenter $gap={6}>
-      {props.label && <h3 id={id ?? props.htmlLabelId}>{props.label}</h3>}
+      {props.label && <h3 id={labelId}>{props.label}</h3>}
       <StyledSelect
-        aria-labelledby={id}
+        aria-labelledby={labelId}
+        inputId={props.id}
         classNamePrefix="react-select"
         isMulti={false}
         placeholder=""

--- a/src/components/Dropdowns/SelectionDropdown.tsx
+++ b/src/components/Dropdowns/SelectionDropdown.tsx
@@ -128,7 +128,7 @@ export default function SelectionDropdown(inputProps: SelectionDropdownProps): R
 
   useEffect(() => {
     if (!props.label && !props.id) {
-      console.log(
+      console.warn(
         "SelectionDropdown: No label or id provided for the dropdown, which means that the select component may not be labeled correctly for screen readers." +
           " Consider either providing the `label` prop, or setting the `id` prop and passing it an HTML `label` via the `for` attribute."
       );

--- a/src/components/Dropdowns/SelectionDropdown.tsx
+++ b/src/components/Dropdowns/SelectionDropdown.tsx
@@ -17,10 +17,6 @@ import StyledSelect from "./StyledSelect";
 type SelectionDropdownProps = {
   /** Text label to include with the dropdown. If null or undefined, hides the label. */
   label?: string | null;
-  /** ID of the HTML element used to label this dropdown, to be used with `aria-labelledby`.
-   * Ignored if `label` is provided.
-   */
-  htmlLabelId?: string;
   id?: string;
   /** The value of the item that is currently selected. */
   selected: string | SelectItem | undefined;
@@ -130,15 +126,6 @@ export default function SelectionDropdown(inputProps: SelectionDropdownProps): R
     selectedOption = props.selected;
   }
 
-  // Warn if no labelling component/ID is provided for the component.
-  useEffect(() => {
-    if (!props.label && !props.htmlLabelId) {
-      console.warn(
-        "SelectionDropdown: Please provide a string 'label' or the HTML ID of the label ('htmlLabelId') to support screen readers."
-      );
-    }
-  }, []);
-
   // Set up fuse for fuzzy searching
   const fuse = useMemo(() => {
     return new Fuse(options, {
@@ -196,15 +183,28 @@ export default function SelectionDropdown(inputProps: SelectionDropdownProps): R
     [props.showSelectedItemTooltip, props.controlTooltipPlacement]
   );
 
-  // Create an ID for the HTML label element if one is provided.
-  const labelId = props.label ? `dropdown-label-${props.label.toLowerCase().replaceAll(" ", "_")}` : undefined;
+  // Create an ID for the HTML label element if one is provided.;
+  useEffect(() => {
+    if (!props.label && !props.id) {
+      console.log(
+        "SelectionDropdown: No label or id provided for the dropdown, which means that the select component may not be labeled correctly for screen readers." +
+          " Consider either providing the `label` prop, or setting the `id` prop and passing it an HTML `label` via the `for` attribute."
+      );
+    }
+  }, []);
+  const selectId = props.id ?? "selection-dropdown-" + props.label?.toLowerCase().replaceAll(" ", "_");
+  const labelId = props.label ? selectId + "-label" : undefined;
 
   return (
     <FlexRowAlignCenter $gap={6}>
-      {props.label && <h3 id={labelId}>{props.label}</h3>}
+      {props.label && (
+        <label htmlFor={selectId}>
+          <h3 id={labelId}>{props.label}</h3>
+        </label>
+      )}
       <StyledSelect
         aria-labelledby={labelId}
-        inputId={props.id}
+        inputId={selectId}
         classNamePrefix="react-select"
         isMulti={false}
         placeholder=""

--- a/src/components/Dropdowns/SelectionDropdown.tsx
+++ b/src/components/Dropdowns/SelectionDropdown.tsx
@@ -126,6 +126,15 @@ export default function SelectionDropdown(inputProps: SelectionDropdownProps): R
     selectedOption = props.selected;
   }
 
+  useEffect(() => {
+    if (!props.label && !props.id) {
+      console.log(
+        "SelectionDropdown: No label or id provided for the dropdown, which means that the select component may not be labeled correctly for screen readers." +
+          " Consider either providing the `label` prop, or setting the `id` prop and passing it an HTML `label` via the `for` attribute."
+      );
+    }
+  }, []);
+
   // Set up fuse for fuzzy searching
   const fuse = useMemo(() => {
     return new Fuse(options, {
@@ -183,15 +192,7 @@ export default function SelectionDropdown(inputProps: SelectionDropdownProps): R
     [props.showSelectedItemTooltip, props.controlTooltipPlacement]
   );
 
-  // Create an ID for the HTML label element if one is provided.;
-  useEffect(() => {
-    if (!props.label && !props.id) {
-      console.log(
-        "SelectionDropdown: No label or id provided for the dropdown, which means that the select component may not be labeled correctly for screen readers." +
-          " Consider either providing the `label` prop, or setting the `id` prop and passing it an HTML `label` via the `for` attribute."
-      );
-    }
-  }, []);
+  // Create an ID for the HTML label element if one is provided.
   const selectId = props.id ?? "selection-dropdown-" + props.label?.toLowerCase().replaceAll(" ", "_");
   const labelId = props.label ? selectId + "-label" : undefined;
 

--- a/src/components/Dropdowns/StyledSelect.tsx
+++ b/src/components/Dropdowns/StyledSelect.tsx
@@ -158,8 +158,8 @@ const SelectContainer = styled.div<{ $type: ButtonProps["type"] | "outlined" }>`
     &:focus-within:has(input:focus-visible) {
       // Focus ring
       box-shadow: none;
-      outline: 2px solid #efe9f7 !important;
-      outline-offset: 0px;
+      outline: 3px solid var(--color-button-focus-shadow) !important;
+      outline-offset: 1px;
       transition: outline-offset 0s, outline 0s;
     }
 

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -30,7 +30,7 @@ import StyledModal, { useStyledModal } from "./Modals/StyledModal";
 import { SettingsContainer, SettingsItem } from "./SettingsContainer";
 import SpinBox from "./SpinBox";
 
-const enum HtmlIds {
+const enum ExportHtmlIds {
   FRAME_RANGE_RADIO = "export-modal-frame-range-radio",
   FRAME_CUSTOM_RANGE_INPUT = "export-modal-frame-custom-range-input",
   FRAME_CUSTOM_RANGE_FRAME_INCREMENT_INPUT = "export-modal-frame-custom-range-frame-increment-input",
@@ -548,10 +548,10 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
                 {rangeMode === RangeMode.CUSTOM ? (
                   // Render the custom range input in the radio list if selected
                   <SettingsContainer indentPx={28}>
-                    <SettingsItem label="Range" htmlFor={HtmlIds.FRAME_CUSTOM_RANGE_INPUT}>
+                    <SettingsItem label="Range" htmlFor={ExportHtmlIds.FRAME_CUSTOM_RANGE_INPUT}>
                       <HorizontalDiv>
                         <InputNumber
-                          id={HtmlIds.FRAME_CUSTOM_RANGE_INPUT}
+                          id={ExportHtmlIds.FRAME_CUSTOM_RANGE_INPUT}
                           style={{ width: 60 }}
                           aria-label="min frame"
                           controls={false}
@@ -575,10 +575,13 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
                         <p>of {props.totalFrames - 1}</p>
                       </HorizontalDiv>
                     </SettingsItem>
-                    <SettingsItem label="Frame increment" htmlFor={HtmlIds.FRAME_CUSTOM_RANGE_FRAME_INCREMENT_INPUT}>
+                    <SettingsItem
+                      label="Frame increment"
+                      htmlFor={ExportHtmlIds.FRAME_CUSTOM_RANGE_FRAME_INCREMENT_INPUT}
+                    >
                       <FlexRow $gap={6}>
                         <SpinBox
-                          id={HtmlIds.FRAME_CUSTOM_RANGE_FRAME_INCREMENT_INPUT}
+                          id={ExportHtmlIds.FRAME_CUSTOM_RANGE_FRAME_INCREMENT_INPUT}
                           value={frameIncrement}
                           onChange={setFrameIncrement}
                           min={1}
@@ -598,10 +601,10 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
           <SettingsContainer gapPx={6}>
             {recordingMode === RecordingMode.VIDEO_MP4 && (
               <>
-                <SettingsItem label="Frames per second" htmlFor={HtmlIds.FPS_INPUT}>
+                <SettingsItem label="Frames per second" htmlFor={ExportHtmlIds.FPS_INPUT}>
                   <FlexRow $gap={6}>
                     <SpinBox
-                      id={HtmlIds.FPS_INPUT}
+                      id={ExportHtmlIds.FPS_INPUT}
                       value={fps}
                       onChange={setFps}
                       min={1}
@@ -612,10 +615,10 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
                     <p style={{ color: theme.color.text.hint }}>({getDurationLabel()})</p>
                   </FlexRow>
                 </SettingsItem>
-                <SettingsItem label="Video quality" htmlFor={HtmlIds.VIDEO_QUALITY_RADIO}>
+                <SettingsItem label="Video quality" htmlFor={ExportHtmlIds.VIDEO_QUALITY_RADIO}>
                   <FlexRow $gap={6}>
                     <VideoQualityRadioGroup
-                      id={HtmlIds.VIDEO_QUALITY_RADIO}
+                      id={ExportHtmlIds.VIDEO_QUALITY_RADIO}
                       disabled={isRecording}
                       options={videoQualityOptions}
                       optionType="button"
@@ -628,10 +631,10 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
               </>
             )}
             {/* Filename prefix */}
-            <SettingsItem label={"Filename"} htmlFor={HtmlIds.IMAGE_FILENAME_INPUT}>
+            <SettingsItem label={"Filename"} htmlFor={ExportHtmlIds.IMAGE_FILENAME_INPUT}>
               <FlexRow $gap={6}>
                 <Input
-                  id={HtmlIds.IMAGE_FILENAME_INPUT}
+                  id={ExportHtmlIds.IMAGE_FILENAME_INPUT}
                   onChange={(event) => {
                     setImagePrefix(event.target.value);
                     setUseDefaultImagePrefix(false);
@@ -651,19 +654,19 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
                 </Button>
               </FlexRow>
             </SettingsItem>
-            <SettingsItem label={"Show feature legend"} htmlFor={HtmlIds.SHOW_FEATURE_LEGEND_CHECKBOX}>
+            <SettingsItem label={"Show feature legend"} htmlFor={ExportHtmlIds.SHOW_FEATURE_LEGEND_CHECKBOX}>
               <div style={{ width: "fit-content" }}>
                 <Checkbox
-                  id={HtmlIds.SHOW_FEATURE_LEGEND_CHECKBOX}
+                  id={ExportHtmlIds.SHOW_FEATURE_LEGEND_CHECKBOX}
                   checked={showLegendDuringExport}
                   onChange={(e) => setShowLegendDuringExport(e.target.checked)}
                 />
               </div>
             </SettingsItem>
-            <SettingsItem label="Show dataset name" htmlFor={HtmlIds.SHOW_DATASET_NAME_CHECKBOX}>
+            <SettingsItem label="Show dataset name" htmlFor={ExportHtmlIds.SHOW_DATASET_NAME_CHECKBOX}>
               <div style={{ width: "fit-content" }}>
                 <Checkbox
-                  id={HtmlIds.SHOW_DATASET_NAME_CHECKBOX}
+                  id={ExportHtmlIds.SHOW_DATASET_NAME_CHECKBOX}
                   checked={showHeaderDuringExport}
                   onChange={(e) => setShowHeaderDuringExport(e.target.checked)}
                 />

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -30,6 +30,17 @@ import StyledModal, { useStyledModal } from "./Modals/StyledModal";
 import { SettingsContainer, SettingsItem } from "./SettingsContainer";
 import SpinBox from "./SpinBox";
 
+const enum HtmlIDs {
+  EXPORT_MODAL_FRAME_RANGE_RADIO = "export-modal-frame-range-radio",
+  EXPORT_MODAL_FRAME_CUSTOM_RANGE_INPUT = "export-modal-frame-custom-range-input",
+  EXPORT_MODAL_FRAME_CUSTOM_RANGE_FRAME_INCREMENT_INPUT = "export-modal-frame-custom-range-frame-increment-input",
+  EXPORT_MODAL_FPS_INPUT = "export-modal-fps-input",
+  EXPORT_MODAL_VIDEO_QUALITY_RADIO = "export-modal-video-quality-radio",
+  EXPORT_MODAL_IMAGE_FILENAME_INPUT = "export-modal-image-filename-input",
+  EXPORT_MODAL_SHOW_FEATURE_LEGEND_CHECKBOX = "export-modal-show-feature-legend-checkbox",
+  EXPORT_MODAL_SHOW_DATASET_NAME_CHECKBOX = "export-modal-show-dataset-name-checkbox",
+}
+
 type ExportButtonProps = {
   totalFrames: number;
   setFrame: (frame: number) => Promise<void>;
@@ -537,9 +548,10 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
                 {rangeMode === RangeMode.CUSTOM ? (
                   // Render the custom range input in the radio list if selected
                   <SettingsContainer indentPx={28}>
-                    <SettingsItem label="Range">
+                    <SettingsItem label="Range" htmlFor={HtmlIDs.EXPORT_MODAL_FRAME_CUSTOM_RANGE_INPUT}>
                       <HorizontalDiv>
                         <InputNumber
+                          id={HtmlIDs.EXPORT_MODAL_FRAME_CUSTOM_RANGE_INPUT}
                           style={{ width: 60 }}
                           aria-label="min frame"
                           controls={false}
@@ -563,9 +575,13 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
                         <p>of {props.totalFrames - 1}</p>
                       </HorizontalDiv>
                     </SettingsItem>
-                    <SettingsItem label="Frame increment">
+                    <SettingsItem
+                      label="Frame increment"
+                      htmlFor={HtmlIDs.EXPORT_MODAL_FRAME_CUSTOM_RANGE_FRAME_INCREMENT_INPUT}
+                    >
                       <FlexRow $gap={6}>
                         <SpinBox
+                          id={HtmlIDs.EXPORT_MODAL_FRAME_CUSTOM_RANGE_FRAME_INCREMENT_INPUT}
                           value={frameIncrement}
                           onChange={setFrameIncrement}
                           min={1}
@@ -585,15 +601,24 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
           <SettingsContainer gapPx={6}>
             {recordingMode === RecordingMode.VIDEO_MP4 && (
               <>
-                <SettingsItem label="Frames per second">
+                <SettingsItem label="Frames per second" htmlFor={HtmlIDs.EXPORT_MODAL_FPS_INPUT}>
                   <FlexRow $gap={6}>
-                    <SpinBox value={fps} onChange={setFps} min={1} max={120} disabled={isRecording} width="175px" />
+                    <SpinBox
+                      id={HtmlIDs.EXPORT_MODAL_FPS_INPUT}
+                      value={fps}
+                      onChange={setFps}
+                      min={1}
+                      max={120}
+                      disabled={isRecording}
+                      width="175px"
+                    />
                     <p style={{ color: theme.color.text.hint }}>({getDurationLabel()})</p>
                   </FlexRow>
                 </SettingsItem>
-                <SettingsItem label="Video quality">
+                <SettingsItem label="Video quality" htmlFor={HtmlIDs.EXPORT_MODAL_VIDEO_QUALITY_RADIO}>
                   <FlexRow $gap={6}>
                     <VideoQualityRadioGroup
+                      id={HtmlIDs.EXPORT_MODAL_VIDEO_QUALITY_RADIO}
                       disabled={isRecording}
                       options={videoQualityOptions}
                       optionType="button"
@@ -606,9 +631,10 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
               </>
             )}
             {/* Filename prefix */}
-            <SettingsItem label={"Filename"}>
+            <SettingsItem label={"Filename"} htmlFor={HtmlIDs.EXPORT_MODAL_IMAGE_FILENAME_INPUT}>
               <FlexRow $gap={6}>
                 <Input
+                  id={HtmlIDs.EXPORT_MODAL_IMAGE_FILENAME_INPUT}
                   onChange={(event) => {
                     setImagePrefix(event.target.value);
                     setUseDefaultImagePrefix(false);
@@ -628,15 +654,19 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
                 </Button>
               </FlexRow>
             </SettingsItem>
-            <SettingsItem label={"Show feature legend"}>
-              <Checkbox
-                checked={showLegendDuringExport}
-                onChange={(e) => setShowLegendDuringExport(e.target.checked)}
-              />
-            </SettingsItem>
-            <SettingsItem label="Show dataset name">
-              <div>
+            <SettingsItem label={"Show feature legend"} htmlFor={HtmlIDs.EXPORT_MODAL_SHOW_FEATURE_LEGEND_CHECKBOX}>
+              <div style={{ width: "fit-content" }}>
                 <Checkbox
+                  id={HtmlIDs.EXPORT_MODAL_SHOW_FEATURE_LEGEND_CHECKBOX}
+                  checked={showLegendDuringExport}
+                  onChange={(e) => setShowLegendDuringExport(e.target.checked)}
+                />
+              </div>
+            </SettingsItem>
+            <SettingsItem label="Show dataset name" htmlFor={HtmlIDs.EXPORT_MODAL_SHOW_DATASET_NAME_CHECKBOX}>
+              <div style={{ width: "fit-content" }}>
+                <Checkbox
+                  id={HtmlIDs.EXPORT_MODAL_SHOW_DATASET_NAME_CHECKBOX}
                   checked={showHeaderDuringExport}
                   onChange={(e) => setShowHeaderDuringExport(e.target.checked)}
                 />

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -30,15 +30,15 @@ import StyledModal, { useStyledModal } from "./Modals/StyledModal";
 import { SettingsContainer, SettingsItem } from "./SettingsContainer";
 import SpinBox from "./SpinBox";
 
-const enum HtmlIDs {
-  EXPORT_MODAL_FRAME_RANGE_RADIO = "export-modal-frame-range-radio",
-  EXPORT_MODAL_FRAME_CUSTOM_RANGE_INPUT = "export-modal-frame-custom-range-input",
-  EXPORT_MODAL_FRAME_CUSTOM_RANGE_FRAME_INCREMENT_INPUT = "export-modal-frame-custom-range-frame-increment-input",
-  EXPORT_MODAL_FPS_INPUT = "export-modal-fps-input",
-  EXPORT_MODAL_VIDEO_QUALITY_RADIO = "export-modal-video-quality-radio",
-  EXPORT_MODAL_IMAGE_FILENAME_INPUT = "export-modal-image-filename-input",
-  EXPORT_MODAL_SHOW_FEATURE_LEGEND_CHECKBOX = "export-modal-show-feature-legend-checkbox",
-  EXPORT_MODAL_SHOW_DATASET_NAME_CHECKBOX = "export-modal-show-dataset-name-checkbox",
+const enum HtmlIds {
+  FRAME_RANGE_RADIO = "export-modal-frame-range-radio",
+  FRAME_CUSTOM_RANGE_INPUT = "export-modal-frame-custom-range-input",
+  FRAME_CUSTOM_RANGE_FRAME_INCREMENT_INPUT = "export-modal-frame-custom-range-frame-increment-input",
+  FPS_INPUT = "export-modal-fps-input",
+  VIDEO_QUALITY_RADIO = "export-modal-video-quality-radio",
+  IMAGE_FILENAME_INPUT = "export-modal-image-filename-input",
+  SHOW_FEATURE_LEGEND_CHECKBOX = "export-modal-show-feature-legend-checkbox",
+  SHOW_DATASET_NAME_CHECKBOX = "export-modal-show-dataset-name-checkbox",
 }
 
 type ExportButtonProps = {
@@ -548,10 +548,10 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
                 {rangeMode === RangeMode.CUSTOM ? (
                   // Render the custom range input in the radio list if selected
                   <SettingsContainer indentPx={28}>
-                    <SettingsItem label="Range" htmlFor={HtmlIDs.EXPORT_MODAL_FRAME_CUSTOM_RANGE_INPUT}>
+                    <SettingsItem label="Range" htmlFor={HtmlIds.FRAME_CUSTOM_RANGE_INPUT}>
                       <HorizontalDiv>
                         <InputNumber
-                          id={HtmlIDs.EXPORT_MODAL_FRAME_CUSTOM_RANGE_INPUT}
+                          id={HtmlIds.FRAME_CUSTOM_RANGE_INPUT}
                           style={{ width: 60 }}
                           aria-label="min frame"
                           controls={false}
@@ -575,13 +575,10 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
                         <p>of {props.totalFrames - 1}</p>
                       </HorizontalDiv>
                     </SettingsItem>
-                    <SettingsItem
-                      label="Frame increment"
-                      htmlFor={HtmlIDs.EXPORT_MODAL_FRAME_CUSTOM_RANGE_FRAME_INCREMENT_INPUT}
-                    >
+                    <SettingsItem label="Frame increment" htmlFor={HtmlIds.FRAME_CUSTOM_RANGE_FRAME_INCREMENT_INPUT}>
                       <FlexRow $gap={6}>
                         <SpinBox
-                          id={HtmlIDs.EXPORT_MODAL_FRAME_CUSTOM_RANGE_FRAME_INCREMENT_INPUT}
+                          id={HtmlIds.FRAME_CUSTOM_RANGE_FRAME_INCREMENT_INPUT}
                           value={frameIncrement}
                           onChange={setFrameIncrement}
                           min={1}
@@ -601,10 +598,10 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
           <SettingsContainer gapPx={6}>
             {recordingMode === RecordingMode.VIDEO_MP4 && (
               <>
-                <SettingsItem label="Frames per second" htmlFor={HtmlIDs.EXPORT_MODAL_FPS_INPUT}>
+                <SettingsItem label="Frames per second" htmlFor={HtmlIds.FPS_INPUT}>
                   <FlexRow $gap={6}>
                     <SpinBox
-                      id={HtmlIDs.EXPORT_MODAL_FPS_INPUT}
+                      id={HtmlIds.FPS_INPUT}
                       value={fps}
                       onChange={setFps}
                       min={1}
@@ -615,10 +612,10 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
                     <p style={{ color: theme.color.text.hint }}>({getDurationLabel()})</p>
                   </FlexRow>
                 </SettingsItem>
-                <SettingsItem label="Video quality" htmlFor={HtmlIDs.EXPORT_MODAL_VIDEO_QUALITY_RADIO}>
+                <SettingsItem label="Video quality" htmlFor={HtmlIds.VIDEO_QUALITY_RADIO}>
                   <FlexRow $gap={6}>
                     <VideoQualityRadioGroup
-                      id={HtmlIDs.EXPORT_MODAL_VIDEO_QUALITY_RADIO}
+                      id={HtmlIds.VIDEO_QUALITY_RADIO}
                       disabled={isRecording}
                       options={videoQualityOptions}
                       optionType="button"
@@ -631,10 +628,10 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
               </>
             )}
             {/* Filename prefix */}
-            <SettingsItem label={"Filename"} htmlFor={HtmlIDs.EXPORT_MODAL_IMAGE_FILENAME_INPUT}>
+            <SettingsItem label={"Filename"} htmlFor={HtmlIds.IMAGE_FILENAME_INPUT}>
               <FlexRow $gap={6}>
                 <Input
-                  id={HtmlIDs.EXPORT_MODAL_IMAGE_FILENAME_INPUT}
+                  id={HtmlIds.IMAGE_FILENAME_INPUT}
                   onChange={(event) => {
                     setImagePrefix(event.target.value);
                     setUseDefaultImagePrefix(false);
@@ -654,19 +651,19 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
                 </Button>
               </FlexRow>
             </SettingsItem>
-            <SettingsItem label={"Show feature legend"} htmlFor={HtmlIDs.EXPORT_MODAL_SHOW_FEATURE_LEGEND_CHECKBOX}>
+            <SettingsItem label={"Show feature legend"} htmlFor={HtmlIds.SHOW_FEATURE_LEGEND_CHECKBOX}>
               <div style={{ width: "fit-content" }}>
                 <Checkbox
-                  id={HtmlIDs.EXPORT_MODAL_SHOW_FEATURE_LEGEND_CHECKBOX}
+                  id={HtmlIds.SHOW_FEATURE_LEGEND_CHECKBOX}
                   checked={showLegendDuringExport}
                   onChange={(e) => setShowLegendDuringExport(e.target.checked)}
                 />
               </div>
             </SettingsItem>
-            <SettingsItem label="Show dataset name" htmlFor={HtmlIDs.EXPORT_MODAL_SHOW_DATASET_NAME_CHECKBOX}>
+            <SettingsItem label="Show dataset name" htmlFor={HtmlIds.SHOW_DATASET_NAME_CHECKBOX}>
               <div style={{ width: "fit-content" }}>
                 <Checkbox
-                  id={HtmlIDs.EXPORT_MODAL_SHOW_DATASET_NAME_CHECKBOX}
+                  id={HtmlIds.SHOW_DATASET_NAME_CHECKBOX}
                   checked={showHeaderDuringExport}
                   onChange={(e) => setShowHeaderDuringExport(e.target.checked)}
                 />

--- a/src/components/Inputs/LabeledSlider.tsx
+++ b/src/components/Inputs/LabeledSlider.tsx
@@ -4,10 +4,11 @@ import React, { ReactElement, ReactEventHandler, ReactNode, useRef } from "react
 import styled, { css } from "styled-components";
 import { clamp } from "three/src/math/MathUtils";
 
-import { formatNumber, setMaxDecimalPrecision } from "../colorizer/utils/math_utils";
-import { excludeUndefinedValues } from "../colorizer/utils/react_utils";
+import { formatNumber, setMaxDecimalPrecision } from "../../colorizer/utils/math_utils";
+import { excludeUndefinedValues } from "../../colorizer/utils/react_utils";
 
 type BaseLabeledSliderProps = {
+  id?: string;
   type: "range" | "value";
   disabled?: boolean;
 
@@ -273,9 +274,9 @@ export default function LabeledSlider(inputProps: LabeledSliderProps): ReactElem
       {
         // Conditionally render either min or value input
         props.type === "value" ? (
-          <InputNumber {...sharedInputNumberProps} {...valueInputNumberProps} />
+          <InputNumber {...sharedInputNumberProps} {...valueInputNumberProps} id={props.id} />
         ) : (
-          <InputNumber {...sharedInputNumberProps} {...minInputNumberProps} />
+          <InputNumber {...sharedInputNumberProps} {...minInputNumberProps} id={props.id} />
         )
       }
       <SliderContainer>
@@ -283,7 +284,9 @@ export default function LabeledSlider(inputProps: LabeledSliderProps): ReactElem
         <SliderLabel $disabled={props.disabled}>{minSliderLabel}</SliderLabel>
         <SliderLabel $disabled={props.disabled}>{maxSliderLabel}</SliderLabel>
       </SliderContainer>
-      {props.type === "range" && <InputNumber {...sharedInputNumberProps} {...maxInputNumberProps} />}
+      {props.type === "range" && (
+        <InputNumber {...sharedInputNumberProps} {...maxInputNumberProps} id={props.id + "-max"} />
+      )}
     </ComponentContainer>
   );
 }

--- a/src/components/Inputs/LabeledSlider.tsx
+++ b/src/components/Inputs/LabeledSlider.tsx
@@ -284,9 +284,7 @@ export default function LabeledSlider(inputProps: LabeledSliderProps): ReactElem
         <SliderLabel $disabled={props.disabled}>{minSliderLabel}</SliderLabel>
         <SliderLabel $disabled={props.disabled}>{maxSliderLabel}</SliderLabel>
       </SliderContainer>
-      {props.type === "range" && (
-        <InputNumber {...sharedInputNumberProps} {...maxInputNumberProps} id={props.id + "-max"} />
-      )}
+      {props.type === "range" && <InputNumber {...sharedInputNumberProps} {...maxInputNumberProps} />}
     </ComponentContainer>
   );
 }

--- a/src/components/Inputs/WrappedColorPicker.tsx
+++ b/src/components/Inputs/WrappedColorPicker.tsx
@@ -1,0 +1,116 @@
+import { Button, ColorPicker, ColorPickerProps } from "antd";
+import React, { ReactElement, useContext, useMemo, useRef, useState } from "react";
+import styled from "styled-components";
+
+import { antToThreeColor } from "../../utils/color_utils";
+
+import { AppTheme, AppThemeContext } from "../AppStyle";
+
+type WrappedColorPickerProps = ColorPickerProps & {
+  id?: string;
+  /**
+   * If true, uses the global default container (`document.body`) for the color
+   * picker popup instead of an inline container. Useful for components that are
+   * rendered in smaller containers that might overflow the screen edges.
+   */
+  disablePopupContainer?: boolean;
+};
+
+const StyledColorPickerTrigger = styled(Button)<{ $theme: AppTheme; $open: boolean }>`
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  padding: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &&& {
+    border: 1px solid ${(props) => (props.$open ? props.$theme.color.button.active : props.$theme.color.layout.borders)};
+    outline: ${(props) => (props.$open ? `2px solid ${props.$theme.color.button.focusShadow}` : "none")};
+    background: transparent;
+
+    &:hover,
+    &:active {
+      background: transparent;
+    }
+
+    &:focus {
+      outline: 2px solid ${(props) => props.$theme.color.button.focusShadow};
+      outline-offset: 0;
+    }
+
+    &:disabled {
+      border-color: ${(props) => props.$theme.color.layout.borders};
+      background: ${(props) => props.$theme.color.button.backgroundDisabled};
+    }
+  }
+`;
+
+// Reimplements the color block in the ColorPicker trigger since it's not
+// exported by Ant.
+const ColorPickerBlock = styled.div<{ $theme: AppTheme }>`
+  // Grid pattern
+  width: 14px;
+  height: 14px;
+  background-image: conic-gradient(
+    rgba(0, 0, 0, 0.06) 0 25%,
+    transparent 0 50%,
+    rgba(0, 0, 0, 0.06) 0 75%,
+    transparent 0
+  );
+  background-size: 50% 50%;
+  border-radius: 2px;
+
+  & > div {
+    width: 100%;
+    height: 100%;
+    border-radius: 2px;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.06);
+    box-sizing: border-box;
+  }
+`;
+
+/**
+ * Wraps the Ant Design ColorPicker component.
+ *
+ * This fixes several accessibility issues, including:
+ * - Popup was placed in a separate part of DOM (direct child of
+ *   `document.body`)
+ * - Base ColorPicker was not accessible via keyboard navigation (used a
+ *   non-focusable `div` as trigger)
+ * - `id` could not be set on the ColorPicker trigger for labeling
+ */
+export default function WrappedColorPicker(props: WrappedColorPickerProps): ReactElement {
+  const colorPickerContainerRef = useRef<HTMLDivElement>(null);
+  const theme = useContext(AppThemeContext);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const colorCss = useMemo(() => {
+    const { value } = props;
+    if (!value) {
+      return "transparent";
+    }
+    const { color: threeColor, alpha } = antToThreeColor(value as string);
+    threeColor.convertLinearToSRGB();
+    return `rgb(${threeColor.r * 255}, ${threeColor.g * 255}, ${threeColor.b * 255}, ${alpha})`;
+  }, [props.value]);
+
+  return (
+    <div ref={colorPickerContainerRef}>
+      <ColorPicker
+        {...props}
+        getPopupContainer={
+          props.disablePopupContainer ? undefined : () => colorPickerContainerRef.current || document.body
+        }
+        onOpenChange={setIsOpen}
+      >
+        <StyledColorPickerTrigger type="default" id={props.id} disabled={props.disabled} $theme={theme} $open={isOpen}>
+          <ColorPickerBlock $theme={theme}>
+            <div style={{ backgroundColor: colorCss }} />
+          </ColorPickerBlock>
+        </StyledColorPickerTrigger>
+      </ColorPicker>
+    </div>
+  );
+}

--- a/src/components/Inputs/WrappedColorPicker.tsx
+++ b/src/components/Inputs/WrappedColorPicker.tsx
@@ -8,14 +8,9 @@ import { AppTheme, AppThemeContext } from "../AppStyle";
 
 type WrappedColorPickerProps = ColorPickerProps & {
   id?: string;
-  /**
-   * If true, uses the global default container (`document.body`) for the color
-   * picker popup instead of an inline container. Useful for components that are
-   * rendered in smaller containers that might overflow the screen edges.
-   */
-  disablePopupContainer?: boolean;
 };
 
+// Square button trigger with an inset color block inside
 const StyledColorPickerTrigger = styled(Button)<{ $theme: AppTheme; $open: boolean }>`
   width: 28px;
   height: 28px;
@@ -36,8 +31,8 @@ const StyledColorPickerTrigger = styled(Button)<{ $theme: AppTheme; $open: boole
     }
 
     &:focus {
-      outline: 2px solid ${(props) => props.$theme.color.button.focusShadow};
-      outline-offset: 0;
+      outline: 3px solid ${(props) => props.$theme.color.button.focusShadow};
+      outline-offset: 1;
     }
 
     &:disabled {
@@ -47,12 +42,12 @@ const StyledColorPickerTrigger = styled(Button)<{ $theme: AppTheme; $open: boole
   }
 `;
 
-// Reimplements the color block in the ColorPicker trigger since it's not
-// exported by Ant.
+// Smaller block inside the trigger that shows the selected color,
+// including a transparent checkerboard pattern.
 const ColorPickerBlock = styled.div<{ $theme: AppTheme }>`
-  // Grid pattern
   width: 14px;
   height: 14px;
+  // Transparency checkerboard pattern
   background-image: conic-gradient(
     rgba(0, 0, 0, 0.06) 0 25%,
     transparent 0 50%,
@@ -62,6 +57,7 @@ const ColorPickerBlock = styled.div<{ $theme: AppTheme }>`
   background-size: 50% 50%;
   border-radius: 2px;
 
+  // Selected color
   & > div {
     width: 100%;
     height: 100%;
@@ -99,11 +95,12 @@ export default function WrappedColorPicker(props: WrappedColorPickerProps): Reac
   return (
     <div ref={colorPickerContainerRef}>
       <ColorPicker
+        getPopupContainer={() => colorPickerContainerRef.current || document.body}
         {...props}
-        getPopupContainer={
-          props.disablePopupContainer ? undefined : () => colorPickerContainerRef.current || document.body
-        }
-        onOpenChange={setIsOpen}
+        onOpenChange={(open) => {
+          setIsOpen(open);
+          props.onOpenChange?.(open);
+        }}
       >
         <StyledColorPickerTrigger type="default" id={props.id} disabled={props.disabled} $theme={theme} $open={isOpen}>
           <ColorPickerBlock $theme={theme}>

--- a/src/components/Inputs/WrappedColorPicker.tsx
+++ b/src/components/Inputs/WrappedColorPicker.tsx
@@ -30,7 +30,7 @@ const StyledColorPickerTrigger = styled(Button)<{ $theme: AppTheme; $open: boole
       background: transparent;
     }
 
-    &:focus {
+    &:focus-visible {
       outline: 3px solid ${(props) => props.$theme.color.button.focusShadow};
       outline-offset: 1;
     }
@@ -78,9 +78,9 @@ const ColorPickerBlock = styled.div<{ $theme: AppTheme }>`
  * - `id` could not be set on the ColorPicker trigger for labeling
  */
 export default function WrappedColorPicker(props: WrappedColorPickerProps): ReactElement {
-  const colorPickerContainerRef = useRef<HTMLDivElement>(null);
   const theme = useContext(AppThemeContext);
   const [isOpen, setIsOpen] = useState(false);
+  const colorPickerContainerRef = useRef<HTMLDivElement>(null);
 
   const colorCss = useMemo(() => {
     const { value } = props;

--- a/src/components/SettingsContainer.tsx
+++ b/src/components/SettingsContainer.tsx
@@ -7,6 +7,8 @@ type SettingsItemProps = {
   label?: string | ReactElement;
   /** HTML ID applied to the `label` element, if `label` is a string. */
   id?: string;
+  /** HTML `for` attribute applied to the `label` element, if `label` is a string. */
+  htmlFor?: string;
   /** A formatting function that will be applied to the label. If defined, overrides `labelFormatter`
    * of the parent `SettingsContainer`. */
   labelFormatter?: (label: string | ReactElement) => string | ReactElement;
@@ -35,12 +37,12 @@ export function SettingsItem(inputProps: PropsWithChildren<Partial<SettingsItemP
   const formattedLabel = props.labelFormatter ? props.labelFormatter(props.label) : props.label;
 
   return (
-    <label style={props.style}>
-      <span style={props.labelStyle} id={props.id}>
+    <div style={props.style}>
+      <label style={props.labelStyle} id={props.id} htmlFor={props.htmlFor}>
         {formattedLabel}
-      </span>
+      </label>
       {props.children}
-    </label>
+    </div>
   );
 }
 
@@ -49,10 +51,10 @@ export function SettingsItem(inputProps: PropsWithChildren<Partial<SettingsItemP
  *
  * For all children matching the following pattern:
  * ```
- * <label>
- *   <span>Some Label Text</span>
+ * <div>
+ *   <label>Some Label Text</label>
  *   <... any element ...>
- * </label>
+ * </div>
  * ```
  * aligns the label text and the element in grid columns.
  */
@@ -71,7 +73,7 @@ const SettingsDivContainer = styled.div<{ $labelWidth?: string; $gapPx?: number;
     `;
   }}
 
-  & > label {
+  & > div:has(label) {
     grid-column: 1 / 3; // Labels span both columns
     display: grid;
     grid-template-columns: subgrid;
@@ -81,20 +83,20 @@ const SettingsDivContainer = styled.div<{ $labelWidth?: string; $gapPx?: number;
         gap: ${props.$gapPx ? props.$gapPx : 6}px;
       `;
     }}
-  }
 
-  & > label > span:first-of-type {
-    display: grid;
-    grid-column: 1;
-    align-items: center;
-    text-align: right;
-  }
+    & > label:first-of-type {
+      display: grid;
+      grid-column: 1;
+      align-items: center;
+      text-align: right;
+    }
 
-  & > label > :not(span:first-of-type) {
-    grid-column: 2;
-    // Lines up the bottom of the input with the bottom of the label,
-    // where the colon separator is.
-    align-items: end;
+    & > :not(label:first-of-type) {
+      grid-column: 2;
+      // Lines up the bottom of the input with the bottom of the label,
+      // where the colon separator is.
+      align-items: end;
+    }
   }
 `;
 

--- a/src/components/SettingsContainer.tsx
+++ b/src/components/SettingsContainer.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { PropsWithChildren, ReactElement } from "react";
 import styled, { css } from "styled-components";
+
+const SETTINGS_LABEL_CLASS = "settings-label";
 
 type SettingsItemProps = {
   /** A string or ReactElement label. Strings will be displayed as `p`. Defaults to empty string ("").*/
@@ -17,7 +19,6 @@ type SettingsItemProps = {
 };
 
 const defaultSettingsItemProps = {
-  label: "",
   labelStyle: {},
 };
 
@@ -34,13 +35,27 @@ export function SettingsItem(inputProps: PropsWithChildren<Partial<SettingsItemP
     props.children = <div>{props.children}</div>;
   }
 
-  const formattedLabel = props.labelFormatter ? props.labelFormatter(props.label) : props.label;
+  useEffect(() => {
+    if (props.label && typeof props.label === "string" && !props.htmlFor) {
+      console.warn(
+        "SettingsItem: Please set the 'htmlFor' attribute to support screen readers in setting '" + props.label + "'."
+      );
+    }
+  }, [props.label, props.htmlFor]);
+
+  let labelElement = <div className={SETTINGS_LABEL_CLASS}></div>;
+  if (props.label) {
+    const formattedLabel = props.labelFormatter ? props.labelFormatter(props.label) : props.label;
+    labelElement = (
+      <label style={props.labelStyle} id={props.id} htmlFor={props.htmlFor} className={SETTINGS_LABEL_CLASS}>
+        {formattedLabel}
+      </label>
+    );
+  }
 
   return (
     <div style={props.style}>
-      <label style={props.labelStyle} id={props.id} htmlFor={props.htmlFor}>
-        {formattedLabel}
-      </label>
+      {labelElement}
       {props.children}
     </div>
   );
@@ -73,7 +88,7 @@ const SettingsDivContainer = styled.div<{ $labelWidth?: string; $gapPx?: number;
     `;
   }}
 
-  & > div:has(label) {
+  & > div:has(.${SETTINGS_LABEL_CLASS}) {
     grid-column: 1 / 3; // Labels span both columns
     display: grid;
     grid-template-columns: subgrid;
@@ -84,14 +99,14 @@ const SettingsDivContainer = styled.div<{ $labelWidth?: string; $gapPx?: number;
       `;
     }}
 
-    & > label:first-of-type {
+    & > ${"." + SETTINGS_LABEL_CLASS}:first-of-type {
       display: grid;
       grid-column: 1;
       align-items: center;
       text-align: right;
     }
 
-    & > :not(label:first-of-type) {
+    & > :not(${"." + SETTINGS_LABEL_CLASS}:first-of-type) {
       grid-column: 2;
       // Lines up the bottom of the input with the bottom of the label,
       // where the colon separator is.

--- a/src/components/SettingsContainer.tsx
+++ b/src/components/SettingsContainer.tsx
@@ -11,9 +11,6 @@ type SettingsItemProps = {
   labelId?: string;
   /** HTML `for` attribute applied to the `label` element. */
   htmlFor?: string;
-  /** A formatting function that will be applied to the label. If defined, overrides `labelFormatter`
-   * of the parent `SettingsContainer`. */
-  labelFormatter?: (label: string | ReactElement) => string | ReactElement;
   labelStyle?: React.CSSProperties;
   style?: React.CSSProperties;
 };
@@ -45,10 +42,9 @@ export function SettingsItem(inputProps: PropsWithChildren<Partial<SettingsItemP
 
   let labelElement = <div></div>;
   if (props.label) {
-    const formattedLabel = props.labelFormatter ? props.labelFormatter(props.label) : props.label;
     labelElement = (
       <label style={props.labelStyle} id={props.labelId} htmlFor={props.htmlFor}>
-        {formattedLabel}
+        {props.label}
       </label>
     );
   }
@@ -116,7 +112,6 @@ const SettingsDivContainer = styled.div<{ $labelWidth?: string; $gapPx?: number;
 `;
 
 type SettingsContainerProps = {
-  labelFormatter?: (label: string | ReactElement) => string | ReactElement;
   labelWidth?: string;
   gapPx?: number;
   indentPx?: number;
@@ -131,13 +126,12 @@ const defaultSettingsContainerProps: Partial<SettingsContainerProps> = {
 /**
  * A grid container that aligns a list of `SettingsItem` components by labels and input.
  *
- * @param labelFormatter A formatting function that will be applied to the labels of all `SettingsItem` children, unless overridden.
- * @param labelWidth CSS string used to set the width of the label column. Defaults to `"fit-content(30%)"`, where the label column
+ * @param $labelWidth CSS string used to set the width of the label column. Defaults to `"fit-content(30%)"`, where the label column
  * will be up to 30% of the `SettingsContainer`'s width..
  * If you do not want the label column to be sized automatically, set this to a fixed width or percentage (ex: `"30%"` or `"100px"`).
- * @param gapPx The vertical gap, in pixels, between each `SettingsItem` and the horizontal gap between the label
+ * @param $gapPx The vertical gap, in pixels, between each `SettingsItem` and the horizontal gap between the label
  * and settings content. 6 by default.
- * @param indentPx The left indent, in pixels, of items in the container. 10 by default.
+ * @param $indentPx The left indent, in pixels, of items in the container. 10 by default.
  *
  * @example
  * ```
@@ -155,29 +149,11 @@ const defaultSettingsContainerProps: Partial<SettingsContainerProps> = {
  * ```
  */
 export function SettingsContainer(inputProps: PropsWithChildren<Partial<SettingsContainerProps>>): ReactElement {
-  const props = { ...defaultSettingsContainerProps, ...inputProps } as PropsWithChildren<
-    Required<SettingsContainerProps>
-  >;
-
-  const renderChildren = (children: React.ReactNode): React.ReactNode => {
-    return React.Children.map(children, (child) => {
-      if (React.isValidElement(child)) {
-        if (child.type === SettingsItem && props.labelFormatter && child.props.labelFormatter === undefined) {
-          // Override label formatter if provided and the child doesn't have an override
-          return React.cloneElement(child, {
-            labelFormatter: props.labelFormatter,
-          } as SettingsItemProps);
-        } else {
-          return child;
-        }
-      }
-      return child;
-    });
-  };
+  const props = { ...defaultSettingsContainerProps, ...inputProps };
 
   return (
     <SettingsDivContainer $gapPx={props.gapPx} $indentPx={props.indentPx} $labelWidth={props.labelWidth}>
-      {renderChildren(props.children)}
+      {props.children}
     </SettingsDivContainer>
   );
 }

--- a/src/components/SettingsContainer.tsx
+++ b/src/components/SettingsContainer.tsx
@@ -2,13 +2,13 @@ import React, { useEffect } from "react";
 import { PropsWithChildren, ReactElement } from "react";
 import styled, { css } from "styled-components";
 
-const SETTINGS_LABEL_CLASS = "settings-label";
+const SETTINGS_ITEM_CLASS = "settings-item";
 
 type SettingsItemProps = {
   /** A string or ReactElement label. Strings will be displayed as `p`. Defaults to empty string ("").*/
   label?: string | ReactElement;
   /** HTML ID applied to the `label` element, if `label` is a string. */
-  id?: string;
+  labelId?: string;
   /** HTML `for` attribute applied to the `label` element, if `label` is a string. */
   htmlFor?: string;
   /** A formatting function that will be applied to the label. If defined, overrides `labelFormatter`
@@ -43,18 +43,18 @@ export function SettingsItem(inputProps: PropsWithChildren<Partial<SettingsItemP
     }
   }, [props.label, props.htmlFor]);
 
-  let labelElement = <div className={SETTINGS_LABEL_CLASS}></div>;
+  let labelElement = <div></div>;
   if (props.label) {
     const formattedLabel = props.labelFormatter ? props.labelFormatter(props.label) : props.label;
     labelElement = (
-      <label style={props.labelStyle} id={props.id} htmlFor={props.htmlFor} className={SETTINGS_LABEL_CLASS}>
+      <label style={props.labelStyle} id={props.labelId} htmlFor={props.htmlFor}>
         {formattedLabel}
       </label>
     );
   }
 
   return (
-    <div style={props.style}>
+    <div style={props.style} className={SETTINGS_ITEM_CLASS}>
       {labelElement}
       {props.children}
     </div>
@@ -66,8 +66,8 @@ export function SettingsItem(inputProps: PropsWithChildren<Partial<SettingsItemP
  *
  * For all children matching the following pattern:
  * ```
- * <div>
- *   <label>Some Label Text</label>
+ * <div className="settings-item">
+ *   <any>Some Label Text</any>
  *   <... any element ...>
  * </div>
  * ```
@@ -88,7 +88,7 @@ const SettingsDivContainer = styled.div<{ $labelWidth?: string; $gapPx?: number;
     `;
   }}
 
-  & > div:has(.${SETTINGS_LABEL_CLASS}) {
+  & > div.${SETTINGS_ITEM_CLASS} {
     grid-column: 1 / 3; // Labels span both columns
     display: grid;
     grid-template-columns: subgrid;
@@ -99,14 +99,14 @@ const SettingsDivContainer = styled.div<{ $labelWidth?: string; $gapPx?: number;
       `;
     }}
 
-    & > ${"." + SETTINGS_LABEL_CLASS}:first-of-type {
+    & > :first-child {
       display: grid;
       grid-column: 1;
       align-items: center;
       text-align: right;
     }
 
-    & > :not(${"." + SETTINGS_LABEL_CLASS}:first-of-type) {
+    & > :not(:first-child) {
       grid-column: 2;
       // Lines up the bottom of the input with the bottom of the label,
       // where the colon separator is.
@@ -142,11 +142,11 @@ const defaultSettingsContainerProps: Partial<SettingsContainerProps> = {
  * @example
  * ```
  * <SettingsContainer>
- *   <SettingsItem label="Name:">
- *     <input type="text" />
+ *   <SettingsItem label="Name:" htmlFor="name-input">
+ *     <input type="text" id="name-input"/>
  *   </SettingsItem>
- *   <SettingsItem label="Reset:">
- *     <button>Reset</button>
+ *   <SettingsItem label="Reset:" htmlFor="reset-button">
+ *     <button id="reset-button">Reset</button>
  *   </SettingsItem>
  *   <SettingsItem>  // no label
  *     <input type="checkbox" />

--- a/src/components/SettingsContainer.tsx
+++ b/src/components/SettingsContainer.tsx
@@ -5,11 +5,11 @@ import styled, { css } from "styled-components";
 const SETTINGS_ITEM_CLASS = "settings-item";
 
 type SettingsItemProps = {
-  /** A string or ReactElement label. Strings will be displayed as `p`. Defaults to empty string ("").*/
+  /** A string or ReactElement label, placed inside of a `label` tag.*/
   label?: string | ReactElement;
-  /** HTML ID applied to the `label` element, if `label` is a string. */
+  /** HTML ID applied to the `label` element.*/
   labelId?: string;
-  /** HTML `for` attribute applied to the `label` element, if `label` is a string. */
+  /** HTML `for` attribute applied to the `label` element. */
   htmlFor?: string;
   /** A formatting function that will be applied to the label. If defined, overrides `labelFormatter`
    * of the parent `SettingsContainer`. */
@@ -36,7 +36,7 @@ export function SettingsItem(inputProps: PropsWithChildren<Partial<SettingsItemP
   }
 
   useEffect(() => {
-    if (props.label && typeof props.label === "string" && !props.htmlFor) {
+    if (props.label && !props.htmlFor) {
       console.warn(
         "SettingsItem: Please set the 'htmlFor' attribute to support screen readers in setting '" + props.label + "'."
       );

--- a/src/components/SpinBox.tsx
+++ b/src/components/SpinBox.tsx
@@ -5,6 +5,7 @@ import { SpinBoxHandleDownSVG, SpinBoxHandleUpSVG } from "../assets";
 import styles from "./SpinBox.module.css";
 
 type SpinBoxProps = {
+  id?: string;
   min?: number;
   max?: number;
   value: number;
@@ -109,6 +110,7 @@ export default function SpinBox(propsInput: SpinBoxProps): ReactElement {
     >
       <input
         type="number"
+        id={props.id}
         min={props.min}
         max={props.max}
         value={inputValue}

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -23,7 +23,8 @@ import AnnotationModeButton from "./AnnotationModeButton";
 import CreateLabelForm from "./CreateLabelForm";
 import LabelEditControls from "./LabelEditControls";
 
-const LABEL_DROPDOWN_LABEL_ID = "label-dropdown-label";
+const ANNOTATION_KEY_SELECT_ID = "annotation-key-select";
+
 const enum AnnotationViewType {
   TABLE,
   LIST,
@@ -162,17 +163,19 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
   const valueToIds = isMultiValueLabel ? selectedLabel.valueToIds : undefined;
 
   const labelSelectionDropdown = (
-    <>
-      <VisuallyHidden id={LABEL_DROPDOWN_LABEL_ID}>Current label</VisuallyHidden>
+    <FlexRow>
+      <label htmlFor={ANNOTATION_KEY_SELECT_ID}>
+        <VisuallyHidden>Current label</VisuallyHidden>
+      </label>
       <SelectionDropdown
+        id={ANNOTATION_KEY_SELECT_ID}
         selected={(currentLabelIdx ?? -1).toString()}
         items={selectLabelOptions}
         onChange={onSelectLabelIdx}
         disabled={currentLabelIdx === null}
         showSelectedItemTooltip={false}
-        htmlLabelId={LABEL_DROPDOWN_LABEL_ID}
       ></SelectionDropdown>
-    </>
+    </FlexRow>
   );
 
   return (

--- a/src/components/Tabs/Annotation/AnnotationTab.tsx
+++ b/src/components/Tabs/Annotation/AnnotationTab.tsx
@@ -209,6 +209,7 @@ export default function AnnotationTab(props: AnnotationTabProps): ReactElement {
         >
           <div style={{ marginTop: "15px" }}>
             <CreateLabelForm
+              baseId="annotation-create-label-modal"
               initialLabelOptions={annotationData.getNextDefaultLabelSettings()}
               onConfirm={(options: Partial<LabelOptions>) => {
                 onCreateNewLabel(options);

--- a/src/components/Tabs/Annotation/CreateLabelForm.tsx
+++ b/src/components/Tabs/Annotation/CreateLabelForm.tsx
@@ -1,15 +1,16 @@
-import { Button, Checkbox, ColorPicker, ConfigProvider, Input, InputRef, Radio } from "antd";
+import { Button, Checkbox, ConfigProvider, Input, InputRef, Radio } from "antd";
 import React, { ReactElement, useContext, useEffect, useRef, useState } from "react";
 import { Color, ColorRepresentation } from "three";
 
 import { FlexColumn, FlexRow } from "../../../styles/utils";
 import { threeToAntColor } from "../../../utils/color_utils";
+import { DEFAULT_LABEL_COLOR_PRESETS } from "../../../utils/color_utils";
 
 import { CSV_COL_ID, CSV_COL_TIME, CSV_COL_TRACK, LabelOptions, LabelType } from "../../../colorizer/AnnotationData";
 import { AppThemeContext, Z_INDEX_POPOVER } from "../../AppStyle";
+import WrappedColorPicker from "../../Inputs/WrappedColorPicker";
 import { SettingsContainer, SettingsItem } from "../../SettingsContainer";
 import { TooltipWithSubtitle } from "../../Tooltips/TooltipWithSubtitle";
-import { DEFAULT_LABEL_COLOR_PRESETS } from "./LabelEditControls";
 
 type CreateLabelFormProps = {
   initialLabelOptions: LabelOptions;
@@ -114,7 +115,7 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
            */}
           <ConfigProvider theme={{ components: { Popover: { zIndexPopup: props.zIndex } } }}>
             <div ref={colorPickerContainerRef}>
-              <ColorPicker
+              <WrappedColorPicker
                 size="small"
                 value={threeToAntColor(color)}
                 onChange={onColorPickerChange}

--- a/src/components/Tabs/Annotation/CreateLabelForm.tsx
+++ b/src/components/Tabs/Annotation/CreateLabelForm.tsx
@@ -4,22 +4,36 @@ import { Color, ColorRepresentation } from "three";
 
 import { FlexColumn, FlexRow } from "../../../styles/utils";
 import { threeToAntColor } from "../../../utils/color_utils";
-import { DEFAULT_LABEL_COLOR_PRESETS } from "../../../utils/color_utils";
 
-import { CSV_COL_ID, CSV_COL_TIME, CSV_COL_TRACK, LabelOptions, LabelType } from "../../../colorizer/AnnotationData";
+import {
+  CSV_COL_ID,
+  CSV_COL_TIME,
+  CSV_COL_TRACK,
+  DEFAULT_ANNOTATION_LABEL_COLORS,
+  LabelOptions,
+  LabelType,
+} from "../../../colorizer/AnnotationData";
 import { AppThemeContext, Z_INDEX_POPOVER } from "../../AppStyle";
 import WrappedColorPicker from "../../Inputs/WrappedColorPicker";
 import { SettingsContainer, SettingsItem } from "../../SettingsContainer";
 import { TooltipWithSubtitle } from "../../Tooltips/TooltipWithSubtitle";
 
-const enum HtmlIDs {
-  NAME_INPUT = "create-label-name-input",
-  COLOR_PICKER = "create-label-color-picker",
-  LABEL_TYPE_RADIO_GROUP = "create-label-type-radio-group",
-  AUTO_INCREMENT_CHECKBOX = "create-label-auto-increment-checkbox",
+const DEFAULT_LABEL_COLOR_PRESETS = [
+  {
+    label: "Presets",
+    colors: DEFAULT_ANNOTATION_LABEL_COLORS,
+  },
+];
+
+const enum HtmlIds {
+  NAME_INPUT = "-create-label-name-input",
+  COLOR_PICKER = "-create-label-color-picker",
+  LABEL_TYPE_RADIO_GROUP = "-create-label-type-radio-group",
+  AUTO_INCREMENT_CHECKBOX = "-create-label-auto-increment-checkbox",
 }
 
 type CreateLabelFormProps = {
+  baseId: string;
   initialLabelOptions: LabelOptions;
   onConfirm: (options: Partial<LabelOptions>) => void;
   onCancel: () => void;
@@ -52,6 +66,7 @@ const isMetadataColumnName = (name: string): boolean => {
 
 export default function CreateLabelForm(inputProps: CreateLabelFormProps): ReactElement {
   const props = { ...defaultProps, ...inputProps };
+  const { baseId } = props;
 
   const [colorPickerOpenState, setColorPickerOpenState] = useState(false);
   const onColorPickerOpenChange = (open: boolean): void => {
@@ -106,9 +121,9 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
   return (
     <FlexColumn style={{ width: "300px" }} $gap={10}>
       <SettingsContainer gapPx={8}>
-        <SettingsItem label="Name" labelStyle={{ margin: "2px 0 auto 0" }} htmlFor={HtmlIDs.NAME_INPUT}>
+        <SettingsItem label="Name" labelStyle={{ margin: "2px 0 auto 0" }} htmlFor={baseId + HtmlIds.NAME_INPUT}>
           <Input
-            id={HtmlIDs.NAME_INPUT}
+            id={baseId + HtmlIds.NAME_INPUT}
             value={nameInput}
             onChange={(e) => setNameInput(e.target.value)}
             onPressEnter={confirm}
@@ -116,9 +131,9 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
           ></Input>
           {nameInputError && <p style={{ color: theme.color.text.error }}>{nameInputError}</p>}
         </SettingsItem>
-        <SettingsItem label="Color" htmlFor={HtmlIDs.COLOR_PICKER}>
+        <SettingsItem label="Color" htmlFor={baseId + HtmlIds.COLOR_PICKER}>
           <WrappedColorPicker
-            id={HtmlIDs.COLOR_PICKER}
+            id={baseId + HtmlIds.COLOR_PICKER}
             size="small"
             value={threeToAntColor(color)}
             onChange={onColorPickerChange}
@@ -128,10 +143,14 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
             open={colorPickerOpen}
           />
         </SettingsItem>
-        <SettingsItem label="Type" labelStyle={{ marginBottom: "auto" }} htmlFor={HtmlIDs.LABEL_TYPE_RADIO_GROUP}>
+        <SettingsItem
+          label="Type"
+          labelStyle={{ marginBottom: "auto" }}
+          htmlFor={baseId + HtmlIds.LABEL_TYPE_RADIO_GROUP}
+        >
           {props.allowTypeSelection ? (
             <Radio.Group
-              id={HtmlIDs.LABEL_TYPE_RADIO_GROUP}
+              id={baseId + HtmlIds.LABEL_TYPE_RADIO_GROUP}
               value={labelType}
               onChange={(e) => setLabelType(e.target.value)}
               style={{ width: "100%", position: "relative" }}
@@ -156,7 +175,7 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
             >
               <div ref={autoIncrementContainerRef} style={{ width: "fit-content" }}>
                 <Checkbox
-                  id={HtmlIDs.AUTO_INCREMENT_CHECKBOX}
+                  id={baseId + HtmlIds.AUTO_INCREMENT_CHECKBOX}
                   checked={autoIncrement}
                   onChange={(e) => {
                     setAutoIncrement(e.target.checked);

--- a/src/components/Tabs/Annotation/CreateLabelForm.tsx
+++ b/src/components/Tabs/Annotation/CreateLabelForm.tsx
@@ -25,7 +25,7 @@ const DEFAULT_LABEL_COLOR_PRESETS = [
   },
 ];
 
-const enum HtmlIds {
+const enum CreateLabelFormHtmlIds {
   NAME_INPUT = "-create-label-name-input",
   COLOR_PICKER = "-create-label-color-picker",
   LABEL_TYPE_RADIO_GROUP = "-create-label-type-radio-group",
@@ -121,9 +121,13 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
   return (
     <FlexColumn style={{ width: "300px" }} $gap={10}>
       <SettingsContainer gapPx={8}>
-        <SettingsItem label="Name" labelStyle={{ margin: "2px 0 auto 0" }} htmlFor={baseId + HtmlIds.NAME_INPUT}>
+        <SettingsItem
+          label="Name"
+          labelStyle={{ margin: "2px 0 auto 0" }}
+          htmlFor={baseId + CreateLabelFormHtmlIds.NAME_INPUT}
+        >
           <Input
-            id={baseId + HtmlIds.NAME_INPUT}
+            id={baseId + CreateLabelFormHtmlIds.NAME_INPUT}
             value={nameInput}
             onChange={(e) => setNameInput(e.target.value)}
             onPressEnter={confirm}
@@ -131,9 +135,9 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
           ></Input>
           {nameInputError && <p style={{ color: theme.color.text.error }}>{nameInputError}</p>}
         </SettingsItem>
-        <SettingsItem label="Color" htmlFor={baseId + HtmlIds.COLOR_PICKER}>
+        <SettingsItem label="Color" htmlFor={baseId + CreateLabelFormHtmlIds.COLOR_PICKER}>
           <WrappedColorPicker
-            id={baseId + HtmlIds.COLOR_PICKER}
+            id={baseId + CreateLabelFormHtmlIds.COLOR_PICKER}
             size="small"
             value={threeToAntColor(color)}
             onChange={onColorPickerChange}
@@ -146,11 +150,11 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
         <SettingsItem
           label="Type"
           labelStyle={{ marginBottom: "auto" }}
-          htmlFor={baseId + HtmlIds.LABEL_TYPE_RADIO_GROUP}
+          htmlFor={baseId + CreateLabelFormHtmlIds.LABEL_TYPE_RADIO_GROUP}
         >
           {props.allowTypeSelection ? (
             <Radio.Group
-              id={baseId + HtmlIds.LABEL_TYPE_RADIO_GROUP}
+              id={baseId + CreateLabelFormHtmlIds.LABEL_TYPE_RADIO_GROUP}
               value={labelType}
               onChange={(e) => setLabelType(e.target.value)}
               style={{ width: "100%", position: "relative" }}
@@ -161,7 +165,10 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
               <Radio value={LabelType.CUSTOM}>Custom</Radio>
             </Radio.Group>
           ) : (
-            <p style={{ margin: 0, color: theme.color.text.hint }} id={baseId + HtmlIds.LABEL_TYPE_RADIO_GROUP}>
+            <p
+              style={{ margin: 0, color: theme.color.text.hint }}
+              id={baseId + CreateLabelFormHtmlIds.LABEL_TYPE_RADIO_GROUP}
+            >
               {labelTypeToDisplayName[labelType]}
             </p>
           )}
@@ -177,7 +184,7 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
             >
               <div ref={autoIncrementContainerRef} style={{ width: "fit-content" }}>
                 <Checkbox
-                  id={baseId + HtmlIds.AUTO_INCREMENT_CHECKBOX}
+                  id={baseId + CreateLabelFormHtmlIds.AUTO_INCREMENT_CHECKBOX}
                   checked={autoIncrement}
                   onChange={(e) => {
                     setAutoIncrement(e.target.checked);

--- a/src/components/Tabs/Annotation/CreateLabelForm.tsx
+++ b/src/components/Tabs/Annotation/CreateLabelForm.tsx
@@ -161,7 +161,9 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
               <Radio value={LabelType.CUSTOM}>Custom</Radio>
             </Radio.Group>
           ) : (
-            <p style={{ margin: 0, color: theme.color.text.hint }}>{labelTypeToDisplayName[labelType]}</p>
+            <p style={{ margin: 0, color: theme.color.text.hint }} id={baseId + HtmlIds.LABEL_TYPE_RADIO_GROUP}>
+              {labelTypeToDisplayName[labelType]}
+            </p>
           )}
         </SettingsItem>
         {labelType === LabelType.INTEGER && (

--- a/src/components/Tabs/Annotation/CreateLabelForm.tsx
+++ b/src/components/Tabs/Annotation/CreateLabelForm.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, ConfigProvider, Input, InputRef, Radio } from "antd";
+import { Button, Checkbox, Input, InputRef, Radio } from "antd";
 import React, { ReactElement, useContext, useEffect, useRef, useState } from "react";
 import { Color, ColorRepresentation } from "three";
 
@@ -11,6 +11,13 @@ import { AppThemeContext, Z_INDEX_POPOVER } from "../../AppStyle";
 import WrappedColorPicker from "../../Inputs/WrappedColorPicker";
 import { SettingsContainer, SettingsItem } from "../../SettingsContainer";
 import { TooltipWithSubtitle } from "../../Tooltips/TooltipWithSubtitle";
+
+const enum HtmlIDs {
+  NAME_INPUT = "create-label-name-input",
+  COLOR_PICKER = "create-label-color-picker",
+  LABEL_TYPE_RADIO_GROUP = "create-label-type-radio-group",
+  AUTO_INCREMENT_CHECKBOX = "create-label-auto-increment-checkbox",
+}
 
 type CreateLabelFormProps = {
   initialLabelOptions: LabelOptions;
@@ -52,9 +59,9 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
     props.onColorPickerOpenChange?.(open);
   };
   const colorPickerOpen = props.colorPickerOpen ?? colorPickerOpenState;
-  const colorPickerContainerRef = useRef<HTMLDivElement>(null);
 
   const [labelType, setLabelType] = useState<LabelType>(props.initialLabelOptions.type);
+  const autoIncrementContainerRef = useRef<HTMLDivElement>(null);
   const [autoIncrement, setAutoIncrement] = useState(props.initialLabelOptions.autoIncrement);
   const [color, setColor] = useState(props.initialLabelOptions.color);
   const [nameInput, setNameInput] = useState(props.initialLabelOptions.name);
@@ -99,8 +106,9 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
   return (
     <FlexColumn style={{ width: "300px" }} $gap={10}>
       <SettingsContainer gapPx={8}>
-        <SettingsItem label="Name" labelStyle={{ margin: "2px 0 auto 0" }}>
+        <SettingsItem label="Name" labelStyle={{ margin: "2px 0 auto 0" }} htmlFor={HtmlIDs.NAME_INPUT}>
           <Input
+            id={HtmlIDs.NAME_INPUT}
             value={nameInput}
             onChange={(e) => setNameInput(e.target.value)}
             onPressEnter={confirm}
@@ -108,29 +116,22 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
           ></Input>
           {nameInputError && <p style={{ color: theme.color.text.error }}>{nameInputError}</p>}
         </SettingsItem>
-        <SettingsItem label="Color">
-          {/* TODO: This is a fix for a bug where the ColorPicker's popover cannot have its
-           * containing element set. This means that we have to manually set the zIndex
-           * if it's in a modal or other element with a higher zIndex.
-           */}
-          <ConfigProvider theme={{ components: { Popover: { zIndexPopup: props.zIndex } } }}>
-            <div ref={colorPickerContainerRef}>
-              <WrappedColorPicker
-                size="small"
-                value={threeToAntColor(color)}
-                onChange={onColorPickerChange}
-                disabledAlpha={true}
-                presets={DEFAULT_LABEL_COLOR_PRESETS}
-                onOpenChange={onColorPickerOpenChange}
-                open={colorPickerOpen}
-                getPopupContainer={() => colorPickerContainerRef.current || document.body}
-              />
-            </div>
-          </ConfigProvider>
+        <SettingsItem label="Color" htmlFor={HtmlIDs.COLOR_PICKER}>
+          <WrappedColorPicker
+            id={HtmlIDs.COLOR_PICKER}
+            size="small"
+            value={threeToAntColor(color)}
+            onChange={onColorPickerChange}
+            disabledAlpha={true}
+            presets={DEFAULT_LABEL_COLOR_PRESETS}
+            onOpenChange={onColorPickerOpenChange}
+            open={colorPickerOpen}
+          />
         </SettingsItem>
-        <SettingsItem label="Type" labelStyle={{ marginBottom: "auto" }}>
+        <SettingsItem label="Type" labelStyle={{ marginBottom: "auto" }} htmlFor={HtmlIDs.LABEL_TYPE_RADIO_GROUP}>
           {props.allowTypeSelection ? (
             <Radio.Group
+              id={HtmlIDs.LABEL_TYPE_RADIO_GROUP}
               value={labelType}
               onChange={(e) => setLabelType(e.target.value)}
               style={{ width: "100%", position: "relative" }}
@@ -145,15 +146,17 @@ export default function CreateLabelForm(inputProps: CreateLabelFormProps): React
           )}
         </SettingsItem>
         {labelType === LabelType.INTEGER && (
-          <SettingsItem label="">
+          <SettingsItem>
             <TooltipWithSubtitle
               trigger={["hover", "focus"]}
               title="Increments the value on each click"
               subtitle="Hold Ctrl to reuse last value"
               placement="right"
+              getPopupContainer={() => autoIncrementContainerRef.current ?? document.body}
             >
-              <div>
+              <div ref={autoIncrementContainerRef} style={{ width: "fit-content" }}>
                 <Checkbox
+                  id={HtmlIDs.AUTO_INCREMENT_CHECKBOX}
                   checked={autoIncrement}
                   onChange={(e) => {
                     setAutoIncrement(e.target.checked);

--- a/src/components/Tabs/Annotation/LabelEditControls.tsx
+++ b/src/components/Tabs/Annotation/LabelEditControls.tsx
@@ -7,18 +7,11 @@ import { AnnotationSelectionMode } from "../../../colorizer";
 import { StyledRadioGroup } from "../../../styles/components";
 import { formatQuantityString } from "../../../utils/formatting";
 
-import { DEFAULT_ANNOTATION_LABEL_COLORS, LabelData, LabelOptions } from "../../../colorizer/AnnotationData";
+import { LabelData, LabelOptions } from "../../../colorizer/AnnotationData";
 import { AppThemeContext } from "../../AppStyle";
 import IconButton from "../../IconButton";
 import { TooltipWithSubtitle } from "../../Tooltips/TooltipWithSubtitle";
 import CreateLabelForm from "./CreateLabelForm";
-
-export const DEFAULT_LABEL_COLOR_PRESETS = [
-  {
-    label: "Presets",
-    colors: DEFAULT_ANNOTATION_LABEL_COLORS,
-  },
-];
 
 type LabelEditControlsProps = {
   onCreateNewLabel: (options: Partial<LabelOptions>) => void;

--- a/src/components/Tabs/Annotation/LabelEditControls.tsx
+++ b/src/components/Tabs/Annotation/LabelEditControls.tsx
@@ -135,6 +135,7 @@ export default function LabelEditControls(props: PropsWithChildren<LabelEditCont
         placement="bottom"
         content={
           <CreateLabelForm
+            baseId="label-edit-controls-create-button"
             initialLabelOptions={props.defaultLabelOptions}
             onConfirm={props.onCreateNewLabel}
             onCancel={() => setShowCreatePopover(false)}
@@ -161,6 +162,7 @@ export default function LabelEditControls(props: PropsWithChildren<LabelEditCont
         placement="bottom"
         content={
           <CreateLabelForm
+            baseId="label-edit-controls-edit-button"
             initialLabelOptions={props.selectedLabel.options}
             onConfirm={onClickEditSave}
             onCancel={onClickEditCancel}

--- a/src/components/Tabs/FeatureThresholdsTab.tsx
+++ b/src/components/Tabs/FeatureThresholdsTab.tsx
@@ -20,7 +20,7 @@ import { FlexColumn } from "../../styles/utils";
 import { FeatureType } from "../../colorizer/Dataset";
 import { useViewerStateStore } from "../../state/ViewerState";
 import IconButton from "../IconButton";
-import LabeledSlider from "../LabeledSlider";
+import LabeledSlider from "../Inputs/LabeledSlider";
 
 const PanelContainer = styled(FlexColumn)`
   flex-grow: 1;

--- a/src/components/Tabs/Settings/VectorFieldSettings.tsx
+++ b/src/components/Tabs/Settings/VectorFieldSettings.tsx
@@ -1,4 +1,4 @@
-import { Card, Checkbox, ColorPicker, Radio } from "antd";
+import { Card, Checkbox, Radio } from "antd";
 import React, { ReactElement, useMemo } from "react";
 import { Color, ColorRepresentation } from "three";
 
@@ -18,6 +18,13 @@ const VECTOR_OPTION_MOTION = {
   value: VECTOR_KEY_MOTION_DELTA,
   label: "Avg. movement delta (auto-calculated)",
 };
+
+const ID_SHOW_VECTOR_ARROWS_CHECKBOX = "show-vector-arrows-checkbox";
+const ID_VECTOR_KEY_SELECT = "vector-key-select";
+const ID_VECTOR_SCALE_FACTOR_SLIDER = "vector-scale-factor-slider";
+const ID_VECTOR_COLOR_PICKER = "vector-color-picker";
+const ID_VECTOR_MOTION_TIME_INTERVALS_SLIDER = "vector-motion-time-intervals-slider";
+const ID_VECTOR_TOOLTIP_MODE_RADIO = "vector-tooltip-mode-radio";
 
 export default function VectorFieldSettings(): ReactElement {
   const dataset = useViewerStateStore((state) => state.dataset);
@@ -40,10 +47,11 @@ export default function VectorFieldSettings(): ReactElement {
 
   return (
     <>
-      <SettingsItem label={"Show vector arrows"}>
+      <SettingsItem label={"Show vector arrows"} htmlFor={ID_SHOW_VECTOR_ARROWS_CHECKBOX}>
         <div>
           {/* TODO: Replace with a top-level checkbox for Vector arrows when Collapse menus are removed */}
           <Checkbox
+            id={ID_SHOW_VECTOR_ARROWS_CHECKBOX}
             checked={vectorVisible}
             onChange={(e) => setVectorVisible(e.target.checked)}
             disabled={dataset === null}
@@ -51,8 +59,13 @@ export default function VectorFieldSettings(): ReactElement {
         </div>
       </SettingsItem>
 
-      <SettingsItem label="Vector" labelStyle={{ height: "min-content", paddingTop: "2px" }}>
+      <SettingsItem
+        label="Vector"
+        labelStyle={{ height: "min-content", paddingTop: "2px" }}
+        htmlFor={ID_VECTOR_KEY_SELECT}
+      >
         <SelectionDropdown
+          id={ID_VECTOR_KEY_SELECT}
           disabled={!vectorOptionsEnabled}
           selected={vectorKey}
           items={vectorOptions}
@@ -61,9 +74,10 @@ export default function VectorFieldSettings(): ReactElement {
         {vectorKey === VECTOR_KEY_MOTION_DELTA && vectorOptionsEnabled && (
           <Card style={{ position: "relative", width: "fit-content", marginTop: "10px" }} size="small">
             <SettingsContainer>
-              <SettingsItem label="Average over # time intervals">
+              <SettingsItem label="Average over # time intervals" htmlFor={ID_VECTOR_MOTION_TIME_INTERVALS_SLIDER}>
                 <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
                   <LabeledSlider
+                    id={ID_VECTOR_MOTION_TIME_INTERVALS_SLIDER}
                     type="value"
                     disabled={!vectorOptionsEnabled}
                     step={1}
@@ -87,9 +101,10 @@ export default function VectorFieldSettings(): ReactElement {
        * all deltas.
        * See examples in https://github.com/react-component/slider/issues/393.
        */}
-      <SettingsItem label={"Scale factor"}>
+      <SettingsItem label={"Scale factor"} htmlFor={ID_VECTOR_SCALE_FACTOR_SLIDER}>
         <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
           <LabeledSlider
+            id={ID_VECTOR_SCALE_FACTOR_SLIDER}
             disabled={!vectorOptionsEnabled}
             type="value"
             minSliderBound={0}
@@ -115,9 +130,14 @@ export default function VectorFieldSettings(): ReactElement {
           presets={DEFAULT_OUTLINE_COLOR_PRESETS}
         ></WrappedColorPicker>
       </SettingsItem>
-      <SettingsItem label="Show vector in tooltip as" labelStyle={{ height: "fit-content" }}>
+      <SettingsItem
+        label="Show vector in tooltip as"
+        labelStyle={{ height: "fit-content" }}
+        htmlFor={ID_VECTOR_TOOLTIP_MODE_RADIO}
+      >
         <div style={{ width: "fit-content" }}>
           <Radio.Group
+            id={ID_VECTOR_TOOLTIP_MODE_RADIO}
             value={vectorTooltipMode}
             onChange={(e) => setVectorTooltipMode(e.target.value)}
             disabled={!vectorOptionsEnabled}

--- a/src/components/Tabs/Settings/VectorFieldSettings.tsx
+++ b/src/components/Tabs/Settings/VectorFieldSettings.tsx
@@ -9,7 +9,8 @@ import { DEFAULT_OUTLINE_COLOR_PRESETS } from "./constants";
 
 import { useViewerStateStore } from "../../../state/ViewerState";
 import SelectionDropdown from "../../Dropdowns/SelectionDropdown";
-import LabeledSlider from "../../LabeledSlider";
+import LabeledSlider from "../../Inputs/LabeledSlider";
+import WrappedColorPicker from "../../Inputs/WrappedColorPicker";
 import { SettingsContainer, SettingsItem } from "../../SettingsContainer";
 import { MAX_SLIDER_WIDTH } from "../SettingsTab";
 
@@ -101,19 +102,18 @@ export default function VectorFieldSettings(): ReactElement {
           />
         </div>
       </SettingsItem>
-      <SettingsItem label="Arrow color">
-        <div>
-          <ColorPicker
-            disabled={!vectorOptionsEnabled}
-            disabledAlpha={true}
-            size="small"
-            value={threeToAntColor(vectorColor)}
-            onChange={(_color, hex) => {
-              setVectorColor(new Color(hex as ColorRepresentation));
-            }}
-            presets={DEFAULT_OUTLINE_COLOR_PRESETS}
-          ></ColorPicker>
-        </div>
+      <SettingsItem label="Arrow color" htmlFor={ID_VECTOR_COLOR_PICKER}>
+        <WrappedColorPicker
+          id={ID_VECTOR_COLOR_PICKER}
+          disabled={!vectorOptionsEnabled}
+          disabledAlpha={true}
+          size="small"
+          value={threeToAntColor(vectorColor)}
+          onChange={(_color, hex) => {
+            setVectorColor(new Color(hex as ColorRepresentation));
+          }}
+          presets={DEFAULT_OUTLINE_COLOR_PRESETS}
+        ></WrappedColorPicker>
       </SettingsItem>
       <SettingsItem label="Show vector in tooltip as" labelStyle={{ height: "fit-content" }}>
         <div style={{ width: "fit-content" }}>

--- a/src/components/Tabs/Settings/VectorFieldSettings.tsx
+++ b/src/components/Tabs/Settings/VectorFieldSettings.tsx
@@ -20,12 +20,12 @@ const VECTOR_OPTION_MOTION = {
 };
 
 const enum HtmlIDs {
-  ID_SHOW_VECTOR_ARROWS_CHECKBOX = "show-vector-arrows-checkbox",
-  ID_VECTOR_KEY_SELECT = "vector-key-select",
-  ID_VECTOR_SCALE_FACTOR_SLIDER = "vector-scale-factor-slider",
-  ID_VECTOR_COLOR_PICKER = "vector-color-picker",
-  ID_VECTOR_MOTION_TIME_INTERVALS_SLIDER = "vector-motion-time-intervals-slider",
-  ID_VECTOR_TOOLTIP_MODE_RADIO = "vector-tooltip-mode-radio",
+  SHOW_VECTOR_ARROWS_CHECKBOX = "show-vector-arrows-checkbox",
+  VECTOR_KEY_SELECT = "vector-key-select",
+  VECTOR_SCALE_FACTOR_SLIDER = "vector-scale-factor-slider",
+  VECTOR_COLOR_PICKER = "vector-color-picker",
+  VECTOR_MOTION_TIME_INTERVALS_SLIDER = "vector-motion-time-intervals-slider",
+  VECTOR_TOOLTIP_MODE_RADIO = "vector-tooltip-mode-radio",
 }
 
 export default function VectorFieldSettings(): ReactElement {
@@ -49,11 +49,11 @@ export default function VectorFieldSettings(): ReactElement {
 
   return (
     <>
-      <SettingsItem label={"Show vector arrows"} htmlFor={HtmlIDs.ID_SHOW_VECTOR_ARROWS_CHECKBOX}>
+      <SettingsItem label={"Show vector arrows"} htmlFor={HtmlIDs.SHOW_VECTOR_ARROWS_CHECKBOX}>
         <div style={{ width: "fit-content" }}>
           {/* TODO: Replace with a top-level checkbox for Vector arrows when Collapse menus are removed */}
           <Checkbox
-            id={HtmlIDs.ID_SHOW_VECTOR_ARROWS_CHECKBOX}
+            id={HtmlIDs.SHOW_VECTOR_ARROWS_CHECKBOX}
             checked={vectorVisible}
             onChange={(e) => setVectorVisible(e.target.checked)}
             disabled={dataset === null}
@@ -64,10 +64,10 @@ export default function VectorFieldSettings(): ReactElement {
       <SettingsItem
         label="Vector"
         labelStyle={{ height: "min-content", paddingTop: "2px" }}
-        htmlFor={HtmlIDs.ID_VECTOR_KEY_SELECT}
+        htmlFor={HtmlIDs.VECTOR_KEY_SELECT}
       >
         <SelectionDropdown
-          id={HtmlIDs.ID_VECTOR_KEY_SELECT}
+          id={HtmlIDs.VECTOR_KEY_SELECT}
           disabled={!vectorOptionsEnabled}
           selected={vectorKey}
           items={vectorOptions}
@@ -76,13 +76,10 @@ export default function VectorFieldSettings(): ReactElement {
         {vectorKey === VECTOR_KEY_MOTION_DELTA && vectorOptionsEnabled && (
           <Card style={{ position: "relative", width: "fit-content", marginTop: "10px" }} size="small">
             <SettingsContainer>
-              <SettingsItem
-                label="Average over # time intervals"
-                htmlFor={HtmlIDs.ID_VECTOR_MOTION_TIME_INTERVALS_SLIDER}
-              >
+              <SettingsItem label="Average over # time intervals" htmlFor={HtmlIDs.VECTOR_MOTION_TIME_INTERVALS_SLIDER}>
                 <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
                   <LabeledSlider
-                    id={HtmlIDs.ID_VECTOR_MOTION_TIME_INTERVALS_SLIDER}
+                    id={HtmlIDs.VECTOR_MOTION_TIME_INTERVALS_SLIDER}
                     type="value"
                     disabled={!vectorOptionsEnabled}
                     step={1}
@@ -106,10 +103,10 @@ export default function VectorFieldSettings(): ReactElement {
        * all deltas.
        * See examples in https://github.com/react-component/slider/issues/393.
        */}
-      <SettingsItem label={"Scale factor"} htmlFor={HtmlIDs.ID_VECTOR_SCALE_FACTOR_SLIDER}>
+      <SettingsItem label={"Scale factor"} htmlFor={HtmlIDs.VECTOR_SCALE_FACTOR_SLIDER}>
         <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
           <LabeledSlider
-            id={HtmlIDs.ID_VECTOR_SCALE_FACTOR_SLIDER}
+            id={HtmlIDs.VECTOR_SCALE_FACTOR_SLIDER}
             disabled={!vectorOptionsEnabled}
             type="value"
             minSliderBound={0}
@@ -122,9 +119,9 @@ export default function VectorFieldSettings(): ReactElement {
           />
         </div>
       </SettingsItem>
-      <SettingsItem label="Arrow color" htmlFor={HtmlIDs.ID_VECTOR_COLOR_PICKER}>
+      <SettingsItem label="Arrow color" htmlFor={HtmlIDs.VECTOR_COLOR_PICKER}>
         <WrappedColorPicker
-          id={HtmlIDs.ID_VECTOR_COLOR_PICKER}
+          id={HtmlIDs.VECTOR_COLOR_PICKER}
           disabled={!vectorOptionsEnabled}
           disabledAlpha={true}
           size="small"
@@ -138,11 +135,11 @@ export default function VectorFieldSettings(): ReactElement {
       <SettingsItem
         label="Show vector in tooltip as"
         labelStyle={{ height: "fit-content" }}
-        htmlFor={HtmlIDs.ID_VECTOR_TOOLTIP_MODE_RADIO}
+        htmlFor={HtmlIDs.VECTOR_TOOLTIP_MODE_RADIO}
       >
         <div style={{ width: "fit-content" }}>
           <Radio.Group
-            id={HtmlIDs.ID_VECTOR_TOOLTIP_MODE_RADIO}
+            id={HtmlIDs.VECTOR_TOOLTIP_MODE_RADIO}
             value={vectorTooltipMode}
             onChange={(e) => setVectorTooltipMode(e.target.value)}
             disabled={!vectorOptionsEnabled}

--- a/src/components/Tabs/Settings/VectorFieldSettings.tsx
+++ b/src/components/Tabs/Settings/VectorFieldSettings.tsx
@@ -19,7 +19,7 @@ const VECTOR_OPTION_MOTION = {
   label: "Avg. movement delta (auto-calculated)",
 };
 
-const enum HtmlIds {
+const enum VectorSettingsHtmlIds {
   SHOW_VECTOR_ARROWS_CHECKBOX = "show-vector-arrows-checkbox",
   VECTOR_KEY_SELECT = "vector-key-select",
   VECTOR_SCALE_FACTOR_SLIDER = "vector-scale-factor-slider",
@@ -49,11 +49,11 @@ export default function VectorFieldSettings(): ReactElement {
 
   return (
     <>
-      <SettingsItem label={"Show vector arrows"} htmlFor={HtmlIds.SHOW_VECTOR_ARROWS_CHECKBOX}>
+      <SettingsItem label={"Show vector arrows"} htmlFor={VectorSettingsHtmlIds.SHOW_VECTOR_ARROWS_CHECKBOX}>
         <div style={{ width: "fit-content" }}>
           {/* TODO: Replace with a top-level checkbox for Vector arrows when Collapse menus are removed */}
           <Checkbox
-            id={HtmlIds.SHOW_VECTOR_ARROWS_CHECKBOX}
+            id={VectorSettingsHtmlIds.SHOW_VECTOR_ARROWS_CHECKBOX}
             checked={vectorVisible}
             onChange={(e) => setVectorVisible(e.target.checked)}
             disabled={dataset === null}
@@ -64,10 +64,10 @@ export default function VectorFieldSettings(): ReactElement {
       <SettingsItem
         label="Vector"
         labelStyle={{ height: "min-content", paddingTop: "2px" }}
-        htmlFor={HtmlIds.VECTOR_KEY_SELECT}
+        htmlFor={VectorSettingsHtmlIds.VECTOR_KEY_SELECT}
       >
         <SelectionDropdown
-          id={HtmlIds.VECTOR_KEY_SELECT}
+          id={VectorSettingsHtmlIds.VECTOR_KEY_SELECT}
           disabled={!vectorOptionsEnabled}
           selected={vectorKey}
           items={vectorOptions}
@@ -76,10 +76,13 @@ export default function VectorFieldSettings(): ReactElement {
         {vectorKey === VECTOR_KEY_MOTION_DELTA && vectorOptionsEnabled && (
           <Card style={{ position: "relative", width: "fit-content", marginTop: "10px" }} size="small">
             <SettingsContainer>
-              <SettingsItem label="Average over # time intervals" htmlFor={HtmlIds.VECTOR_MOTION_TIME_INTERVALS_SLIDER}>
+              <SettingsItem
+                label="Average over # time intervals"
+                htmlFor={VectorSettingsHtmlIds.VECTOR_MOTION_TIME_INTERVALS_SLIDER}
+              >
                 <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
                   <LabeledSlider
-                    id={HtmlIds.VECTOR_MOTION_TIME_INTERVALS_SLIDER}
+                    id={VectorSettingsHtmlIds.VECTOR_MOTION_TIME_INTERVALS_SLIDER}
                     type="value"
                     disabled={!vectorOptionsEnabled}
                     step={1}
@@ -103,10 +106,10 @@ export default function VectorFieldSettings(): ReactElement {
        * all deltas.
        * See examples in https://github.com/react-component/slider/issues/393.
        */}
-      <SettingsItem label={"Scale factor"} htmlFor={HtmlIds.VECTOR_SCALE_FACTOR_SLIDER}>
+      <SettingsItem label={"Scale factor"} htmlFor={VectorSettingsHtmlIds.VECTOR_SCALE_FACTOR_SLIDER}>
         <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
           <LabeledSlider
-            id={HtmlIds.VECTOR_SCALE_FACTOR_SLIDER}
+            id={VectorSettingsHtmlIds.VECTOR_SCALE_FACTOR_SLIDER}
             disabled={!vectorOptionsEnabled}
             type="value"
             minSliderBound={0}
@@ -119,9 +122,9 @@ export default function VectorFieldSettings(): ReactElement {
           />
         </div>
       </SettingsItem>
-      <SettingsItem label="Arrow color" htmlFor={HtmlIds.VECTOR_COLOR_PICKER}>
+      <SettingsItem label="Arrow color" htmlFor={VectorSettingsHtmlIds.VECTOR_COLOR_PICKER}>
         <WrappedColorPicker
-          id={HtmlIds.VECTOR_COLOR_PICKER}
+          id={VectorSettingsHtmlIds.VECTOR_COLOR_PICKER}
           disabled={!vectorOptionsEnabled}
           disabledAlpha={true}
           size="small"
@@ -135,11 +138,11 @@ export default function VectorFieldSettings(): ReactElement {
       <SettingsItem
         label="Show vector in tooltip as"
         labelStyle={{ height: "fit-content" }}
-        htmlFor={HtmlIds.VECTOR_TOOLTIP_MODE_RADIO}
+        htmlFor={VectorSettingsHtmlIds.VECTOR_TOOLTIP_MODE_RADIO}
       >
         <div style={{ width: "fit-content" }}>
           <Radio.Group
-            id={HtmlIds.VECTOR_TOOLTIP_MODE_RADIO}
+            id={VectorSettingsHtmlIds.VECTOR_TOOLTIP_MODE_RADIO}
             value={vectorTooltipMode}
             onChange={(e) => setVectorTooltipMode(e.target.value)}
             disabled={!vectorOptionsEnabled}

--- a/src/components/Tabs/Settings/VectorFieldSettings.tsx
+++ b/src/components/Tabs/Settings/VectorFieldSettings.tsx
@@ -19,12 +19,14 @@ const VECTOR_OPTION_MOTION = {
   label: "Avg. movement delta (auto-calculated)",
 };
 
-const ID_SHOW_VECTOR_ARROWS_CHECKBOX = "show-vector-arrows-checkbox";
-const ID_VECTOR_KEY_SELECT = "vector-key-select";
-const ID_VECTOR_SCALE_FACTOR_SLIDER = "vector-scale-factor-slider";
-const ID_VECTOR_COLOR_PICKER = "vector-color-picker";
-const ID_VECTOR_MOTION_TIME_INTERVALS_SLIDER = "vector-motion-time-intervals-slider";
-const ID_VECTOR_TOOLTIP_MODE_RADIO = "vector-tooltip-mode-radio";
+const enum HtmlIDs {
+  ID_SHOW_VECTOR_ARROWS_CHECKBOX = "show-vector-arrows-checkbox",
+  ID_VECTOR_KEY_SELECT = "vector-key-select",
+  ID_VECTOR_SCALE_FACTOR_SLIDER = "vector-scale-factor-slider",
+  ID_VECTOR_COLOR_PICKER = "vector-color-picker",
+  ID_VECTOR_MOTION_TIME_INTERVALS_SLIDER = "vector-motion-time-intervals-slider",
+  ID_VECTOR_TOOLTIP_MODE_RADIO = "vector-tooltip-mode-radio",
+}
 
 export default function VectorFieldSettings(): ReactElement {
   const dataset = useViewerStateStore((state) => state.dataset);
@@ -47,11 +49,11 @@ export default function VectorFieldSettings(): ReactElement {
 
   return (
     <>
-      <SettingsItem label={"Show vector arrows"} htmlFor={ID_SHOW_VECTOR_ARROWS_CHECKBOX}>
-        <div>
+      <SettingsItem label={"Show vector arrows"} htmlFor={HtmlIDs.ID_SHOW_VECTOR_ARROWS_CHECKBOX}>
+        <div style={{ width: "fit-content" }}>
           {/* TODO: Replace with a top-level checkbox for Vector arrows when Collapse menus are removed */}
           <Checkbox
-            id={ID_SHOW_VECTOR_ARROWS_CHECKBOX}
+            id={HtmlIDs.ID_SHOW_VECTOR_ARROWS_CHECKBOX}
             checked={vectorVisible}
             onChange={(e) => setVectorVisible(e.target.checked)}
             disabled={dataset === null}
@@ -62,10 +64,10 @@ export default function VectorFieldSettings(): ReactElement {
       <SettingsItem
         label="Vector"
         labelStyle={{ height: "min-content", paddingTop: "2px" }}
-        htmlFor={ID_VECTOR_KEY_SELECT}
+        htmlFor={HtmlIDs.ID_VECTOR_KEY_SELECT}
       >
         <SelectionDropdown
-          id={ID_VECTOR_KEY_SELECT}
+          id={HtmlIDs.ID_VECTOR_KEY_SELECT}
           disabled={!vectorOptionsEnabled}
           selected={vectorKey}
           items={vectorOptions}
@@ -74,10 +76,13 @@ export default function VectorFieldSettings(): ReactElement {
         {vectorKey === VECTOR_KEY_MOTION_DELTA && vectorOptionsEnabled && (
           <Card style={{ position: "relative", width: "fit-content", marginTop: "10px" }} size="small">
             <SettingsContainer>
-              <SettingsItem label="Average over # time intervals" htmlFor={ID_VECTOR_MOTION_TIME_INTERVALS_SLIDER}>
+              <SettingsItem
+                label="Average over # time intervals"
+                htmlFor={HtmlIDs.ID_VECTOR_MOTION_TIME_INTERVALS_SLIDER}
+              >
                 <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
                   <LabeledSlider
-                    id={ID_VECTOR_MOTION_TIME_INTERVALS_SLIDER}
+                    id={HtmlIDs.ID_VECTOR_MOTION_TIME_INTERVALS_SLIDER}
                     type="value"
                     disabled={!vectorOptionsEnabled}
                     step={1}
@@ -101,10 +106,10 @@ export default function VectorFieldSettings(): ReactElement {
        * all deltas.
        * See examples in https://github.com/react-component/slider/issues/393.
        */}
-      <SettingsItem label={"Scale factor"} htmlFor={ID_VECTOR_SCALE_FACTOR_SLIDER}>
+      <SettingsItem label={"Scale factor"} htmlFor={HtmlIDs.ID_VECTOR_SCALE_FACTOR_SLIDER}>
         <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
           <LabeledSlider
-            id={ID_VECTOR_SCALE_FACTOR_SLIDER}
+            id={HtmlIDs.ID_VECTOR_SCALE_FACTOR_SLIDER}
             disabled={!vectorOptionsEnabled}
             type="value"
             minSliderBound={0}
@@ -117,9 +122,9 @@ export default function VectorFieldSettings(): ReactElement {
           />
         </div>
       </SettingsItem>
-      <SettingsItem label="Arrow color" htmlFor={ID_VECTOR_COLOR_PICKER}>
+      <SettingsItem label="Arrow color" htmlFor={HtmlIDs.ID_VECTOR_COLOR_PICKER}>
         <WrappedColorPicker
-          id={ID_VECTOR_COLOR_PICKER}
+          id={HtmlIDs.ID_VECTOR_COLOR_PICKER}
           disabled={!vectorOptionsEnabled}
           disabledAlpha={true}
           size="small"
@@ -133,11 +138,11 @@ export default function VectorFieldSettings(): ReactElement {
       <SettingsItem
         label="Show vector in tooltip as"
         labelStyle={{ height: "fit-content" }}
-        htmlFor={ID_VECTOR_TOOLTIP_MODE_RADIO}
+        htmlFor={HtmlIDs.ID_VECTOR_TOOLTIP_MODE_RADIO}
       >
         <div style={{ width: "fit-content" }}>
           <Radio.Group
-            id={ID_VECTOR_TOOLTIP_MODE_RADIO}
+            id={HtmlIDs.ID_VECTOR_TOOLTIP_MODE_RADIO}
             value={vectorTooltipMode}
             onChange={(e) => setVectorTooltipMode(e.target.value)}
             disabled={!vectorOptionsEnabled}

--- a/src/components/Tabs/Settings/VectorFieldSettings.tsx
+++ b/src/components/Tabs/Settings/VectorFieldSettings.tsx
@@ -19,7 +19,7 @@ const VECTOR_OPTION_MOTION = {
   label: "Avg. movement delta (auto-calculated)",
 };
 
-const enum HtmlIDs {
+const enum HtmlIds {
   SHOW_VECTOR_ARROWS_CHECKBOX = "show-vector-arrows-checkbox",
   VECTOR_KEY_SELECT = "vector-key-select",
   VECTOR_SCALE_FACTOR_SLIDER = "vector-scale-factor-slider",
@@ -49,11 +49,11 @@ export default function VectorFieldSettings(): ReactElement {
 
   return (
     <>
-      <SettingsItem label={"Show vector arrows"} htmlFor={HtmlIDs.SHOW_VECTOR_ARROWS_CHECKBOX}>
+      <SettingsItem label={"Show vector arrows"} htmlFor={HtmlIds.SHOW_VECTOR_ARROWS_CHECKBOX}>
         <div style={{ width: "fit-content" }}>
           {/* TODO: Replace with a top-level checkbox for Vector arrows when Collapse menus are removed */}
           <Checkbox
-            id={HtmlIDs.SHOW_VECTOR_ARROWS_CHECKBOX}
+            id={HtmlIds.SHOW_VECTOR_ARROWS_CHECKBOX}
             checked={vectorVisible}
             onChange={(e) => setVectorVisible(e.target.checked)}
             disabled={dataset === null}
@@ -64,10 +64,10 @@ export default function VectorFieldSettings(): ReactElement {
       <SettingsItem
         label="Vector"
         labelStyle={{ height: "min-content", paddingTop: "2px" }}
-        htmlFor={HtmlIDs.VECTOR_KEY_SELECT}
+        htmlFor={HtmlIds.VECTOR_KEY_SELECT}
       >
         <SelectionDropdown
-          id={HtmlIDs.VECTOR_KEY_SELECT}
+          id={HtmlIds.VECTOR_KEY_SELECT}
           disabled={!vectorOptionsEnabled}
           selected={vectorKey}
           items={vectorOptions}
@@ -76,10 +76,10 @@ export default function VectorFieldSettings(): ReactElement {
         {vectorKey === VECTOR_KEY_MOTION_DELTA && vectorOptionsEnabled && (
           <Card style={{ position: "relative", width: "fit-content", marginTop: "10px" }} size="small">
             <SettingsContainer>
-              <SettingsItem label="Average over # time intervals" htmlFor={HtmlIDs.VECTOR_MOTION_TIME_INTERVALS_SLIDER}>
+              <SettingsItem label="Average over # time intervals" htmlFor={HtmlIds.VECTOR_MOTION_TIME_INTERVALS_SLIDER}>
                 <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
                   <LabeledSlider
-                    id={HtmlIDs.VECTOR_MOTION_TIME_INTERVALS_SLIDER}
+                    id={HtmlIds.VECTOR_MOTION_TIME_INTERVALS_SLIDER}
                     type="value"
                     disabled={!vectorOptionsEnabled}
                     step={1}
@@ -103,10 +103,10 @@ export default function VectorFieldSettings(): ReactElement {
        * all deltas.
        * See examples in https://github.com/react-component/slider/issues/393.
        */}
-      <SettingsItem label={"Scale factor"} htmlFor={HtmlIDs.VECTOR_SCALE_FACTOR_SLIDER}>
+      <SettingsItem label={"Scale factor"} htmlFor={HtmlIds.VECTOR_SCALE_FACTOR_SLIDER}>
         <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
           <LabeledSlider
-            id={HtmlIDs.VECTOR_SCALE_FACTOR_SLIDER}
+            id={HtmlIds.VECTOR_SCALE_FACTOR_SLIDER}
             disabled={!vectorOptionsEnabled}
             type="value"
             minSliderBound={0}
@@ -119,9 +119,9 @@ export default function VectorFieldSettings(): ReactElement {
           />
         </div>
       </SettingsItem>
-      <SettingsItem label="Arrow color" htmlFor={HtmlIDs.VECTOR_COLOR_PICKER}>
+      <SettingsItem label="Arrow color" htmlFor={HtmlIds.VECTOR_COLOR_PICKER}>
         <WrappedColorPicker
-          id={HtmlIDs.VECTOR_COLOR_PICKER}
+          id={HtmlIds.VECTOR_COLOR_PICKER}
           disabled={!vectorOptionsEnabled}
           disabledAlpha={true}
           size="small"
@@ -135,11 +135,11 @@ export default function VectorFieldSettings(): ReactElement {
       <SettingsItem
         label="Show vector in tooltip as"
         labelStyle={{ height: "fit-content" }}
-        htmlFor={HtmlIDs.VECTOR_TOOLTIP_MODE_RADIO}
+        htmlFor={HtmlIds.VECTOR_TOOLTIP_MODE_RADIO}
       >
         <div style={{ width: "fit-content" }}>
           <Radio.Group
-            id={HtmlIDs.VECTOR_TOOLTIP_MODE_RADIO}
+            id={HtmlIds.VECTOR_TOOLTIP_MODE_RADIO}
             value={vectorTooltipMode}
             onChange={(e) => setVectorTooltipMode(e.target.value)}
             disabled={!vectorOptionsEnabled}

--- a/src/components/Tabs/Settings/VectorFieldSettings.tsx
+++ b/src/components/Tabs/Settings/VectorFieldSettings.tsx
@@ -135,6 +135,9 @@ export default function VectorFieldSettings(): ReactElement {
           presets={DEFAULT_OUTLINE_COLOR_PRESETS}
         ></WrappedColorPicker>
       </SettingsItem>
+      {/* TODO: Use a fieldset + legend for Radio inputs?
+       * See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/radio#defining_a_radio_group
+       */}
       <SettingsItem
         label="Show vector in tooltip as"
         labelStyle={{ height: "fit-content" }}

--- a/src/components/Tabs/SettingsTab.tsx
+++ b/src/components/Tabs/SettingsTab.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, ColorPicker, Switch, Tooltip } from "antd";
+import { Checkbox, Switch, Tooltip } from "antd";
 import { PresetsItem } from "antd/es/color-picker/interface";
 import React, { ReactElement, useMemo } from "react";
 import { Color, ColorRepresentation } from "three";
@@ -15,6 +15,7 @@ import CustomCollapse from "../CustomCollapse";
 import DropdownWithColorPicker from "../Dropdowns/DropdownWithColorPicker";
 import SelectionDropdown from "../Dropdowns/SelectionDropdown";
 import LabeledSlider from "../Inputs/LabeledSlider";
+import WrappedColorPicker from "../Inputs/WrappedColorPicker";
 import { SettingsContainer, SettingsItem } from "../SettingsContainer";
 import VectorFieldSettings from "./Settings/VectorFieldSettings";
 
@@ -194,17 +195,15 @@ export default function SettingsTab(): ReactElement {
         <SettingsContainer indentPx={SETTINGS_INDENT_PX} gapPx={SETTINGS_GAP_PX}>
           <SettingsItem label="Highlight">
             {/* NOTE: 'Highlight color' is 'outline' internally, and 'Outline color' is 'edge' for legacy reasons. */}
-            <div>
-              <ColorPicker
-                style={{ width: "min-content" }}
-                size="small"
-                disabledAlpha={true}
-                defaultValue={OUTLINE_COLOR_DEFAULT}
-                onChange={(_color, hex) => setOutlineColor(new Color(hex as ColorRepresentation))}
-                value={threeToAntColor(outlineColor)}
-                presets={DEFAULT_OUTLINE_COLOR_PRESETS}
-              />
-            </div>
+            <WrappedColorPicker
+              style={{ width: "min-content" }}
+              size="small"
+              disabledAlpha={true}
+              defaultValue={OUTLINE_COLOR_DEFAULT}
+              onChange={(_color, hex) => setOutlineColor(new Color(hex as ColorRepresentation))}
+              value={threeToAntColor(outlineColor)}
+              presets={DEFAULT_OUTLINE_COLOR_PRESETS}
+            />
           </SettingsItem>
           <SettingsItem label="Outline" id="edge-color-label">
             <DropdownWithColorPicker

--- a/src/components/Tabs/SettingsTab.tsx
+++ b/src/components/Tabs/SettingsTab.tsx
@@ -14,7 +14,7 @@ import { useViewerStateStore } from "../../state/ViewerState";
 import CustomCollapse from "../CustomCollapse";
 import DropdownWithColorPicker from "../Dropdowns/DropdownWithColorPicker";
 import SelectionDropdown from "../Dropdowns/SelectionDropdown";
-import LabeledSlider from "../LabeledSlider";
+import LabeledSlider from "../Inputs/LabeledSlider";
 import { SettingsContainer, SettingsItem } from "../SettingsContainer";
 import VectorFieldSettings from "./Settings/VectorFieldSettings";
 

--- a/src/components/Tabs/SettingsTab.tsx
+++ b/src/components/Tabs/SettingsTab.tsx
@@ -19,7 +19,7 @@ import WrappedColorPicker from "../Inputs/WrappedColorPicker";
 import { SettingsContainer, SettingsItem } from "../SettingsContainer";
 import VectorFieldSettings from "./Settings/VectorFieldSettings";
 
-const enum HtmlIds {
+const enum SettingsHtmlIds {
   SHOW_BACKDROPS_CHECKBOX = "show-backdrops-checkbox",
   BACKDROP_KEY_SELECT = "backdrop-key-select",
   BACKDROP_BRIGHTNESS_SLIDER = "backdrop-brightness-slider",
@@ -142,10 +142,10 @@ export default function SettingsTab(): ReactElement {
     <FlexColumn $gap={5}>
       <CustomCollapse label="Backdrop">
         <SettingsContainer indentPx={SETTINGS_INDENT_PX} gapPx={SETTINGS_GAP_PX}>
-          <SettingsItem label={"Show backdrops"} htmlFor={HtmlIds.SHOW_BACKDROPS_CHECKBOX}>
+          <SettingsItem label={"Show backdrops"} htmlFor={SettingsHtmlIds.SHOW_BACKDROPS_CHECKBOX}>
             <div style={{ width: "fit-content" }}>
               <Checkbox
-                id={HtmlIds.SHOW_BACKDROPS_CHECKBOX}
+                id={SettingsHtmlIds.SHOW_BACKDROPS_CHECKBOX}
                 type="checkbox"
                 disabled={isBackdropDisabled}
                 checked={backdropVisible}
@@ -153,19 +153,19 @@ export default function SettingsTab(): ReactElement {
               />
             </div>
           </SettingsItem>
-          <SettingsItem label="Backdrop" htmlFor={HtmlIds.BACKDROP_KEY_SELECT}>
+          <SettingsItem label="Backdrop" htmlFor={SettingsHtmlIds.BACKDROP_KEY_SELECT}>
             <SelectionDropdown
-              id={HtmlIds.BACKDROP_KEY_SELECT}
+              id={SettingsHtmlIds.BACKDROP_KEY_SELECT}
               selected={selectedBackdropKey}
               items={backdropOptions}
               onChange={(key) => dataset && setBackdropKey(key)}
               disabled={isBackdropOptionsDisabled}
             />
           </SettingsItem>
-          <SettingsItem label="Brightness" htmlFor={HtmlIds.BACKDROP_BRIGHTNESS_SLIDER}>
+          <SettingsItem label="Brightness" htmlFor={SettingsHtmlIds.BACKDROP_BRIGHTNESS_SLIDER}>
             <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
               <LabeledSlider
-                id={HtmlIds.BACKDROP_BRIGHTNESS_SLIDER}
+                id={SettingsHtmlIds.BACKDROP_BRIGHTNESS_SLIDER}
                 type="value"
                 minSliderBound={0}
                 maxSliderBound={200}
@@ -180,10 +180,10 @@ export default function SettingsTab(): ReactElement {
             </div>
           </SettingsItem>
 
-          <SettingsItem label="Saturation" htmlFor={HtmlIds.BACKDROP_SATURATION_SLIDER}>
+          <SettingsItem label="Saturation" htmlFor={SettingsHtmlIds.BACKDROP_SATURATION_SLIDER}>
             <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
               <LabeledSlider
-                id={HtmlIds.BACKDROP_SATURATION_SLIDER}
+                id={SettingsHtmlIds.BACKDROP_SATURATION_SLIDER}
                 type="value"
                 minSliderBound={0}
                 maxSliderBound={100}
@@ -197,10 +197,10 @@ export default function SettingsTab(): ReactElement {
               />
             </div>
           </SettingsItem>
-          <SettingsItem label="Object opacity" htmlFor={HtmlIds.OBJECT_OPACITY_SLIDER}>
+          <SettingsItem label="Object opacity" htmlFor={SettingsHtmlIds.OBJECT_OPACITY_SLIDER}>
             <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
               <LabeledSlider
-                id={HtmlIds.OBJECT_OPACITY_SLIDER}
+                id={SettingsHtmlIds.OBJECT_OPACITY_SLIDER}
                 type="value"
                 disabled={isBackdropOptionsDisabled}
                 minSliderBound={0}
@@ -219,10 +219,10 @@ export default function SettingsTab(): ReactElement {
 
       <CustomCollapse label="Objects">
         <SettingsContainer indentPx={SETTINGS_INDENT_PX} gapPx={SETTINGS_GAP_PX}>
-          <SettingsItem label="Highlight" htmlFor={HtmlIds.HIGHLIGHT_COLOR_PICKER}>
+          <SettingsItem label="Highlight" htmlFor={SettingsHtmlIds.HIGHLIGHT_COLOR_PICKER}>
             {/* NOTE: 'Highlight color' is 'outline' internally, and 'Outline color' is 'edge' for legacy reasons. */}
             <WrappedColorPicker
-              id={HtmlIds.HIGHLIGHT_COLOR_PICKER}
+              id={SettingsHtmlIds.HIGHLIGHT_COLOR_PICKER}
               style={{ width: "min-content" }}
               size="small"
               disabledAlpha={true}
@@ -232,9 +232,9 @@ export default function SettingsTab(): ReactElement {
               presets={DEFAULT_OUTLINE_COLOR_PRESETS}
             />
           </SettingsItem>
-          <SettingsItem label="Outline" htmlFor={HtmlIds.EDGE_COLOR_SELECT}>
+          <SettingsItem label="Outline" htmlFor={SettingsHtmlIds.EDGE_COLOR_SELECT}>
             <DropdownWithColorPicker
-              id={HtmlIds.EDGE_COLOR_SELECT}
+              id={SettingsHtmlIds.EDGE_COLOR_SELECT}
               selected={edgeMode.toString()}
               items={DRAW_MODE_ITEMS}
               onValueChange={(mode: string) => {
@@ -247,9 +247,9 @@ export default function SettingsTab(): ReactElement {
               presets={EDGE_COLOR_PRESETS}
             />
           </SettingsItem>
-          <SettingsItem label="Filtered objects" htmlFor={HtmlIds.OUT_OF_RANGE_OBJECT_COLOR_SELECT}>
+          <SettingsItem label="Filtered objects" htmlFor={SettingsHtmlIds.OUT_OF_RANGE_OBJECT_COLOR_SELECT}>
             <DropdownWithColorPicker
-              id={HtmlIds.OUT_OF_RANGE_OBJECT_COLOR_SELECT}
+              id={SettingsHtmlIds.OUT_OF_RANGE_OBJECT_COLOR_SELECT}
               selected={outOfRangeDrawSettings.mode.toString()}
               color={outOfRangeDrawSettings.color}
               onValueChange={(mode: string) => {
@@ -263,9 +263,9 @@ export default function SettingsTab(): ReactElement {
               presets={DRAW_MODE_COLOR_PRESETS}
             />
           </SettingsItem>
-          <SettingsItem label="Outliers" htmlFor={HtmlIds.OUTLIER_OBJECT_COLOR_SELECT}>
+          <SettingsItem label="Outliers" htmlFor={SettingsHtmlIds.OUTLIER_OBJECT_COLOR_SELECT}>
             <DropdownWithColorPicker
-              id={HtmlIds.OUTLIER_OBJECT_COLOR_SELECT}
+              id={SettingsHtmlIds.OUTLIER_OBJECT_COLOR_SELECT}
               selected={outlierDrawSettings.mode.toString()}
               color={outlierDrawSettings.color}
               onValueChange={(mode: string) => {
@@ -282,19 +282,23 @@ export default function SettingsTab(): ReactElement {
 
           <SettingsItem
             label={"Track path"}
-            htmlFor={HtmlIds.SHOW_TRACK_PATH_SWITCH}
+            htmlFor={SettingsHtmlIds.SHOW_TRACK_PATH_SWITCH}
             labelStyle={{ height: "min-content" }}
             style={{ marginTop: "15px" }}
           >
             <div>
-              <Switch id={HtmlIds.SHOW_TRACK_PATH_SWITCH} checked={showTrackPath} onChange={setShowTrackPath}></Switch>
+              <Switch
+                id={SettingsHtmlIds.SHOW_TRACK_PATH_SWITCH}
+                checked={showTrackPath}
+                onChange={setShowTrackPath}
+              ></Switch>
             </div>
           </SettingsItem>
           {showTrackPath && (
             <>
-              <SettingsItem label="Color" htmlFor={HtmlIds.TRACK_PATH_COLOR_SELECT}>
+              <SettingsItem label="Color" htmlFor={SettingsHtmlIds.TRACK_PATH_COLOR_SELECT}>
                 <DropdownWithColorPicker
-                  id={HtmlIds.TRACK_PATH_COLOR_SELECT}
+                  id={SettingsHtmlIds.TRACK_PATH_COLOR_SELECT}
                   selected={trackPathColorMode.toString()}
                   items={TRACK_MODE_ITEMS}
                   onValueChange={(value) => setTrackPathColorMode(Number.parseInt(value, 10) as TrackPathColorMode)}
@@ -304,10 +308,10 @@ export default function SettingsTab(): ReactElement {
                   showColorPicker={trackPathColorMode === TrackPathColorMode.USE_CUSTOM_COLOR}
                 />
               </SettingsItem>
-              <SettingsItem label="Width" htmlFor={HtmlIds.TRACK_PATH_WIDTH_SLIDER}>
+              <SettingsItem label="Width" htmlFor={SettingsHtmlIds.TRACK_PATH_WIDTH_SLIDER}>
                 <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
                   <LabeledSlider
-                    id={HtmlIds.TRACK_PATH_WIDTH_SLIDER}
+                    id={SettingsHtmlIds.TRACK_PATH_WIDTH_SLIDER}
                     type="value"
                     minSliderBound={1}
                     maxSliderBound={5}
@@ -324,7 +328,7 @@ export default function SettingsTab(): ReactElement {
               </SettingsItem>
               <SettingsItem
                 label={"Show breaks"}
-                htmlFor={HtmlIds.TRACK_PATH_SHOW_BREAKS_CHECKBOX}
+                htmlFor={SettingsHtmlIds.TRACK_PATH_SHOW_BREAKS_CHECKBOX}
                 labelStyle={{ height: "min-content" }}
                 style={{ marginBottom: "20px", marginTop: "-5px" }}
               >
@@ -332,7 +336,7 @@ export default function SettingsTab(): ReactElement {
                   <div style={{ width: "fit-content" }}>
                     <VisuallyHidden>Show breaks in the track path where the track is not continuous.</VisuallyHidden>
                     <Checkbox
-                      id={HtmlIds.TRACK_PATH_SHOW_BREAKS_CHECKBOX}
+                      id={SettingsHtmlIds.TRACK_PATH_SHOW_BREAKS_CHECKBOX}
                       type="checkbox"
                       checked={showTrackPathBreaks}
                       onChange={(event) => {
@@ -344,14 +348,14 @@ export default function SettingsTab(): ReactElement {
               </SettingsItem>
             </>
           )}
-          <SettingsItem label="Scale bar" htmlFor={HtmlIds.SCALE_BAR_SWITCH}>
+          <SettingsItem label="Scale bar" htmlFor={SettingsHtmlIds.SCALE_BAR_SWITCH}>
             <div>
-              <Switch id={HtmlIds.SCALE_BAR_SWITCH} checked={showScaleBar} onChange={setShowScaleBar} />
+              <Switch id={SettingsHtmlIds.SCALE_BAR_SWITCH} checked={showScaleBar} onChange={setShowScaleBar} />
             </div>
           </SettingsItem>
-          <SettingsItem label="Timestamp" htmlFor={HtmlIds.TIMESTAMP_SWITCH}>
+          <SettingsItem label="Timestamp" htmlFor={SettingsHtmlIds.TIMESTAMP_SWITCH}>
             <div>
-              <Switch id={HtmlIds.TIMESTAMP_SWITCH} checked={showTimestamp} onChange={setShowTimestamp} />
+              <Switch id={SettingsHtmlIds.TIMESTAMP_SWITCH} checked={showTimestamp} onChange={setShowTimestamp} />
             </div>
           </SettingsItem>
         </SettingsContainer>

--- a/src/components/Tabs/SettingsTab.tsx
+++ b/src/components/Tabs/SettingsTab.tsx
@@ -19,6 +19,25 @@ import WrappedColorPicker from "../Inputs/WrappedColorPicker";
 import { SettingsContainer, SettingsItem } from "../SettingsContainer";
 import VectorFieldSettings from "./Settings/VectorFieldSettings";
 
+const enum HtmlIDs {
+  ID_SHOW_BACKDROPS_CHECKBOX = "show-backdrops-checkbox",
+  ID_BACKDROP_KEY_SELECT = "backdrop-key-select",
+  ID_BACKDROP_BRIGHTNESS_SLIDER = "backdrop-brightness-slider",
+  ID_BACKDROP_SATURATION_SLIDER = "backdrop-saturation-slider",
+  ID_OBJECT_OPACITY_SLIDER = "object-opacity-slider",
+  ID_HIGHLIGHT_COLOR_PICKER = "highlight-color-picker",
+  ID_EDGE_COLOR_SELECT = "edge-color-select",
+  ID_OUTLIER_OBJECT_COLOR_SELECT = "outlier-object-color-select",
+  ID_OUTLIER_OBJECT_COLOR_PICKER = "outlier-object-color-picker",
+  ID_OUT_OF_RANGE_OBJECT_COLOR_SELECT = "out-of-range-object-color-select",
+  ID_SHOW_TRACK_PATH_SWITCH = "show-track-path-switch",
+  ID_TRACK_PATH_COLOR_SELECT = "track-path-color-select",
+  ID_TRACK_PATH_WIDTH_SLIDER = "track-path-width-slider",
+  ID_TRACK_PATH_SHOW_BREAKS_CHECKBOX = "track-path-show-breaks-checkbox",
+  ID_SCALE_BAR_SWITCH = "scale-bar-switch",
+  ID_TIMESTAMP_SWITCH = "timestamp-switch",
+}
+
 const NO_BACKDROP = {
   value: "",
   label: "(None)",
@@ -123,25 +142,30 @@ export default function SettingsTab(): ReactElement {
     <FlexColumn $gap={5}>
       <CustomCollapse label="Backdrop">
         <SettingsContainer indentPx={SETTINGS_INDENT_PX} gapPx={SETTINGS_GAP_PX}>
-          <SettingsItem label={"Show backdrops"}>
-            <Checkbox
-              type="checkbox"
-              disabled={isBackdropDisabled}
-              checked={backdropVisible}
-              onChange={(event) => setBackdropVisible(event.target.checked)}
-            />
+          <SettingsItem label={"Show backdrops"} htmlFor={HtmlIDs.ID_SHOW_BACKDROPS_CHECKBOX}>
+            <div style={{ width: "fit-content" }}>
+              <Checkbox
+                id={HtmlIDs.ID_SHOW_BACKDROPS_CHECKBOX}
+                type="checkbox"
+                disabled={isBackdropDisabled}
+                checked={backdropVisible}
+                onChange={(event) => setBackdropVisible(event.target.checked)}
+              />
+            </div>
           </SettingsItem>
-          <SettingsItem label="Backdrop">
+          <SettingsItem label="Backdrop" htmlFor={HtmlIDs.ID_BACKDROP_KEY_SELECT}>
             <SelectionDropdown
+              id={HtmlIDs.ID_BACKDROP_KEY_SELECT}
               selected={selectedBackdropKey}
               items={backdropOptions}
               onChange={(key) => dataset && setBackdropKey(key)}
               disabled={isBackdropOptionsDisabled}
             />
           </SettingsItem>
-          <SettingsItem label="Brightness">
+          <SettingsItem label="Brightness" htmlFor={HtmlIDs.ID_BACKDROP_BRIGHTNESS_SLIDER}>
             <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
               <LabeledSlider
+                id={HtmlIDs.ID_BACKDROP_BRIGHTNESS_SLIDER}
                 type="value"
                 minSliderBound={0}
                 maxSliderBound={200}
@@ -156,9 +180,10 @@ export default function SettingsTab(): ReactElement {
             </div>
           </SettingsItem>
 
-          <SettingsItem label="Saturation">
+          <SettingsItem label="Saturation" htmlFor={HtmlIDs.ID_BACKDROP_SATURATION_SLIDER}>
             <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
               <LabeledSlider
+                id={HtmlIDs.ID_BACKDROP_SATURATION_SLIDER}
                 type="value"
                 minSliderBound={0}
                 maxSliderBound={100}
@@ -172,9 +197,10 @@ export default function SettingsTab(): ReactElement {
               />
             </div>
           </SettingsItem>
-          <SettingsItem label="Object opacity">
+          <SettingsItem label="Object opacity" htmlFor={HtmlIDs.ID_OBJECT_OPACITY_SLIDER}>
             <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
               <LabeledSlider
+                id={HtmlIDs.ID_OBJECT_OPACITY_SLIDER}
                 type="value"
                 disabled={isBackdropOptionsDisabled}
                 minSliderBound={0}
@@ -193,9 +219,10 @@ export default function SettingsTab(): ReactElement {
 
       <CustomCollapse label="Objects">
         <SettingsContainer indentPx={SETTINGS_INDENT_PX} gapPx={SETTINGS_GAP_PX}>
-          <SettingsItem label="Highlight">
+          <SettingsItem label="Highlight" htmlFor={HtmlIDs.ID_HIGHLIGHT_COLOR_PICKER}>
             {/* NOTE: 'Highlight color' is 'outline' internally, and 'Outline color' is 'edge' for legacy reasons. */}
             <WrappedColorPicker
+              id={HtmlIDs.ID_HIGHLIGHT_COLOR_PICKER}
               style={{ width: "min-content" }}
               size="small"
               disabledAlpha={true}
@@ -205,9 +232,9 @@ export default function SettingsTab(): ReactElement {
               presets={DEFAULT_OUTLINE_COLOR_PRESETS}
             />
           </SettingsItem>
-          <SettingsItem label="Outline" id="edge-color-label">
+          <SettingsItem label="Outline" htmlFor={HtmlIDs.ID_EDGE_COLOR_SELECT}>
             <DropdownWithColorPicker
-              htmlLabelId="edge-color-label"
+              id={HtmlIDs.ID_EDGE_COLOR_SELECT}
               selected={edgeMode.toString()}
               items={DRAW_MODE_ITEMS}
               onValueChange={(mode: string) => {
@@ -220,9 +247,9 @@ export default function SettingsTab(): ReactElement {
               presets={EDGE_COLOR_PRESETS}
             />
           </SettingsItem>
-          <SettingsItem label="Filtered objects" id="filtered-object-color-label">
+          <SettingsItem label="Filtered objects" htmlFor={HtmlIDs.ID_OUT_OF_RANGE_OBJECT_COLOR_SELECT}>
             <DropdownWithColorPicker
-              htmlLabelId="filtered-object-color-label"
+              id={HtmlIDs.ID_OUT_OF_RANGE_OBJECT_COLOR_SELECT}
               selected={outOfRangeDrawSettings.mode.toString()}
               color={outOfRangeDrawSettings.color}
               onValueChange={(mode: string) => {
@@ -236,9 +263,9 @@ export default function SettingsTab(): ReactElement {
               presets={DRAW_MODE_COLOR_PRESETS}
             />
           </SettingsItem>
-          <SettingsItem label="Outliers" id="outlier-object-color-label">
+          <SettingsItem label="Outliers" htmlFor={HtmlIDs.ID_OUTLIER_OBJECT_COLOR_SELECT}>
             <DropdownWithColorPicker
-              htmlLabelId="outlier-object-color-label"
+              id={HtmlIDs.ID_OUTLIER_OBJECT_COLOR_SELECT}
               selected={outlierDrawSettings.mode.toString()}
               color={outlierDrawSettings.color}
               onValueChange={(mode: string) => {
@@ -255,21 +282,25 @@ export default function SettingsTab(): ReactElement {
 
           <SettingsItem
             label={"Track path"}
+            htmlFor={HtmlIDs.ID_SHOW_TRACK_PATH_SWITCH}
             labelStyle={{ height: "min-content" }}
-            id="track-path-label"
             style={{ marginTop: "15px" }}
           >
             <div>
-              <Switch checked={showTrackPath} onChange={setShowTrackPath}></Switch>
+              <Switch
+                id={HtmlIDs.ID_SHOW_TRACK_PATH_SWITCH}
+                checked={showTrackPath}
+                onChange={setShowTrackPath}
+              ></Switch>
             </div>
           </SettingsItem>
           {showTrackPath && (
             <>
-              <SettingsItem label="Color" id="track-path-color-label">
+              <SettingsItem label="Color" htmlFor={HtmlIDs.ID_TRACK_PATH_COLOR_SELECT}>
                 <DropdownWithColorPicker
+                  id={HtmlIDs.ID_TRACK_PATH_COLOR_SELECT}
                   selected={trackPathColorMode.toString()}
                   items={TRACK_MODE_ITEMS}
-                  htmlLabelId={"track-path-color-label"}
                   onValueChange={(value) => setTrackPathColorMode(Number.parseInt(value, 10) as TrackPathColorMode)}
                   onColorChange={setTrackPathColor}
                   color={trackPathColor}
@@ -277,9 +308,10 @@ export default function SettingsTab(): ReactElement {
                   showColorPicker={trackPathColorMode === TrackPathColorMode.USE_CUSTOM_COLOR}
                 />
               </SettingsItem>
-              <SettingsItem label="Width">
+              <SettingsItem label="Width" htmlFor={HtmlIDs.ID_TRACK_PATH_WIDTH_SLIDER}>
                 <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
                   <LabeledSlider
+                    id={HtmlIDs.ID_TRACK_PATH_WIDTH_SLIDER}
                     type="value"
                     minSliderBound={1}
                     maxSliderBound={5}
@@ -296,6 +328,7 @@ export default function SettingsTab(): ReactElement {
               </SettingsItem>
               <SettingsItem
                 label={"Show breaks"}
+                htmlFor={HtmlIDs.ID_TRACK_PATH_SHOW_BREAKS_CHECKBOX}
                 labelStyle={{ height: "min-content" }}
                 style={{ marginBottom: "20px", marginTop: "-5px" }}
               >
@@ -303,6 +336,7 @@ export default function SettingsTab(): ReactElement {
                   <div style={{ width: "fit-content" }}>
                     <VisuallyHidden>Show breaks in the track path where the track is not continuous.</VisuallyHidden>
                     <Checkbox
+                      id={HtmlIDs.ID_TRACK_PATH_SHOW_BREAKS_CHECKBOX}
                       type="checkbox"
                       checked={showTrackPathBreaks}
                       onChange={(event) => {
@@ -314,14 +348,14 @@ export default function SettingsTab(): ReactElement {
               </SettingsItem>
             </>
           )}
-          <SettingsItem label="Scale bar">
+          <SettingsItem label="Scale bar" htmlFor={HtmlIDs.ID_SCALE_BAR_SWITCH}>
             <div>
-              <Switch checked={showScaleBar} onChange={setShowScaleBar} />
+              <Switch id={HtmlIDs.ID_SCALE_BAR_SWITCH} checked={showScaleBar} onChange={setShowScaleBar} />
             </div>
           </SettingsItem>
-          <SettingsItem label="Timestamp">
+          <SettingsItem label="Timestamp" htmlFor={HtmlIDs.ID_TIMESTAMP_SWITCH}>
             <div>
-              <Switch checked={showTimestamp} onChange={setShowTimestamp} />
+              <Switch id={HtmlIDs.ID_TIMESTAMP_SWITCH} checked={showTimestamp} onChange={setShowTimestamp} />
             </div>
           </SettingsItem>
         </SettingsContainer>

--- a/src/components/Tabs/SettingsTab.tsx
+++ b/src/components/Tabs/SettingsTab.tsx
@@ -19,23 +19,23 @@ import WrappedColorPicker from "../Inputs/WrappedColorPicker";
 import { SettingsContainer, SettingsItem } from "../SettingsContainer";
 import VectorFieldSettings from "./Settings/VectorFieldSettings";
 
-const enum HtmlIDs {
-  ID_SHOW_BACKDROPS_CHECKBOX = "show-backdrops-checkbox",
-  ID_BACKDROP_KEY_SELECT = "backdrop-key-select",
-  ID_BACKDROP_BRIGHTNESS_SLIDER = "backdrop-brightness-slider",
-  ID_BACKDROP_SATURATION_SLIDER = "backdrop-saturation-slider",
-  ID_OBJECT_OPACITY_SLIDER = "object-opacity-slider",
-  ID_HIGHLIGHT_COLOR_PICKER = "highlight-color-picker",
-  ID_EDGE_COLOR_SELECT = "edge-color-select",
-  ID_OUTLIER_OBJECT_COLOR_SELECT = "outlier-object-color-select",
-  ID_OUTLIER_OBJECT_COLOR_PICKER = "outlier-object-color-picker",
-  ID_OUT_OF_RANGE_OBJECT_COLOR_SELECT = "out-of-range-object-color-select",
-  ID_SHOW_TRACK_PATH_SWITCH = "show-track-path-switch",
-  ID_TRACK_PATH_COLOR_SELECT = "track-path-color-select",
-  ID_TRACK_PATH_WIDTH_SLIDER = "track-path-width-slider",
-  ID_TRACK_PATH_SHOW_BREAKS_CHECKBOX = "track-path-show-breaks-checkbox",
-  ID_SCALE_BAR_SWITCH = "scale-bar-switch",
-  ID_TIMESTAMP_SWITCH = "timestamp-switch",
+const enum HtmlIds {
+  SHOW_BACKDROPS_CHECKBOX = "show-backdrops-checkbox",
+  BACKDROP_KEY_SELECT = "backdrop-key-select",
+  BACKDROP_BRIGHTNESS_SLIDER = "backdrop-brightness-slider",
+  BACKDROP_SATURATION_SLIDER = "backdrop-saturation-slider",
+  OBJECT_OPACITY_SLIDER = "object-opacity-slider",
+  HIGHLIGHT_COLOR_PICKER = "highlight-color-picker",
+  EDGE_COLOR_SELECT = "edge-color-select",
+  OUTLIER_OBJECT_COLOR_SELECT = "outlier-object-color-select",
+  OUTLIER_OBJECT_COLOR_PICKER = "outlier-object-color-picker",
+  OUT_OF_RANGE_OBJECT_COLOR_SELECT = "out-of-range-object-color-select",
+  SHOW_TRACK_PATH_SWITCH = "show-track-path-switch",
+  TRACK_PATH_COLOR_SELECT = "track-path-color-select",
+  TRACK_PATH_WIDTH_SLIDER = "track-path-width-slider",
+  TRACK_PATH_SHOW_BREAKS_CHECKBOX = "track-path-show-breaks-checkbox",
+  SCALE_BAR_SWITCH = "scale-bar-switch",
+  TIMESTAMP_SWITCH = "timestamp-switch",
 }
 
 const NO_BACKDROP = {
@@ -142,10 +142,10 @@ export default function SettingsTab(): ReactElement {
     <FlexColumn $gap={5}>
       <CustomCollapse label="Backdrop">
         <SettingsContainer indentPx={SETTINGS_INDENT_PX} gapPx={SETTINGS_GAP_PX}>
-          <SettingsItem label={"Show backdrops"} htmlFor={HtmlIDs.ID_SHOW_BACKDROPS_CHECKBOX}>
+          <SettingsItem label={"Show backdrops"} htmlFor={HtmlIds.SHOW_BACKDROPS_CHECKBOX}>
             <div style={{ width: "fit-content" }}>
               <Checkbox
-                id={HtmlIDs.ID_SHOW_BACKDROPS_CHECKBOX}
+                id={HtmlIds.SHOW_BACKDROPS_CHECKBOX}
                 type="checkbox"
                 disabled={isBackdropDisabled}
                 checked={backdropVisible}
@@ -153,19 +153,19 @@ export default function SettingsTab(): ReactElement {
               />
             </div>
           </SettingsItem>
-          <SettingsItem label="Backdrop" htmlFor={HtmlIDs.ID_BACKDROP_KEY_SELECT}>
+          <SettingsItem label="Backdrop" htmlFor={HtmlIds.BACKDROP_KEY_SELECT}>
             <SelectionDropdown
-              id={HtmlIDs.ID_BACKDROP_KEY_SELECT}
+              id={HtmlIds.BACKDROP_KEY_SELECT}
               selected={selectedBackdropKey}
               items={backdropOptions}
               onChange={(key) => dataset && setBackdropKey(key)}
               disabled={isBackdropOptionsDisabled}
             />
           </SettingsItem>
-          <SettingsItem label="Brightness" htmlFor={HtmlIDs.ID_BACKDROP_BRIGHTNESS_SLIDER}>
+          <SettingsItem label="Brightness" htmlFor={HtmlIds.BACKDROP_BRIGHTNESS_SLIDER}>
             <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
               <LabeledSlider
-                id={HtmlIDs.ID_BACKDROP_BRIGHTNESS_SLIDER}
+                id={HtmlIds.BACKDROP_BRIGHTNESS_SLIDER}
                 type="value"
                 minSliderBound={0}
                 maxSliderBound={200}
@@ -180,10 +180,10 @@ export default function SettingsTab(): ReactElement {
             </div>
           </SettingsItem>
 
-          <SettingsItem label="Saturation" htmlFor={HtmlIDs.ID_BACKDROP_SATURATION_SLIDER}>
+          <SettingsItem label="Saturation" htmlFor={HtmlIds.BACKDROP_SATURATION_SLIDER}>
             <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
               <LabeledSlider
-                id={HtmlIDs.ID_BACKDROP_SATURATION_SLIDER}
+                id={HtmlIds.BACKDROP_SATURATION_SLIDER}
                 type="value"
                 minSliderBound={0}
                 maxSliderBound={100}
@@ -197,10 +197,10 @@ export default function SettingsTab(): ReactElement {
               />
             </div>
           </SettingsItem>
-          <SettingsItem label="Object opacity" htmlFor={HtmlIDs.ID_OBJECT_OPACITY_SLIDER}>
+          <SettingsItem label="Object opacity" htmlFor={HtmlIds.OBJECT_OPACITY_SLIDER}>
             <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
               <LabeledSlider
-                id={HtmlIDs.ID_OBJECT_OPACITY_SLIDER}
+                id={HtmlIds.OBJECT_OPACITY_SLIDER}
                 type="value"
                 disabled={isBackdropOptionsDisabled}
                 minSliderBound={0}
@@ -219,10 +219,10 @@ export default function SettingsTab(): ReactElement {
 
       <CustomCollapse label="Objects">
         <SettingsContainer indentPx={SETTINGS_INDENT_PX} gapPx={SETTINGS_GAP_PX}>
-          <SettingsItem label="Highlight" htmlFor={HtmlIDs.ID_HIGHLIGHT_COLOR_PICKER}>
+          <SettingsItem label="Highlight" htmlFor={HtmlIds.HIGHLIGHT_COLOR_PICKER}>
             {/* NOTE: 'Highlight color' is 'outline' internally, and 'Outline color' is 'edge' for legacy reasons. */}
             <WrappedColorPicker
-              id={HtmlIDs.ID_HIGHLIGHT_COLOR_PICKER}
+              id={HtmlIds.HIGHLIGHT_COLOR_PICKER}
               style={{ width: "min-content" }}
               size="small"
               disabledAlpha={true}
@@ -232,9 +232,9 @@ export default function SettingsTab(): ReactElement {
               presets={DEFAULT_OUTLINE_COLOR_PRESETS}
             />
           </SettingsItem>
-          <SettingsItem label="Outline" htmlFor={HtmlIDs.ID_EDGE_COLOR_SELECT}>
+          <SettingsItem label="Outline" htmlFor={HtmlIds.EDGE_COLOR_SELECT}>
             <DropdownWithColorPicker
-              id={HtmlIDs.ID_EDGE_COLOR_SELECT}
+              id={HtmlIds.EDGE_COLOR_SELECT}
               selected={edgeMode.toString()}
               items={DRAW_MODE_ITEMS}
               onValueChange={(mode: string) => {
@@ -247,9 +247,9 @@ export default function SettingsTab(): ReactElement {
               presets={EDGE_COLOR_PRESETS}
             />
           </SettingsItem>
-          <SettingsItem label="Filtered objects" htmlFor={HtmlIDs.ID_OUT_OF_RANGE_OBJECT_COLOR_SELECT}>
+          <SettingsItem label="Filtered objects" htmlFor={HtmlIds.OUT_OF_RANGE_OBJECT_COLOR_SELECT}>
             <DropdownWithColorPicker
-              id={HtmlIDs.ID_OUT_OF_RANGE_OBJECT_COLOR_SELECT}
+              id={HtmlIds.OUT_OF_RANGE_OBJECT_COLOR_SELECT}
               selected={outOfRangeDrawSettings.mode.toString()}
               color={outOfRangeDrawSettings.color}
               onValueChange={(mode: string) => {
@@ -263,9 +263,9 @@ export default function SettingsTab(): ReactElement {
               presets={DRAW_MODE_COLOR_PRESETS}
             />
           </SettingsItem>
-          <SettingsItem label="Outliers" htmlFor={HtmlIDs.ID_OUTLIER_OBJECT_COLOR_SELECT}>
+          <SettingsItem label="Outliers" htmlFor={HtmlIds.OUTLIER_OBJECT_COLOR_SELECT}>
             <DropdownWithColorPicker
-              id={HtmlIDs.ID_OUTLIER_OBJECT_COLOR_SELECT}
+              id={HtmlIds.OUTLIER_OBJECT_COLOR_SELECT}
               selected={outlierDrawSettings.mode.toString()}
               color={outlierDrawSettings.color}
               onValueChange={(mode: string) => {
@@ -282,23 +282,19 @@ export default function SettingsTab(): ReactElement {
 
           <SettingsItem
             label={"Track path"}
-            htmlFor={HtmlIDs.ID_SHOW_TRACK_PATH_SWITCH}
+            htmlFor={HtmlIds.SHOW_TRACK_PATH_SWITCH}
             labelStyle={{ height: "min-content" }}
             style={{ marginTop: "15px" }}
           >
             <div>
-              <Switch
-                id={HtmlIDs.ID_SHOW_TRACK_PATH_SWITCH}
-                checked={showTrackPath}
-                onChange={setShowTrackPath}
-              ></Switch>
+              <Switch id={HtmlIds.SHOW_TRACK_PATH_SWITCH} checked={showTrackPath} onChange={setShowTrackPath}></Switch>
             </div>
           </SettingsItem>
           {showTrackPath && (
             <>
-              <SettingsItem label="Color" htmlFor={HtmlIDs.ID_TRACK_PATH_COLOR_SELECT}>
+              <SettingsItem label="Color" htmlFor={HtmlIds.TRACK_PATH_COLOR_SELECT}>
                 <DropdownWithColorPicker
-                  id={HtmlIDs.ID_TRACK_PATH_COLOR_SELECT}
+                  id={HtmlIds.TRACK_PATH_COLOR_SELECT}
                   selected={trackPathColorMode.toString()}
                   items={TRACK_MODE_ITEMS}
                   onValueChange={(value) => setTrackPathColorMode(Number.parseInt(value, 10) as TrackPathColorMode)}
@@ -308,10 +304,10 @@ export default function SettingsTab(): ReactElement {
                   showColorPicker={trackPathColorMode === TrackPathColorMode.USE_CUSTOM_COLOR}
                 />
               </SettingsItem>
-              <SettingsItem label="Width" htmlFor={HtmlIDs.ID_TRACK_PATH_WIDTH_SLIDER}>
+              <SettingsItem label="Width" htmlFor={HtmlIds.TRACK_PATH_WIDTH_SLIDER}>
                 <div style={{ maxWidth: MAX_SLIDER_WIDTH, width: "100%" }}>
                   <LabeledSlider
-                    id={HtmlIDs.ID_TRACK_PATH_WIDTH_SLIDER}
+                    id={HtmlIds.TRACK_PATH_WIDTH_SLIDER}
                     type="value"
                     minSliderBound={1}
                     maxSliderBound={5}
@@ -328,7 +324,7 @@ export default function SettingsTab(): ReactElement {
               </SettingsItem>
               <SettingsItem
                 label={"Show breaks"}
-                htmlFor={HtmlIDs.ID_TRACK_PATH_SHOW_BREAKS_CHECKBOX}
+                htmlFor={HtmlIds.TRACK_PATH_SHOW_BREAKS_CHECKBOX}
                 labelStyle={{ height: "min-content" }}
                 style={{ marginBottom: "20px", marginTop: "-5px" }}
               >
@@ -336,7 +332,7 @@ export default function SettingsTab(): ReactElement {
                   <div style={{ width: "fit-content" }}>
                     <VisuallyHidden>Show breaks in the track path where the track is not continuous.</VisuallyHidden>
                     <Checkbox
-                      id={HtmlIDs.ID_TRACK_PATH_SHOW_BREAKS_CHECKBOX}
+                      id={HtmlIds.TRACK_PATH_SHOW_BREAKS_CHECKBOX}
                       type="checkbox"
                       checked={showTrackPathBreaks}
                       onChange={(event) => {
@@ -348,14 +344,14 @@ export default function SettingsTab(): ReactElement {
               </SettingsItem>
             </>
           )}
-          <SettingsItem label="Scale bar" htmlFor={HtmlIDs.ID_SCALE_BAR_SWITCH}>
+          <SettingsItem label="Scale bar" htmlFor={HtmlIds.SCALE_BAR_SWITCH}>
             <div>
-              <Switch id={HtmlIDs.ID_SCALE_BAR_SWITCH} checked={showScaleBar} onChange={setShowScaleBar} />
+              <Switch id={HtmlIds.SCALE_BAR_SWITCH} checked={showScaleBar} onChange={setShowScaleBar} />
             </div>
           </SettingsItem>
-          <SettingsItem label="Timestamp" htmlFor={HtmlIDs.ID_TIMESTAMP_SWITCH}>
+          <SettingsItem label="Timestamp" htmlFor={HtmlIds.TIMESTAMP_SWITCH}>
             <div>
-              <Switch id={HtmlIDs.ID_TIMESTAMP_SWITCH} checked={showTimestamp} onChange={setShowTimestamp} />
+              <Switch id={HtmlIds.TIMESTAMP_SWITCH} checked={showTimestamp} onChange={setShowTimestamp} />
             </div>
           </SettingsItem>
         </SettingsContainer>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_ANNOTATION_LABEL_COLORS } from "../colorizer/AnnotationData";
+
 export const DEFAULT_PLAYBACK_FPS = 10;
 export const MAX_FEATURE_CATEGORIES = 12;
 
@@ -15,5 +17,12 @@ export const BACKDROP_OBJECT_OPACITY_MIN = 0;
 export const BACKDROP_OBJECT_OPACITY_MAX = 100;
 export const BACKDROP_OBJECT_OPACITY_DEFAULT = 50;
 export const COLOR_RAMP_RANGE_DEFAULT: [number, number] = [0, 0];
+
+export const DEFAULT_LABEL_COLOR_PRESETS = [
+  {
+    label: "Presets",
+    colors: DEFAULT_ANNOTATION_LABEL_COLORS,
+  },
+];
 
 export * from "./url";

--- a/src/utils/color_utils.ts
+++ b/src/utils/color_utils.ts
@@ -13,7 +13,6 @@ export const antToThreeColor = (color: AntColor): { color: Color; alpha: number 
     const threeColor = new Color(`#${hex.slice(0, 6)}`);
     let alpha = 1;
     if (hex.length === 8) {
-      // If the color is in ARGB format, extract the alpha channel
       alpha = parseInt(hex.slice(6, 8), 16) / 255;
     }
     return { color: threeColor, alpha };

--- a/src/utils/color_utils.ts
+++ b/src/utils/color_utils.ts
@@ -1,16 +1,31 @@
 import { ColorPickerProps, GetProp } from "antd";
 import { Color } from "three";
 
+import { DEFAULT_ANNOTATION_LABEL_COLORS } from "../colorizer/AnnotationData";
+
 export type AntColor = Extract<GetProp<ColorPickerProps, "value">, string | { cleared: any }>;
+
+export const DEFAULT_LABEL_COLOR_PRESETS = [
+  {
+    label: "Presets",
+    colors: DEFAULT_ANNOTATION_LABEL_COLORS,
+  },
+];
 
 export const threeToAntColor = (color: Color): AntColor => {
   return `#${color.getHexString()}`;
 };
 
-export const antToThreeColor = (color: AntColor): Color => {
+export const antToThreeColor = (color: AntColor): { color: Color; alpha: number } => {
   if (typeof color === "string") {
     const hex = color.startsWith("#") ? color.slice(1) : color;
-    return new Color(`#${hex}`);
+    const threeColor = new Color(`#${hex.slice(0, 6)}`);
+    let alpha = 1;
+    if (hex.length === 8) {
+      // If the color is in ARGB format, extract the alpha channel
+      alpha = parseInt(hex.slice(6, 8), 16) / 255;
+    }
+    return { color: threeColor, alpha };
   }
   throw new Error("Invalid color format");
 };

--- a/src/utils/color_utils.ts
+++ b/src/utils/color_utils.ts
@@ -1,16 +1,7 @@
 import { ColorPickerProps, GetProp } from "antd";
 import { Color } from "three";
 
-import { DEFAULT_ANNOTATION_LABEL_COLORS } from "../colorizer/AnnotationData";
-
 export type AntColor = Extract<GetProp<ColorPickerProps, "value">, string | { cleared: any }>;
-
-export const DEFAULT_LABEL_COLOR_PRESETS = [
-  {
-    label: "Presets",
-    colors: DEFAULT_ANNOTATION_LABEL_COLORS,
-  },
-];
 
 export const threeToAntColor = (color: Color): AntColor => {
   return `#${color.getHexString()}`;


### PR DESCRIPTION
Problem
=======
Closes #730, "SettingsItem should not put interactive elements inside of a label HTML tag". 

It also fixes a couple related bugs, such as:
- Click targets for inputs were wider than the inputs themselves
- ColorPicker components could not be accessed using tab navigation
- Labels were not attached to dropdowns correctly

*Estimated review size: large, ~40 minutes (please turn off whitespace changes!)*

Solution
========
- `SettingsItem` no longer wraps both label text and inputs in a `label` component (implicit labeling)
  - Instead, users are expected to pass in an `htmlFor` attribute (explicit labeling)
- Updated several components (SelectDropdown, DropdownWithColorPicker, SpinBox, etc.) to accept and set an `id` prop.
- Fixed bug where inputs would have incorrect/wide click targets by updating all settings to use the `htmlFor` + `id` pattern.
- Fixed bug where SelectDropdown components were not using `label` HTML tags.
- Made a new component, `WrappedColorPicker`, which reimplements the color picker's target styling to fix several accessibility-related bugs.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open PR preview: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-731/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&feature=volume&bg-key=max_intensity_zprojection_of_lamin_b1&t=15&tab=settings
3. Clicking on the white space to the right of the inputs will no longer cause them to become focused.
4. Use tab to navigate to a color picker, and space to click it. Tabbing should allow you to edit fields on the color picker popup.

Screenshots (optional):
-----------------------
**Video talk-through (🔊):**

https://github.com/user-attachments/assets/34be5e30-f2c0-46fb-a29d-a8015ec5b53b


Keyfiles (delete if not relevant):
-----------------------
1. `WrappedColorPicker.tsx`
2. `SettingsContainer.tsx`