### PR TITLE
feat: Load datasets from ZIP file (ZIP pt. 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "fuse.js": "^7.0.0",
         "hyparquet": "^1.0.0",
         "hyparquet-compressors": "^0.1.4",
+        "jszip": "^3.10.1",
         "mp4-muxer": "^5.2.1",
         "papaparse": "^5.4.1",
         "plotly.js-dist-min": "^2.27.0",
@@ -6373,10 +6374,7 @@
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",
@@ -9397,10 +9395,7 @@
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -10161,9 +10156,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -10174,18 +10167,12 @@
     "node_modules/jszip/node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/jszip/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -10199,18 +10186,12 @@
     "node_modules/jszip/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/jszip/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -10295,9 +10276,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "immediate": "~3.0.5"
       }
@@ -11140,10 +11118,7 @@
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/papaparse": {
       "version": "5.4.1",
@@ -11539,10 +11514,7 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -12948,10 +12920,7 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
@@ -14085,10 +14054,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uzip-module": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "fuse.js": "^7.0.0",
     "hyparquet": "^1.0.0",
     "hyparquet-compressors": "^0.1.4",
+    "jszip": "^3.10.1",
     "mp4-muxer": "^5.2.1",
     "papaparse": "^5.4.1",
     "plotly.js-dist-min": "^2.27.0",

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -488,8 +488,11 @@ function Viewer(): ReactElement {
     (newCollection: Collection, newDatasetKey: string, newDataset: Dataset): void => {
       setCollection(newCollection);
       replaceDataset(newDataset, newDatasetKey);
+      if (newCollection !== collection && collection !== null) {
+        collection.dispose();
+      }
     },
-    [replaceDataset]
+    [replaceDataset, collection]
   );
 
   // SCRUBBING CONTROLS ////////////////////////////////////////////////////

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -332,7 +332,12 @@ export default class Collection {
     let response;
     try {
       const fetchMethod = options.fetchMethod ?? fetchWithTimeout;
-      const collectionPath = pathResolver.resolve("", absoluteCollectionUrl)!;
+      const collectionPath = pathResolver.resolve("", absoluteCollectionUrl);
+      if (!collectionPath) {
+        throw new Error(
+          `Could not resolve collection path for ${absoluteCollectionUrl}. ${LoadTroubleshooting.CHECK_FILE_EXISTS}`
+        );
+      }
       response = await fetchMethod(collectionPath, DEFAULT_FETCH_TIMEOUT_MS);
     } catch (e) {
       throw new Error(LoadErrorMessage.UNREACHABLE_COLLECTION + " " + LoadTroubleshooting.CHECK_NETWORK);

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -426,12 +426,15 @@ export default class Collection {
     }
   }
 
+  /**
+   * Attempts to load a collection or dataset from the given file or directory,
+   * with preference for collections.
+   * @throws an error if the path could not be read as a collection or dataset.
+   */
   private static async loadFromAmbiguousResource(
     path: string,
     options: CollectionLoadOptions = {}
   ): Promise<Collection> {
-    // TODO: Also handle Nucmorph URLs that are pasted in? If website base URL matches, redirect?
-
     let result: Collection | null = null;
     let collectionLoadError: Error | null = null;
     let datasetLoadError: Error | null = null;
@@ -486,12 +489,24 @@ export default class Collection {
       reportWarning: ReportWarningCallback;
     }> = {}
   ): Promise<Collection> {
+    url = formatPath(url);
     if (!isUrl(url)) {
       throw new Error(`Provided URLs '${url}' is not a URL and cannot be loaded.`);
     }
     return Collection.loadFromAmbiguousResource(url, options);
   }
 
+  /**
+   * Attempts to load a collection from a directory structure.
+   * @param fileName The name of the file that was loaded.
+   * @param fileMap A map of relative paths to a File object.
+   * @param options Optional configuration object containing the following
+   * properties:
+   *   - `reportWarning`: A callback function for reporting warnings about
+   *     malformed data.
+   * @returns A Promise of a new Collection object, either loaded from a
+   * collection JSON file or generated as a wrapper around a single dataset.
+   */
   public static async loadFromAmbiguousFile(
     _fileName: string,
     fileMap: Record<string, File>,
@@ -503,8 +518,7 @@ export default class Collection {
       pathResolver: filePathResolver,
     });
 
-    // TODO: Mark collection as being from a local file?
-
+    // TODO: Mark collection as being from a local file and save the file name.
     return collection;
   }
 }

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -215,6 +215,11 @@ export default class Collection {
     }
   }
 
+  public dispose(): void {
+    this.entries.clear();
+    this.pathResolver.cleanup();
+  }
+
   // ===================================================================================
   // Helper Methods
 
@@ -445,7 +450,7 @@ export default class Collection {
     } catch (e) {
       collectionLoadError = e as Error;
       console.warn(e);
-      console.log("Resource could not be parsed as a collection; attempting to make a single-database collection.");
+      console.log("Resource could not be parsed as a collection; attempting to make a single-dataset collection.");
     }
 
     // Could not load as a collection, attempt to load as a dataset.

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -34,22 +34,11 @@ export type DatasetLoadResult =
       dataset: Dataset;
     };
 
-// export const enum CollectionSourceType {
-//   URL,
-//   FILE,
-// }
-
 export type CollectionLoadOptions = {
   pathResolver?: IPathResolver;
   fetchMethod?: typeof fetchWithTimeout;
   reportWarning?: ReportWarningCallback;
-  // config?: CollectionConfig;
 };
-
-// export type CollectionConfig = {
-//   sourceType: CollectionSourceType;
-//   source: string;
-// };
 
 export type DatasetLoadOptions = {
   manifestLoader?: typeof fetchManifestJson;
@@ -73,8 +62,6 @@ export default class Collection {
    * such as when generating dummy Collections for single datasets.
    */
   public readonly url: string | null;
-  // public readonly type: CollectionSourceType;
-  // public readonly source: string;
 
   /**
    * Constructs a new Collection from a CollectionData map.
@@ -102,7 +89,9 @@ export default class Collection {
           `Expected dataset '${key}' to have an absolute JSON path; collection was provided path '${value.path}'.`
         );
       }
-      if (pathResolver instanceof UrlPathResolver) {
+      // TODO: Replace this with a declared type (file vs. URL) that is passed
+      // in when a Collection is created.
+      if (this.pathResolver instanceof UrlPathResolver) {
         if (!isUrl(value.path)) {
           throw new Error(
             `Expected dataset '${key}' to have a URL path; collection was provided path '${value.path}'.`

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -490,10 +490,7 @@ export default class Collection {
    */
   public static async loadFromAmbiguousUrl(
     url: string,
-    options: Partial<{
-      fetchMethod: typeof fetchWithTimeout;
-      reportWarning: ReportWarningCallback;
-    }> = {}
+    options: Omit<CollectionLoadOptions, "pathResolver"> = {}
   ): Promise<Collection> {
     url = formatPath(url);
     if (!isUrl(url)) {
@@ -516,7 +513,7 @@ export default class Collection {
   public static async loadFromAmbiguousFile(
     _fileName: string,
     fileMap: Record<string, File>,
-    options: Partial<{ reportWarning: ReportWarningCallback }> = {}
+    options: Omit<CollectionLoadOptions, "pathResolver"> = {}
   ): Promise<Collection> {
     const filePathResolver = new FilePathResolver(fileMap);
     let collection: Collection;
@@ -529,7 +526,6 @@ export default class Collection {
       filePathResolver.cleanup();
       throw e;
     }
-
     // TODO: Mark collection as being from a local file and save the file name.
     return collection;
   }

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -514,7 +514,10 @@ export default class Dataset {
 
     const startTime = new Date();
 
-    const resolvedManifestUrl = this.resolveManifestPath(this.manifestUrl)!;
+    const resolvedManifestUrl = this.resolveManifestPath(this.manifestUrl);
+    if (resolvedManifestUrl === null) {
+      throw new Error(`Failed to resolve path for dataset manifest '${this.manifestUrl}'. Does the file exist?`);
+    }
     const manifest = updateManifestVersion(await options.manifestLoader(resolvedManifestUrl));
 
     this.frameFiles = manifest.frames;

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -170,6 +170,10 @@ export default class Dataset {
     this.getSegmentationId = this.getSegmentationId.bind(this);
   }
 
+  private resolveManifestPath = (url: string): string | null => {
+    return this.pathResolver.resolve("", url);
+  };
+
   private resolvePath = (url: string): string | null => {
     return this.pathResolver.resolve(this.baseUrl, url);
   };
@@ -510,7 +514,7 @@ export default class Dataset {
 
     const startTime = new Date();
 
-    const resolvedManifestUrl = this.resolvePath(this.manifestUrl)!;
+    const resolvedManifestUrl = this.resolveManifestPath(this.manifestUrl)!;
     const manifest = updateManifestVersion(await options.manifestLoader(resolvedManifestUrl));
 
     this.frameFiles = manifest.frames;

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -510,7 +510,8 @@ export default class Dataset {
 
     const startTime = new Date();
 
-    const manifest = updateManifestVersion(await options.manifestLoader(this.manifestUrl));
+    const resolvedManifestUrl = this.resolvePath(this.manifestUrl)!;
+    const manifest = updateManifestVersion(await options.manifestLoader(resolvedManifestUrl));
 
     this.frameFiles = manifest.frames;
     const frames3dSrc = manifest.frames3d;

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -1,6 +1,7 @@
 import { DataTexture, RGBAFormat, RGBAIntegerFormat, Texture, Vector2 } from "three";
 
 import { MAX_FEATURE_CATEGORIES } from "../constants";
+import { IPathResolver, UrlPathResolver } from "./path_resolvers";
 import {
   FeatureArrayType,
   FeatureDataType,
@@ -131,6 +132,7 @@ export default class Dataset {
   public baseUrl: string;
   public manifestUrl: string;
   private hasOpened: boolean;
+  private pathResolver: IPathResolver;
 
   /**
    * Constructs a new Dataset using the provided manifest path.
@@ -138,13 +140,17 @@ export default class Dataset {
    * @param frameLoader Optional.
    * @param arrayLoader Optional.
    */
-  constructor(manifestUrl: string, frameLoader?: ITextureImageLoader, arrayLoader?: IArrayLoader) {
+  constructor(
+    manifestUrl: string,
+    options: { frameLoader?: ITextureImageLoader; arrayLoader?: IArrayLoader; pathResolver?: IPathResolver }
+  ) {
     this.manifestUrl = manifestUrl;
+    this.pathResolver = options.pathResolver ?? new UrlPathResolver();
 
     this.baseUrl = urlUtils.formatPath(manifestUrl.substring(0, manifestUrl.lastIndexOf("/")));
     this.hasOpened = false;
 
-    this.frameLoader = frameLoader || new ImageFrameLoader(RGBAIntegerFormat);
+    this.frameLoader = options.frameLoader || new ImageFrameLoader(RGBAIntegerFormat);
     this.frameFiles = [];
     this.frames = null;
     this.backdropFrames = null;
@@ -152,11 +158,11 @@ export default class Dataset {
 
     this.frameToGlobalIdLookup = null;
 
-    this.backdropLoader = frameLoader || new ImageFrameLoader(RGBAFormat);
+    this.backdropLoader = options.frameLoader || new ImageFrameLoader(RGBAFormat);
     this.backdropData = new Map();
 
-    this.cleanupArrayLoaderOnDispose = !arrayLoader;
-    this.arrayLoader = arrayLoader || new UrlArrayLoader();
+    this.cleanupArrayLoaderOnDispose = !options.arrayLoader;
+    this.arrayLoader = options.arrayLoader || new UrlArrayLoader();
     this.features = new Map();
     this.cachedTracks = new Map();
     this.metadata = defaultMetadata;
@@ -164,22 +170,8 @@ export default class Dataset {
     this.getSegmentationId = this.getSegmentationId.bind(this);
   }
 
-  private resolvePathToUrl = (url: string): string => {
-    if (url.startsWith("http://") || url.startsWith("https://")) {
-      return url;
-    } else if (urlUtils.isAllenPath(url)) {
-      const newUrl = urlUtils.convertAllenPathToHttps(url);
-      if (newUrl) {
-        return newUrl;
-      } else {
-        throw new Error(
-          `Error while resolving path: Allen filepath '${url}' was detected but could not be converted to an HTTPS URL.` +
-            ` This may be because the file is in a directory that is not publicly servable.`
-        );
-      }
-    } else {
-      return `${this.baseUrl}/${url}`;
-    }
+  private resolvePath = (url: string): string | null => {
+    return this.pathResolver.resolve(this.baseUrl, url);
   };
 
   private parseFeatureType(inputType: string | undefined, defaultType = FeatureType.CONTINUOUS): FeatureType {
@@ -198,7 +190,10 @@ export default class Dataset {
   private async loadFeature(metadata: ManifestFile["features"][number]): Promise<[string, FeatureData]> {
     const name = metadata.name;
     const key = metadata.key || getKeyFromName(name);
-    const url = this.resolvePathToUrl(metadata.data);
+    const url = this.resolvePath(metadata.data);
+    if (!url) {
+      throw new Error(`Failed to resolve URL for feature ${name}: '${metadata.data}'`);
+    }
     const featureType = this.parseFeatureType(metadata.type);
 
     const source = await this.arrayLoader.load(
@@ -353,7 +348,10 @@ export default class Dataset {
       return null;
     }
 
-    const url = this.resolvePathToUrl(fileUrl);
+    const url = this.resolvePath(fileUrl);
+    if (!url) {
+      throw new Error(`Failed to resolve path: '${fileUrl}'`);
+    }
     const source = await this.arrayLoader.load(url, dataType);
     return source.getBuffer();
   }
@@ -391,7 +389,10 @@ export default class Dataset {
       return undefined;
     }
 
-    const fullUrl = this.resolvePathToUrl(this.frameFiles[index]);
+    const fullUrl = this.resolvePath(this.frameFiles[index]);
+    if (!fullUrl) {
+      throw new Error(`Failed to resolve path for frame ${index}: '${this.frameFiles[index]}'`);
+    }
     const loadedFrame = await this.frameLoader.load(fullUrl);
     this.frameDimensions = new Vector2(loadedFrame.image.width, loadedFrame.image.height);
     const frameSizeBytes = loadedFrame.image.width * loadedFrame.image.height * 4;
@@ -429,7 +430,10 @@ export default class Dataset {
       return undefined;
     }
 
-    const fullUrl = this.resolvePathToUrl(frames[index]);
+    const fullUrl = this.resolvePath(frames[index]);
+    if (!fullUrl) {
+      throw new Error(`Failed to resolve path for backdrop '${key}' at index ${index}: '${frames[index]}'`);
+    }
     const loadedFrame = await this.backdropLoader.load(fullUrl);
     this.backdropFrames?.insert(cacheKey, loadedFrame);
     return loadedFrame;
@@ -511,8 +515,12 @@ export default class Dataset {
     this.frameFiles = manifest.frames;
     const frames3dSrc = manifest.frames3d;
     if (frames3dSrc && frames3dSrc.source) {
+      const frameSource = this.resolvePath(frames3dSrc.source);
+      if (!frameSource) {
+        throw new Error(`Failed to resolve path for 3D frame source: '${frames3dSrc.source}'`);
+      }
       this.frames3d = {
-        source: this.resolvePathToUrl(frames3dSrc.source),
+        source: frameSource,
         segmentationChannel: manifest.frames3d?.segmentationChannel ?? 0,
         totalFrames: manifest.frames3d?.totalFrames ?? 0,
       };

--- a/src/colorizer/loaders/UrlArrayLoader.ts
+++ b/src/colorizer/loaders/UrlArrayLoader.ts
@@ -49,7 +49,7 @@ export default class UrlArrayLoader implements IArrayLoader {
 
   /**
    * Loads array data from the specified URL, handling both JSON and Parquet files.
-   * @param url The URL to load data from. Must end in ".json" or ".parquet".
+   * @param url The URL to load data from. Must be a ".json" or ".parquet" data file.
    * @param type `FeatureDataType` for the returned array source (e.g. `F32` or `U8`).
    * @param min Optional minimum value for the data. If defined, overrides the `min` field
    *   in JSON files or the calculated minimum value for Parquet files.
@@ -59,11 +59,6 @@ export default class UrlArrayLoader implements IArrayLoader {
    * @returns a URLArraySource object containing the loaded data.
    */
   async load<T extends FeatureDataType>(url: string, type: T, min?: number, max?: number): Promise<UrlArraySource<T>> {
-    if (!url.endsWith(".json") && !url.endsWith(".parquet")) {
-      throw new Error(
-        `Encountered unsupported file format when loading data. URL must end in '.parquet' or '.json': ${url}`
-      );
-    }
     const { data, textureInfo, min: newMin, max: newMax } = await this.workerPool.loadUrlData(url, type);
 
     const tex = infoToDataTexture(textureInfo);

--- a/src/colorizer/path_resolvers/FilePathResolver.ts
+++ b/src/colorizer/path_resolvers/FilePathResolver.ts
@@ -1,0 +1,41 @@
+import { formatPath } from "../utils/url_utils";
+
+import { IPathResolver } from "./IPathResolver";
+
+export class FilePathResolver implements IPathResolver {
+  /** Keys are string paths to files, values are File objects. */
+  private files: Record<string, File>;
+  /** Keys are string paths to files, values are URLs (as created by
+   * `URL.createObjectUrl`). Note that this must be cleaned up when the
+   * resolver is no longer needed.
+   */
+  private fileUrls: Record<string, string>;
+
+  constructor(directoryFiles: Record<string, File>) {
+    this.files = directoryFiles;
+    this.fileUrls = {};
+  }
+
+  resolve(baseUrl: string, url: string): string | null {
+    // Remove starting/trailing slashes
+    baseUrl = formatPath(baseUrl);
+    url = formatPath(url);
+    const path = baseUrl !== "" ? baseUrl + "/" + url : url;
+
+    // TODO: Use a nested directory structure to reduce the amount of repeated strings?
+    // Split the path, and look for matches in each level of the directory structure
+    if (!this.files[path]) {
+      return null;
+    }
+    if (!this.fileUrls[path]) {
+      this.fileUrls[path] = URL.createObjectURL(this.files[path]);
+    }
+    return this.fileUrls[path];
+  }
+
+  cleanup(): void {
+    for (const url in this.fileUrls) {
+      URL.revokeObjectURL(this.fileUrls[url]);
+    }
+  }
+}

--- a/src/colorizer/path_resolvers/FilePathResolver.ts
+++ b/src/colorizer/path_resolvers/FilePathResolver.ts
@@ -11,8 +11,13 @@ export class FilePathResolver implements IPathResolver {
    */
   private fileUrls: Record<string, string>;
 
-  constructor(directoryFiles: Record<string, File>) {
-    this.files = directoryFiles;
+  /**
+   * Creates a new FilePathResolver that can be queried to retrieve File objects
+   * from a string relative path.
+   * @param fileMap A map from a relative string path to a File object.
+   */
+  constructor(fileMap: Record<string, File>) {
+    this.files = fileMap;
     this.fileUrls = {};
   }
 
@@ -22,8 +27,6 @@ export class FilePathResolver implements IPathResolver {
     url = formatPath(url);
     const path = baseUrl !== "" ? baseUrl + "/" + url : url;
 
-    // TODO: Use a nested directory structure to reduce the amount of repeated strings?
-    // Split the path, and look for matches in each level of the directory structure
     if (!this.files[path]) {
       return null;
     }

--- a/src/colorizer/path_resolvers/FilePathResolver.ts
+++ b/src/colorizer/path_resolvers/FilePathResolver.ts
@@ -2,6 +2,10 @@ import { formatPath, isAllenPath, isUrl, resolveUrl } from "../utils/url_utils";
 
 import { IPathResolver } from "./IPathResolver";
 
+/**
+ * Creates and manages object URLs for a collection of files, allowing paths to
+ * be resolved to files that can be fetched.
+ */
 export class FilePathResolver implements IPathResolver {
   /** Keys are string paths to files, values are File objects. */
   private files: Record<string, File>;
@@ -21,26 +25,29 @@ export class FilePathResolver implements IPathResolver {
     this.fileUrls = {};
   }
 
-  resolve(baseUrl: string, url: string): string | null {
+  /**
+   * Returns a URL of either a local file or a remote resource. Returns `null`
+   * if the path could not be resolved to an existing file.
+   */
+  resolve(basePath: string, path: string): string | null {
     // Remove starting/trailing slashes
-    baseUrl = formatPath(baseUrl);
-    url = formatPath(url);
+    basePath = formatPath(basePath);
+    path = formatPath(path);
 
     // Check for URL paths and return those directly
-    if (isUrl(url) || isUrl(baseUrl) || isAllenPath(url) || isAllenPath(baseUrl)) {
-      return resolveUrl(baseUrl, url);
+    if (isUrl(path) || isUrl(basePath) || isAllenPath(path) || isAllenPath(basePath)) {
+      return resolveUrl(basePath, path);
     }
-
-    const path = baseUrl !== "" ? baseUrl + "/" + url : url;
 
     // Return a file URL if the file exists.
-    if (!this.files[path]) {
+    const joinedPath = basePath !== "" ? basePath + "/" + path : path;
+    if (!this.files[joinedPath]) {
       return null;
     }
-    if (!this.fileUrls[path]) {
-      this.fileUrls[path] = URL.createObjectURL(this.files[path]);
+    if (!this.fileUrls[joinedPath]) {
+      this.fileUrls[joinedPath] = URL.createObjectURL(this.files[joinedPath]);
     }
-    return this.fileUrls[path];
+    return this.fileUrls[joinedPath];
   }
 
   cleanup(): void {

--- a/src/colorizer/path_resolvers/FilePathResolver.ts
+++ b/src/colorizer/path_resolvers/FilePathResolver.ts
@@ -1,4 +1,4 @@
-import { formatPath } from "../utils/url_utils";
+import { formatPath, isAllenPath, isUrl, resolveUrl } from "../utils/url_utils";
 
 import { IPathResolver } from "./IPathResolver";
 
@@ -25,8 +25,15 @@ export class FilePathResolver implements IPathResolver {
     // Remove starting/trailing slashes
     baseUrl = formatPath(baseUrl);
     url = formatPath(url);
+
+    // Check for URL paths and return those directly
+    if (isUrl(url) || isUrl(baseUrl) || isAllenPath(url) || isAllenPath(baseUrl)) {
+      return resolveUrl(baseUrl, url);
+    }
+
     const path = baseUrl !== "" ? baseUrl + "/" + url : url;
 
+    // Return a file URL if the file exists.
     if (!this.files[path]) {
       return null;
     }

--- a/src/colorizer/path_resolvers/IPathResolver.ts
+++ b/src/colorizer/path_resolvers/IPathResolver.ts
@@ -1,0 +1,5 @@
+/** Resolves paths when loading files from a manifest or collection. */
+export interface IPathResolver {
+  resolve(baseUrl: string, url: string): string | null;
+  cleanup(): void;
+}

--- a/src/colorizer/path_resolvers/IPathResolver.ts
+++ b/src/colorizer/path_resolvers/IPathResolver.ts
@@ -1,5 +1,5 @@
 /** Resolves paths when loading files from a manifest or collection. */
 export interface IPathResolver {
-  resolve(baseUrl: string, url: string): string | null;
+  resolve(basePath: string, path: string): string | null;
   cleanup(): void;
 }

--- a/src/colorizer/path_resolvers/UrlPathResolver.ts
+++ b/src/colorizer/path_resolvers/UrlPathResolver.ts
@@ -1,0 +1,30 @@
+import { convertAllenPathToHttps, formatPath, isAllenPath } from "../utils/url_utils";
+
+import { IPathResolver } from "./IPathResolver";
+
+export class UrlPathResolver implements IPathResolver {
+  resolve(baseUrl: string, url: string): string | null {
+    baseUrl = formatPath(baseUrl);
+    url = formatPath(url);
+
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      return url;
+    } else if (isAllenPath(url)) {
+      const newUrl = convertAllenPathToHttps(url);
+      if (newUrl) {
+        return newUrl;
+      } else {
+        throw new Error(
+          `Error while resolving path: Allen filepath '${url}' was detected but could not be converted to an HTTPS URL.` +
+            ` This may be because the file is in a directory that is not publicly servable.`
+        );
+      }
+    } else {
+      return `${baseUrl}/${url}`;
+    }
+  }
+
+  cleanup(): void {
+    // Nothing to clean up
+  }
+}

--- a/src/colorizer/path_resolvers/UrlPathResolver.ts
+++ b/src/colorizer/path_resolvers/UrlPathResolver.ts
@@ -1,30 +1,11 @@
-import { convertAllenPathToHttps, formatPath, isAllenPath } from "../utils/url_utils";
+import { resolveUrl } from "../utils/url_utils";
 
 import { IPathResolver } from "./IPathResolver";
 
 export class UrlPathResolver implements IPathResolver {
-  resolve(baseUrl: string, url: string): string | null {
-    baseUrl = formatPath(baseUrl);
-    url = formatPath(url);
-
-    if (url.startsWith("http://") || url.startsWith("https://")) {
-      return url;
-    } else if (isAllenPath(url)) {
-      const newUrl = convertAllenPathToHttps(url);
-      if (newUrl) {
-        return newUrl;
-      } else {
-        throw new Error(
-          `Error while resolving path: Allen filepath '${url}' was detected but could not be converted to an HTTPS URL.` +
-            ` This may be because the file is in a directory that is not publicly servable.`
-        );
-      }
-    } else {
-      return `${baseUrl}/${url}`;
-    }
+  resolve(baseUrl: string, url: string): string {
+    return resolveUrl(baseUrl, url);
   }
 
-  cleanup(): void {
-    // Nothing to clean up
-  }
+  cleanup(): void {}
 }

--- a/src/colorizer/path_resolvers/index.ts
+++ b/src/colorizer/path_resolvers/index.ts
@@ -1,0 +1,6 @@
+import { FilePathResolver } from "./FilePathResolver";
+import { IPathResolver as IPathResolverType } from "./IPathResolver";
+import { UrlPathResolver } from "./UrlPathResolver";
+
+export type IPathResolver = IPathResolverType;
+export { FilePathResolver, UrlPathResolver };

--- a/src/colorizer/utils/data_load_utils.ts
+++ b/src/colorizer/utils/data_load_utils.ts
@@ -111,7 +111,14 @@ export async function zipToFileMap(zipFile: File): Promise<Record<string, File>>
     if (zipObject.dir) {
       return;
     }
-    filePromises.push(loadToFileMap(relativePath, zipObject));
+    const loadFileCallback = async (): Promise<void> => {
+      try {
+        return await loadToFileMap(relativePath, zipObject);
+      } catch (error) {
+        console.error(`Failed to load file ${relativePath} from ${zipFile.name}:`, error);
+      }
+    };
+    filePromises.push(loadFileCallback());
   });
 
   await Promise.allSettled(filePromises);

--- a/src/colorizer/utils/data_load_utils.ts
+++ b/src/colorizer/utils/data_load_utils.ts
@@ -95,14 +95,13 @@ export async function zipToFileMap(zipFile: File): Promise<Record<string, File>>
   // Load all contents and save them as File objects
   const fileMap: Record<string, File> = {};
   const filePromises: Promise<void>[] = [];
-  const loadToFileMap = async (relativePath: string, zipObject: JSZip.JSZipObject) => {
+  const loadToFileMap = async (relativePath: string, zipObject: JSZip.JSZipObject): Promise<void> => {
     const fileContents = await zipObject.async("blob");
     fileMap[relativePath] = new File([fileContents], relativePath);
   };
 
   zip.forEach((relativePath, zipObject) => {
     if (zipObject.dir) {
-      // Skip directories
       return;
     }
     filePromises.push(loadToFileMap(relativePath, zipObject));

--- a/src/colorizer/utils/data_load_utils.ts
+++ b/src/colorizer/utils/data_load_utils.ts
@@ -119,8 +119,12 @@ export async function zipToFileMap(zipFile: File): Promise<Record<string, File>>
   // Handle case where files are all nested one or more layers deep in empty
   // folders by removing the shared prefix. This is very common when zipping
   // folders.
+  const fileKeys = Object.keys(fileMap);
+  if (fileKeys.length === 0) {
+    return {};
+  }
   let prefix = Object.keys(fileMap)[0].split("/").slice(0, -1).join("/");
-  for (const key of Object.keys(fileMap)) {
+  for (const key of fileKeys) {
     if (key.startsWith(prefix)) {
       continue;
     }

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -464,6 +464,31 @@ export function formatPath(input: string): string {
   return input.trim();
 }
 
+/**
+ * Resolves relative paths to absolute URLs using an optional base path.
+ * Also handles resolution for `/allen` paths.
+ */
+export function resolveUrl(baseUrl: string, url: string): string {
+  baseUrl = formatPath(baseUrl);
+  url = formatPath(url);
+
+  if (url.startsWith("http://") || url.startsWith("https://")) {
+    return url;
+  } else if (isAllenPath(url)) {
+    const newUrl = convertAllenPathToHttps(url);
+    if (newUrl) {
+      return newUrl;
+    } else {
+      throw new Error(
+        `Error while resolving path: Allen filepath '${url}' was detected but could not be converted to an HTTPS URL.` +
+          ` This may be because the file is in a directory that is not publicly servable.`
+      );
+    }
+  } else {
+    return `${baseUrl}/${url}`;
+  }
+}
+
 export const makeGitHubIssueLink = (title: string, body: string, labels?: string[]): string => {
   const baseUrl = "https://github.com/allen-cell-animated/timelapse-colorizer/issues/new";
   const titleParam = `title=${encodeURIComponent(title)}`;

--- a/src/colorizer/workers/worker.ts
+++ b/src/colorizer/workers/worker.ts
@@ -14,7 +14,18 @@ async function loadUrlData(url: string, type: FeatureDataType): Promise<Transfer
   } else if (url.endsWith(".parquet")) {
     result = await loadFromParquetUrl(url, type);
   } else {
-    throw new Error(`Unsupported file format: ${url}`);
+    // Try loading as either format.
+    try {
+      result = await loadFromJsonUrl(url, type);
+    } catch (error1) {
+      try {
+        result = await loadFromParquetUrl(url, type);
+      } catch (error2) {
+        // TODO: Nicer error handling here?
+        console.error(error1, error2);
+        throw new Error(`Could not parse '${url}' as either a JSON or Parquet file.`);
+      }
+    }
   }
 
   const { min, max, data } = result;

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -171,9 +171,14 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
     return loadCollectionData(collection);
   };
 
-  const handleLoadFromFileMap = async (fileMap: Record<string, File>): Promise<LoadedCollectionResult> => {
-    console.log("Loading from file map:", fileMap);
-    const collection = await Collection.loadCollectionFromFile(fileMap, { reportWarning: props.reportWarning });
+  const handleLoadFromZipFile = async (
+    fileName: string,
+    fileMap: Record<string, File>
+  ): Promise<LoadedCollectionResult> => {
+    console.log("Loading from ZIP file:", fileName);
+    const collection = await Collection.loadFromAmbiguousFile(fileName, fileMap, {
+      reportWarning: props.reportWarning,
+    });
     return loadCollectionData(collection);
   };
 
@@ -333,7 +338,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
                 const fileMap = await zipToFileMap(zipFile);
                 console.log(fileMap);
                 setIsLoading(true);
-                handleLoadFromFileMap(fileMap)
+                handleLoadFromZipFile(zipFile.name, fileMap)
                   .then((result) => onCollectionLoaded(...result))
                   .catch((reason) => {
                     // failed

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -347,6 +347,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
                 const fileMap = await zipToFileMap(zipFile);
                 if (Object.keys(fileMap).length === 0) {
                   setErrorText("No files found in ZIP file.");
+                  setIsLoadingZip(false);
                   return false;
                 }
                 const didLoadCollection = await handleLoadFromZipFile(zipFile.name, fileMap)

--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -171,7 +171,10 @@ describe("Dataset", () => {
             feature1: { type: "categorical" },
           },
         };
-        const dataset = new Dataset(DEFAULT_DATASET_PATH, new MockFrameLoader(), new MockArrayLoader());
+        const dataset = new Dataset(DEFAULT_DATASET_PATH, {
+          frameLoader: new MockFrameLoader(),
+          arrayLoader: new MockArrayLoader(),
+        });
         const mockFetch = makeMockAsyncLoader(DEFAULT_DATASET_PATH, badManifest);
         await expect(dataset.open({ manifestLoader: mockFetch })).rejects.toThrowError(ANY_ERROR);
       });
@@ -190,7 +193,10 @@ describe("Dataset", () => {
             },
           },
         };
-        const dataset = new Dataset(DEFAULT_DATASET_PATH, new MockFrameLoader(), new MockArrayLoader());
+        const dataset = new Dataset(DEFAULT_DATASET_PATH, {
+          frameLoader: new MockFrameLoader(),
+          arrayLoader: new MockArrayLoader(),
+        });
         const mockFetch = makeMockAsyncLoader(DEFAULT_DATASET_PATH, badManifest);
         await expect(dataset.open({ manifestLoader: mockFetch })).rejects.toThrowError(ANY_ERROR);
       });
@@ -208,7 +214,10 @@ describe("Dataset", () => {
         ];
 
         for (const [width, height] of dimensionTests) {
-          const dataset = new Dataset(DEFAULT_DATASET_PATH, new MockFrameLoader(width, height), new MockArrayLoader());
+          const dataset = new Dataset(DEFAULT_DATASET_PATH, {
+            frameLoader: new MockFrameLoader(width, height),
+            arrayLoader: new MockArrayLoader(),
+          });
           expect(dataset.frameResolution).to.deep.equal(new Vector2(1, 1));
           await dataset.open({ manifestLoader: mockFetch });
           expect(dataset.frameResolution).to.deep.equal(new Vector2(width, height));

--- a/tests/colorizer/FilePathResolver.test.ts
+++ b/tests/colorizer/FilePathResolver.test.ts
@@ -5,8 +5,11 @@ import { FilePathResolver } from "../../src/colorizer/path_resolvers";
 describe("FilePathResolver", () => {
   describe("resolve", () => {
     const exampleResolver = new FilePathResolver({
+      // eslint-disable-next-line
       "example.txt": new File(["Hello World\n"], "example.txt"),
+      // eslint-disable-next-line
       "dir/example.txt": new File(["Hello from a directory\n"], "dir/example.txt"),
+      // eslint-disable-next-line
       "dir/subdir/example.txt": new File(["Hello from a subdirectory\n"], "dir/subdir/example.txt"),
     });
 

--- a/tests/colorizer/FilePathResolver.test.ts
+++ b/tests/colorizer/FilePathResolver.test.ts
@@ -4,7 +4,6 @@ import { FilePathResolver } from "../../src/colorizer/path_resolvers";
 
 describe("FilePathResolver", () => {
   describe("resolve", () => {
-    // TODO: Mock createObjectURL because it is not available in the test environment
     const exampleResolver = new FilePathResolver({
       "example.txt": new File(["Hello World\n"], "example.txt"),
       "dir/example.txt": new File(["Hello from a directory\n"], "dir/example.txt"),

--- a/tests/colorizer/FilePathResolver.test.ts
+++ b/tests/colorizer/FilePathResolver.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { FilePathResolver } from "../../src/colorizer/path_resolvers";
+
+describe("FilePathResolver", () => {
+  describe("resolve", () => {
+    // TODO: Mock createObjectURL because it is not available in the test environment
+    const exampleResolver = new FilePathResolver({
+      "example.txt": new File(["Hello World\n"], "example.txt"),
+      "dir/example.txt": new File(["Hello from a directory\n"], "dir/example.txt"),
+      "dir/subdir/example.txt": new File(["Hello from a subdirectory\n"], "dir/subdir/example.txt"),
+    });
+
+    it("returns a file object URL for a given file path", () => {
+      const url1 = exampleResolver.resolve("", "example.txt");
+      const url2 = exampleResolver.resolve("", "dir/example.txt");
+      const url3 = exampleResolver.resolve("", "dir/subdir/example.txt");
+      expect(url1).to.be.a("string");
+      expect(url2).to.be.a("string");
+      expect(url1).not.to.equal(url2);
+      expect(url3).to.be.a("string");
+      expect(url2).not.to.equal(url3);
+    });
+
+    it("returns the same object URL for the same file paths", () => {
+      const url1 = exampleResolver.resolve("", "example.txt");
+      const url2 = exampleResolver.resolve("", "example.txt");
+      expect(url1).to.equal(url2);
+    });
+
+    it("can use base path for relative pathing", () => {
+      const url1 = exampleResolver.resolve("", "example.txt");
+      const url2 = exampleResolver.resolve("dir", "example.txt");
+      const url3 = exampleResolver.resolve("dir/subdir", "example.txt");
+      expect(url1).to.be.a("string");
+      expect(url2).to.be.a("string");
+      expect(url1).not.to.equal(url2);
+      expect(url3).to.be.a("string");
+      expect(url2).not.to.equal(url3);
+    });
+
+    it("returns null when the file does not exist", () => {
+      const url = exampleResolver.resolve("", "nonexistent.txt");
+      expect(url).to.be.null;
+    });
+
+    it("resolves '/allen'", () => {
+      const url1 = exampleResolver.resolve("", "//allen/aics/users/example");
+      const url2 = exampleResolver.resolve("", "/allen/aics/users/example");
+      expect(url1).to.equal("https://dev-aics-dtp-001.int.allencell.org/users/example");
+      expect(url2).to.equal("https://dev-aics-dtp-001.int.allencell.org/users/example");
+    });
+
+    it("returns HTTP/HTTPS URLs as-is", () => {
+      const httpUrl = exampleResolver.resolve("", "http://example.com");
+      const httpsUrl = exampleResolver.resolve("", "https://example.com");
+      expect(httpUrl).to.equal("http://example.com");
+      expect(httpsUrl).to.equal("https://example.com");
+    });
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -17,8 +17,6 @@ window.URL.createObjectURL = (_blob: Blob): string => {
 const { getComputedStyle } = window;
 window.getComputedStyle = (elt) => getComputedStyle(elt);
 
-// Fix error where File and createObjectUrl do not exist:
-
 // Mocks the `zustand` package so stores can be reset after each test run
 vi.mock("zustand");
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,19 +1,23 @@
 import "@testing-library/jest-dom/vitest";
-import "vitest-canvas-mock";
-
 import { cleanup } from "@testing-library/react";
+import { generateUUID } from "three/src/math/MathUtils";
 import { afterEach, vi } from "vitest";
+import "vitest-canvas-mock";
 
 // Fix for the following error:
 // `TypeError: The "obj" argument must be an instance of Blob. Received an instance of Blob`
 // https://github.com/vitest-dev/vitest/issues/3985
-window.URL.createObjectURL = vi.fn();
+window.URL.createObjectURL = (_blob: Blob): string => {
+  return "http://mocked-created-url/" + generateUUID();
+};
 
 // Fix for the following error:
 // `Error: Not implemented: window.computedStyle(elt, pseudoElt)`
 // https://github.com/nickcolley/jest-axe/issues/147 (not the source of error but a relevant workaround)
 const { getComputedStyle } = window;
 window.getComputedStyle = (elt) => getComputedStyle(elt);
+
+// Fix error where File and createObjectUrl do not exist:
 
 // Mocks the `zustand` package so stores can be reset after each test run
 vi.mock("zustand");

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -52,7 +52,7 @@ export function makeMockFetchMethod(validUrl: string, bodyJson: any): typeof fet
     text: function (): Promise<string> {
       throw new Error("Function not implemented.");
     },
-    bytes: function (): Promise<Uint8Array> {
+    bytes: function (): Promise<Uint8Array<ArrayBuffer>> {
       throw new Error("Function not implemented.");
     },
   };
@@ -143,7 +143,7 @@ export const makeMockDataset = async (
   manifest: AnyManifestFile,
   loader: MockArrayLoader = new MockArrayLoader()
 ): Promise<Dataset> => {
-  const dataset = new Dataset(DEFAULT_DATASET_PATH, new MockFrameLoader(), loader);
+  const dataset = new Dataset(DEFAULT_DATASET_PATH, { frameLoader: new MockFrameLoader(), arrayLoader: loader });
   const mockLoader = makeMockAsyncLoader(DEFAULT_DATASET_PATH, manifest);
   await dataset.open({ manifestLoader: mockLoader });
   return dataset;

--- a/tests/utils/data_load_utils.test.ts
+++ b/tests/utils/data_load_utils.test.ts
@@ -1,0 +1,81 @@
+import JSZip from "jszip";
+import { describe, expect, it } from "vitest";
+
+import { zipToFileMap } from "../../src/colorizer/utils/data_load_utils";
+
+describe("zipToFileMap", () => {
+  it("maps zip file entries to file objects", async () => {
+    const zip = new JSZip();
+    zip.file("test1.json", "Hello World\n");
+    zip.file("dir/test2.json", "Hello World 2\n");
+    zip.file("dir/subdir/test3.json", "Hello World 3\n");
+    zip.folder("empty_dir");
+    const zipBlob = await zip.generateAsync({ type: "blob" });
+    const zipFile = new File([zipBlob], "test.zip");
+
+    const fileMap = await zipToFileMap(zipFile);
+    expect(fileMap).toEqual({
+      "test1.json": expect.any(File),
+      "dir/test2.json": expect.any(File),
+      "dir/subdir/test3.json": expect.any(File),
+    });
+  });
+
+  it("strips empty containing directory", async () => {
+    const zip = new JSZip();
+    zip.file("dir/test.json", "Hello World\n");
+    zip.file("dir/test2.json", "Hello World 2\n");
+    zip.file("dir/subdir/test3.json", "Hello World 3\n");
+    const zipBlob = await zip.generateAsync({ type: "blob" });
+    const zipFile = new File([zipBlob], "test.zip");
+
+    const fileMap = await zipToFileMap(zipFile);
+    expect(fileMap).toEqual({
+      "test.json": expect.any(File),
+      "test2.json": expect.any(File),
+      "subdir/test3.json": expect.any(File),
+    });
+  });
+
+  it("strips multiple nested empty containing directories", async () => {
+    const zip = new JSZip();
+    zip.file("dir/subdir1/subdir2/subdir3/test.json", "Hello World\n");
+    zip.file("dir/subdir1/subdir2/subdir3/test2.json", "Hello World 2\n");
+    zip.file("dir/subdir1/subdir2/subdir3/subdir4/test3.json", "Hello World 3\n");
+    const zipBlob = await zip.generateAsync({ type: "blob" });
+    const zipFile = new File([zipBlob], "test.zip");
+
+    const fileMap = await zipToFileMap(zipFile);
+    expect(fileMap).toEqual({
+      "test.json": expect.any(File),
+      "test2.json": expect.any(File),
+      "subdir4/test3.json": expect.any(File),
+    });
+  });
+
+  it("only strips prefixes at directory level", async () => {
+    const zip = new JSZip();
+    zip.file("dir/subdirA/test.json", "Hello World\n");
+    zip.file("dir/subdirB/test2.json", "Hello World 2\n");
+    zip.file("dir/subdirC/test3.json", "Hello World 3\n");
+    const zipBlob = await zip.generateAsync({ type: "blob" });
+    const zipFile = new File([zipBlob], "test.zip");
+    const fileMap = await zipToFileMap(zipFile);
+    expect(fileMap).toEqual({
+      "subdirA/test.json": expect.any(File),
+      "subdirB/test2.json": expect.any(File),
+      "subdirC/test3.json": expect.any(File),
+    });
+  });
+
+  it("keeps file in path when there is only a single file", async () => {
+    const zip = new JSZip();
+    zip.file("dir/subdirA/test.json", "Hello World\n");
+    const zipBlob = await zip.generateAsync({ type: "blob" });
+    const zipFile = new File([zipBlob], "test.zip");
+    const fileMap = await zipToFileMap(zipFile);
+    expect(fileMap).toEqual({
+      "test.json": expect.any(File),
+    });
+  });
+});

--- a/tests/utils/data_load_utils.test.ts
+++ b/tests/utils/data_load_utils.test.ts
@@ -15,8 +15,11 @@ describe("zipToFileMap", () => {
 
     const fileMap = await zipToFileMap(zipFile);
     expect(fileMap).toEqual({
+      // eslint-disable-next-line
       "test1.json": expect.any(File),
+      // eslint-disable-next-line
       "dir/test2.json": expect.any(File),
+      // eslint-disable-next-line
       "dir/subdir/test3.json": expect.any(File),
     });
   });
@@ -31,8 +34,11 @@ describe("zipToFileMap", () => {
 
     const fileMap = await zipToFileMap(zipFile);
     expect(fileMap).toEqual({
+      // eslint-disable-next-line
       "test.json": expect.any(File),
+      // eslint-disable-next-line
       "test2.json": expect.any(File),
+      // eslint-disable-next-line
       "subdir/test3.json": expect.any(File),
     });
   });
@@ -47,8 +53,11 @@ describe("zipToFileMap", () => {
 
     const fileMap = await zipToFileMap(zipFile);
     expect(fileMap).toEqual({
+      // eslint-disable-next-line
       "test.json": expect.any(File),
+      // eslint-disable-next-line
       "test2.json": expect.any(File),
+      // eslint-disable-next-line
       "subdir4/test3.json": expect.any(File),
     });
   });
@@ -62,8 +71,11 @@ describe("zipToFileMap", () => {
     const zipFile = new File([zipBlob], "test.zip");
     const fileMap = await zipToFileMap(zipFile);
     expect(fileMap).toEqual({
+      // eslint-disable-next-line
       "subdirA/test.json": expect.any(File),
+      // eslint-disable-next-line
       "subdirB/test2.json": expect.any(File),
+      // eslint-disable-next-line
       "subdirC/test3.json": expect.any(File),
     });
   });
@@ -75,6 +87,7 @@ describe("zipToFileMap", () => {
     const zipFile = new File([zipBlob], "test.zip");
     const fileMap = await zipToFileMap(zipFile);
     expect(fileMap).toEqual({
+      // eslint-disable-next-line
       "test.json": expect.any(File),
     });
   });


### PR DESCRIPTION
Problem
=======
Part 1 of 3(?) for #747, "Load ZIP files." This first change adds support for the core ZIP parsing behavior. Additional UX and error handling behaviors will be added in a future change.

*Estimated review size: large, 30-40 minutes*

Solution
========
- Added a new option to upload a ZIP file from the load menu.
- Added the `zipToFileMap` method which unpacks the contents of a ZIP file.
- Adds a new `FilePathResolver` class, which allows a map of relative paths and files to be queried and retrieved via URL.
  - `Collection` and `Dataset` can now use `FilePathResolver` in addition to the previous URL resolution behavior.
- Added unit tests.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Download the two example dataset ZIP files: 
[processed_dataset_collection.zip](https://github.com/user-attachments/files/21944720/processed_dataset_collection.zip)
[processed_dataset.zip](https://github.com/user-attachments/files/21944721/processed_dataset.zip) 
2. Open the preview link:
3. Click Load, then **Load from ZIP** and choose the downloaded dataset.
4. The dataset should open. 
5. When loading the `processed_dataset_collection.zip`, it should also open as a collection with two datasets you can switch between. (For the example, it's the same dataset, but two options will appear in the dropdown.)

Screenshots (optional):
-----------------------
**Video talk-through (🔊):**

https://github.com/user-attachments/assets/3733c19b-e111-4d68-a62c-e95afee990ef



Keyfiles (delete if not relevant):
-----------------------
1. `FilePathResolver.ts`
2. `data_load_utils.ts`
3. `Collection.ts`
