### PR TITLE
refactor: Adjust default dropdown tooltip positions, time units

### DIFF
--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -464,7 +464,7 @@ export default class Dataset {
     if (this.times && !this.features.has(TIME_FEATURE_KEY)) {
       const timeData = new Float32Array(this.times);
       this.features.set(TIME_FEATURE_KEY, {
-        name: "Time",
+        name: "Time (frames)",
         key: TIME_FEATURE_KEY,
         data: this.times,
         tex: packDataTexture(timeData, FeatureDataType.F32),

--- a/src/components/Dropdowns/SelectionDropdown.tsx
+++ b/src/components/Dropdowns/SelectionDropdown.tsx
@@ -52,7 +52,7 @@ type SelectionDropdownProps = {
 const defaultProps: Partial<SelectionDropdownProps> = {
   buttonType: "outlined",
   showSelectedItemTooltip: true,
-  controlTooltipPlacement: "right",
+  controlTooltipPlacement: "top",
 };
 
 // Override options in the menu list to include tooltips and, optionally, image content.

--- a/src/components/Tabs/ScatterPlotTab.tsx
+++ b/src/components/Tabs/ScatterPlotTab.tsx
@@ -868,6 +868,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
             items={PLOT_RANGE_SELECT_ITEMS}
             width={"120px"}
             onChange={(value: string) => setRangeType(value as PlotRangeType)}
+            showSelectedItemTooltip={false}
           ></SelectionDropdown>
         </div>
       </FlexRowAlignCenter>

--- a/src/components/Tabs/Settings/VectorFieldSettings.tsx
+++ b/src/components/Tabs/Settings/VectorFieldSettings.tsx
@@ -72,6 +72,7 @@ export default function VectorFieldSettings(): ReactElement {
           selected={vectorKey}
           items={vectorOptions}
           onChange={setVectorKey}
+          controlTooltipPlacement="right"
         ></SelectionDropdown>
         {vectorKey === VECTOR_KEY_MOTION_DELTA && vectorOptionsEnabled && (
           <Card style={{ position: "relative", width: "fit-content", marginTop: "10px" }} size="small">

--- a/src/components/Tabs/SettingsTab.tsx
+++ b/src/components/Tabs/SettingsTab.tsx
@@ -160,6 +160,7 @@ export default function SettingsTab(): ReactElement {
               items={backdropOptions}
               onChange={(key) => dataset && setBackdropKey(key)}
               disabled={isBackdropOptionsDisabled}
+              controlTooltipPlacement="right"
             />
           </SettingsItem>
           <SettingsItem label="Brightness" htmlFor={SettingsHtmlIds.BACKDROP_BRIGHTNESS_SLIDER}>


### PR DESCRIPTION
Problem
=======
Fixes a bug where the tooltip covered over other buttons/inputs. This change moves all tooltips to the top of a dropdown by default.

I also changed the default time feature added by TFE to be called "Time (frames)" based on feedback from a UX discussion.

*Estimated review size: tiny, 5 minutes*

Steps to Verify:
----------------
1. Open preview link here: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-735/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&feature=volume_at_start_of_growth&tab=scatter_plot&scatter-x=change_in_volume_in_25_minute_window&scatter-y=volume
2. Mouse over any of the onscreen dropdowns.

Screenshots (optional):
-----------------------
| Before | After |
| --- | --- |
| <img width="614" height="188" alt="image" src="https://github.com/user-attachments/assets/b8229bbb-630d-407c-822f-8e903d4a646d" /> | <img width="610" height="215" alt="image" src="https://github.com/user-attachments/assets/1704b725-70a8-4c34-8e8b-2e1d3badfff5" /> |
| <img width="723" height="230" alt="image" src="https://github.com/user-attachments/assets/41e86ba2-7bce-45bb-994a-72e87e47161e" /> | <img width="734" height="287" alt="image" src="https://github.com/user-attachments/assets/c5fc199d-1e16-4f38-b591-277e96cc3054" /> |
| | <img width="983" height="717" alt="image" src="https://github.com/user-attachments/assets/0a30602a-3af3-4a55-a1a2-dd198987b13d" /> |
