### PR TITLE
refactor: Updated `vole-core` to `v3.15.6`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "timelapse-colorizer",
       "version": "1.5.5",
       "dependencies": {
-        "@aics/vole-core": "^3.15.4",
+        "@aics/vole-core": "^3.15.6",
         "@ant-design/icons": "^5.2.5",
         "@fortawesome/fontawesome-svg-core": "^6.5.1",
         "@fortawesome/free-solid-svg-icons": "^6.5.1",
@@ -74,9 +74,10 @@
       "dev": true
     },
     "node_modules/@aics/vole-core": {
-      "version": "3.15.4",
-      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-3.15.4.tgz",
-      "integrity": "sha512-76NcJJSsyg9x7QVdvBPf/ZM6NvcVxTEOAUVVLpmSuf7pe+81n7c/jIfYDY4168A5IAAoQDuXW7Emia5XYD8dJQ==",
+      "version": "3.15.6",
+      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-3.15.6.tgz",
+      "integrity": "sha512-ubyOYQsPpH4+9BMDBP1awu7uiQaN0Gs5RzMqRaJuZhi5kS5Gyy1xH/mKPPstyAczJeECrqzcogcv2fF9YuwOPA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.6",
         "geotiff": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "vitest-canvas-mock": "^0.3.3"
   },
   "dependencies": {
-    "@aics/vole-core": "^3.15.4",
+    "@aics/vole-core": "^3.15.6",
     "@ant-design/icons": "^5.2.5",
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",

--- a/src/colorizer/ColorizeCanvas3D.ts
+++ b/src/colorizer/ColorizeCanvas3D.ts
@@ -201,6 +201,7 @@ export class ColorizeCanvas3D implements IInnerRenderCanvas {
           featureMin: range[0],
           featureMax: range[1],
           outlineColor: this.params.outlineColor.clone().convertLinearToSRGB(),
+          outlineAlpha: 1,
           outlierColor: this.params.outlierDrawSettings.color.clone().convertLinearToSRGB(),
           outOfRangeColor: this.params.outOfRangeDrawSettings.color.clone().convertLinearToSRGB(),
           outlierDrawMode: this.params.outlierDrawSettings.mode,

--- a/src/colorizer/ColorizeCanvas3D.ts
+++ b/src/colorizer/ColorizeCanvas3D.ts
@@ -81,7 +81,6 @@ export class ColorizeCanvas3D implements IInnerRenderCanvas {
   constructor() {
     this.params = null;
     this.view3d = new View3d();
-    this.view3d.loaderContext = loaderContext;
     this.canvasResolution = new Vector2(10, 10);
     this.setResolution(10, 10);
     this.view3d.setShowAxis(true);


### PR DESCRIPTION
Problem
=======
Closes #727 (show outline around selected cell in 3D) and closes #641 (viewport goes black when resized).

*Estimated review size: tiny, <5 minutes*

Solution
========
- Bumped `vole-core` to `v3.15.6`.
  - Fixes a bug where the viewport would go black during resize.
  - Changes the selected object to be visualized with an outline (instead of the color of the volume changing).

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open PR preview (you will need to be on VPN): https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-733/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fusers%2Fpeyton.lee%2Ftfe-emt-nuclear-segmentations%2Fdata%2Ftfe%2Fcollection.json&dataset=EMT+3D
2. Click around in the viewport. The cells should be highlighted with an outline.
3. Resize the window. The viewport will not go black.

Screenshots (optional):
-----------------------

<img width="885" height="636" alt="image" src="https://github.com/user-attachments/assets/28957ab0-2ca7-43c3-bd2c-b6abd37d8424" />

