### PR TITLE
fix: Render header over annotations

### DIFF
--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -509,10 +509,10 @@ export default class CanvasOverlay implements IRenderCanvas {
 
     this.ctx.scale(devicePixelRatio, devicePixelRatio);
 
-    headerRenderer.render(new Vector2(0, 0));
     if (this.isAnnotationVisible) {
       this.getAnnotationRenderer().render(new Vector2(0, this.headerSize.y));
     }
+    headerRenderer.render(new Vector2(0, 0));
     footerRenderer.render(new Vector2(0, this.innerCanvasSize.y + this.headerSize.y));
   }
 


### PR DESCRIPTION
Problem
=======
Closes #739, "annotations render in front of header/footer".

*Estimated review size: tiny, 2 minutes*

Solution
========
- Updates the rendering order so the header is rendered over annotations.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Screenshots (optional):
-----------------------
Before:

After:



Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
2. other important file

Thanks for contributing!
