### PR TITLE
refactor: Moved time playback controls into a separate component

### DIFF
--- a/src/Viewer.module.css
+++ b/src/Viewer.module.css
@@ -73,25 +73,8 @@
 }
 
 .canvasPanel .timeControls {
-  display: flex;
-  flex-direction: row;
-  gap: 4px;
   max-width: calc(100vw - 60px);
   margin-top: 10px;
-  flex-wrap: wrap;
-  align-items: center;
-}
-
-.timeSliderContainer {
-  width: calc(min(50vw, 300px));
-  margin: 0 4px;
-  height: var(--button-height);
-  display: flex;
-  align-items: center;
-}
-
-.timeSliderContainer > div {
-  width: 100%;
 }
 
 .sidePanels {

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -1,13 +1,5 @@
-import {
-  CaretRightOutlined,
-  CheckCircleOutlined,
-  EllipsisOutlined,
-  PauseOutlined,
-  ShareAltOutlined,
-  StepBackwardFilled,
-  StepForwardFilled,
-} from "@ant-design/icons";
-import { notification, Slider, Tabs } from "antd";
+import { CheckCircleOutlined, EllipsisOutlined, ShareAltOutlined } from "@ant-design/icons";
+import { notification, Tabs } from "antd";
 import { NotificationConfig } from "antd/es/notification/interface";
 import React, { ReactElement, ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useLocation, useSearchParams } from "react-router-dom";
@@ -24,10 +16,10 @@ import {
   TabType,
 } from "./colorizer";
 import { AnalyticsEvent, triggerAnalyticsEvent } from "./colorizer/utils/analytics";
-import { useAnnotations, useConstructor, useDebounce, useRecentCollections } from "./colorizer/utils/react_utils";
+import { useAnnotations, useConstructor, useRecentCollections } from "./colorizer/utils/react_utils";
 import { showFailedUrlParseAlert } from "./components/Banner/alert_templates";
 import { SelectItem } from "./components/Dropdowns/types";
-import { DEFAULT_PLAYBACK_FPS, INTERNAL_BUILD } from "./constants";
+import { INTERNAL_BUILD } from "./constants";
 import { getDifferingProperties } from "./state/utils/data_validation";
 import {
   loadInitialViewerStateFromParams,
@@ -51,17 +43,15 @@ import { useAlertBanner } from "./components/Banner";
 import TextButton from "./components/Buttons/TextButton";
 import CanvasWrapper from "./components/CanvasWrapper";
 import FeatureControls from "./components/Controls/FeatureControls";
+import PlaybackControl from "./components/Controls/PlaybackControl";
 import ColorRampDropdown from "./components/Dropdowns/ColorRampDropdown";
 import HelpDropdown from "./components/Dropdowns/HelpDropdown";
 import SelectionDropdown from "./components/Dropdowns/SelectionDropdown";
 import Export from "./components/Export";
 import GlossaryPanel from "./components/GlossaryPanel";
 import Header from "./components/Header";
-import IconButton from "./components/IconButton";
 import LoadDatasetButton from "./components/LoadDatasetButton";
 import SmallScreenWarning from "./components/Modals/SmallScreenWarning";
-import PlaybackSpeedControl from "./components/PlaybackSpeedControl";
-import SpinBox from "./components/SpinBox";
 import {
   AnnotationTab,
   CorrelationPlotTab,
@@ -107,8 +97,8 @@ function Viewer(): ReactElement {
   const workerPool = getSharedWorkerPool();
   const arrayLoader = useConstructor(() => new UrlArrayLoader(workerPool)).current;
 
-  // TODO: Refactor dataset dropdowns, color ramp controls, and time controls into separate
-  // components to greatly reduce the state required for this component.
+  // TODO: Break down into separate components to greatly reduce the state
+  // required for this component.
   // Get viewer state:
   const categoricalPalette = useViewerStateStore((state) => state.categoricalPalette);
   const collection = useViewerStateStore((state) => state.collection);
@@ -145,8 +135,6 @@ function Viewer(): ReactElement {
   const [datasetLoadProgress, setDatasetLoadProgress] = useState<number | null>(null);
   const [datasetOpen, setDatasetOpen] = useState(false);
 
-  const [playbackFps, setPlaybackFps] = useState(DEFAULT_PLAYBACK_FPS);
-
   const [searchParams, setSearchParams] = useSearchParams();
   // Provides a mounting point for Antd's notification component. Otherwise, the notifications
   // are mounted outside of App and don't receive CSS styling variables.
@@ -162,21 +150,6 @@ function Viewer(): ReactElement {
 
   const [isRecording, setIsRecording] = useState(false);
 
-  // TODO: Move all logic for the time slider into its own component!
-  // Flag indicating that frameInput should not be synced with playback.
-  const [isUserDirectlyControllingFrameInput, setIsUserDirectlyControllingFrameInput] = useState(false);
-
-  useEffect(() => {
-    if (timeControls.isPlaying()) {
-      setIsUserDirectlyControllingFrameInput(false);
-    }
-  }, [timeControls.isPlaying()]);
-
-  const timeSliderContainerRef = useRef<HTMLDivElement>(null);
-  /** The frame selected by the time UI. Changes to frameInput are reflected in
-   * canvas after a short delay.
-   */
-  const [frameInput, setFrameInput] = useState(0);
   const [lastValidHoveredId, setLastValidHoveredId] = useState<PixelIdInfo>({ segId: -1, globalId: undefined });
   const [showObjectHoverInfo, setShowObjectHoverInfo] = useState(false);
   const currentHoveredId = showObjectHoverInfo ? lastValidHoveredId : null;
@@ -215,15 +188,6 @@ function Viewer(): ReactElement {
       updateUrlParams();
     });
   }, [isRecording, updateUrlParams]);
-
-  // Sync the time slider with the pending frame.
-  useEffect(() => {
-    // When user is controlling time slider, do not sync frame input w/ playback
-    if (!isUserDirectlyControllingFrameInput) {
-      return useViewerStateStore.subscribe((state) => state.pendingFrame, setFrameInput);
-    }
-    return;
-  }, [isUserDirectlyControllingFrameInput]);
 
   // When the scatterplot tab is opened for the first time, set the default axes
   // to the selected feature and time.
@@ -485,64 +449,6 @@ function Viewer(): ReactElement {
     [replaceDataset, collection]
   );
 
-  // SCRUBBING CONTROLS ////////////////////////////////////////////////////
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent): void => {
-      if (e.target instanceof HTMLInputElement) {
-        return;
-      }
-      if (e.key === "ArrowLeft" || e.key === "Left") {
-        timeControls.advanceFrame(-1);
-      } else if (e.key === "ArrowRight" || e.key === "Right") {
-        timeControls.advanceFrame(1);
-      }
-    },
-    [timeControls]
-  );
-
-  useEffect(() => {
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [handleKeyDown]);
-
-  // Store the current value of the time slider as its own state, and update
-  // the frame using a debounced value to prevent constant updates as it moves.
-  const debouncedFrameInput = useDebounce(frameInput, 250);
-  useEffect(() => {
-    if (!timeControls.isPlaying() && currentFrame !== debouncedFrameInput) {
-      setFrame(debouncedFrameInput);
-    }
-    // Dependency only contains debouncedFrameInput to prevent time from jumping back
-    // to old debounced values when time playback is paused.
-  }, [debouncedFrameInput]);
-
-  // When the slider is released, check if playback was occurring and resume it.
-  // We need to attach the pointerup event listener to the document because it will not fire
-  // if the user releases the pointer outside of the slider.
-  useEffect(() => {
-    const checkIfPlaybackShouldUnpause = async (event: PointerEvent): Promise<void> => {
-      const target = event.target;
-      if (target && timeSliderContainerRef.current?.contains(target as Node)) {
-        // If the user clicked and released on the slider, update the
-        // time immediately.
-        await setFrame(frameInput);
-      }
-      if (isUserDirectlyControllingFrameInput) {
-        await setFrame(frameInput);
-        timeControls.play();
-        // Update the frame and unpause playback when the slider is released.
-        setIsUserDirectlyControllingFrameInput(false);
-      }
-    };
-
-    document.addEventListener("pointerup", checkIfPlaybackShouldUnpause);
-    return () => {
-      document.removeEventListener("pointerup", checkIfPlaybackShouldUnpause);
-    };
-  }, [isUserDirectlyControllingFrameInput, frameInput]);
-
   const onClickId = useCallback(
     // `info` is null if the user clicked on a background pixel. Otherwise, it
     // contains the segmentation ID (raw image pixel value) and the global ID.
@@ -590,7 +496,6 @@ function Viewer(): ReactElement {
   }, [dataset]);
 
   const disableUi: boolean = isRecording || !datasetOpen;
-  const disableTimeControlsUi = disableUi;
 
   const allTabItems: TabItem[] = [
     {
@@ -782,79 +687,11 @@ function Viewer(): ReactElement {
               </CanvasHoverTooltip>
             </div>
 
-            {/** Time Control Bar */}
             <div className={styles.timeControls}>
-              {timeControls.isPlaying() || isUserDirectlyControllingFrameInput ? (
-                // Swap between play and pause button
-                <IconButton
-                  type="primary"
-                  disabled={disableTimeControlsUi}
-                  onClick={() => {
-                    timeControls.pause();
-                    setFrameInput(currentFrame);
-                  }}
-                >
-                  <PauseOutlined />
-                </IconButton>
-              ) : (
-                <IconButton type="primary" disabled={disableTimeControlsUi} onClick={() => timeControls.play()}>
-                  <CaretRightOutlined />
-                </IconButton>
-              )}
-
-              <div
-                ref={timeSliderContainerRef}
-                className={styles.timeSliderContainer}
-                onPointerDownCapture={() => {
-                  if (timeControls.isPlaying()) {
-                    // If the slider is dragged while playing, pause playback.
-                    timeControls.pause();
-                    setIsUserDirectlyControllingFrameInput(true);
-                  }
-                }}
-              >
-                <Slider
-                  min={0}
-                  max={dataset ? dataset.numberOfFrames - 1 : 0}
-                  disabled={disableTimeControlsUi}
-                  value={frameInput}
-                  onChange={(value) => {
-                    setFrameInput(value);
-                  }}
-                />
-              </div>
-
-              <IconButton
-                disabled={disableTimeControlsUi}
-                onClick={() => timeControls.advanceFrame(-1)}
-                type="outlined"
-              >
-                <StepBackwardFilled />
-              </IconButton>
-              <IconButton disabled={disableTimeControlsUi} onClick={() => timeControls.advanceFrame(1)} type="outlined">
-                <StepForwardFilled />
-              </IconButton>
-
-              <SpinBox
-                min={0}
-                max={dataset?.numberOfFrames && dataset?.numberOfFrames - 1}
-                value={frameInput}
-                onChange={setFrame}
-                disabled={disableTimeControlsUi}
-                wrapIncrement={true}
-              />
-              <div style={{ display: "flex", flexDirection: "row", flexGrow: 1, justifyContent: "flex-end" }}>
-                <PlaybackSpeedControl
-                  fps={playbackFps}
-                  onChange={(fps) => {
-                    setPlaybackFps(fps);
-                    timeControls.setPlaybackFps(fps);
-                  }}
-                  disabled={disableTimeControlsUi}
-                />
-              </div>
+              <PlaybackControl disabled={disableUi} />
             </div>
           </div>
+
           <div className={styles.sidePanels}>
             <div className={styles.plotAndFiltersPanel}>
               <Tabs

--- a/src/components/Controls/PlaybackControl.tsx
+++ b/src/components/Controls/PlaybackControl.tsx
@@ -1,0 +1,189 @@
+import { CaretRightOutlined, PauseOutlined, StepBackwardFilled, StepForwardFilled } from "@ant-design/icons";
+import { Slider } from "antd";
+import React, { ReactElement, useEffect, useRef, useState } from "react";
+import styled from "styled-components";
+
+import { useDebounce } from "../../colorizer/utils/react_utils";
+import { DEFAULT_PLAYBACK_FPS } from "../../constants";
+import { useViewerStateStore } from "../../state";
+import { FlexRowAlignCenter } from "../../styles/utils";
+
+import IconButton from "../IconButton";
+import PlaybackSpeedControl from "../PlaybackSpeedControl";
+import SpinBox from "../SpinBox";
+
+const TimeSliderContainer = styled.div`
+  width: calc(min(50vw, 300px));
+  margin: 0 4px;
+  height: var(--button-height);
+  display: flex;
+  align-items: center;
+
+  & > div {
+    width: 100%;
+  }
+`;
+
+type PlaybackControlProps = {
+  disabled: boolean;
+};
+
+export default function PlaybackControl(props: PlaybackControlProps): ReactElement {
+  const dataset = useViewerStateStore((state) => state.dataset);
+  const currentFrame = useViewerStateStore((state) => state.currentFrame);
+  const setFrame = useViewerStateStore((state) => state.setFrame);
+  const timeControls = useViewerStateStore((state) => state.timeControls);
+
+  const [playbackFps, setPlaybackFps] = useState(DEFAULT_PLAYBACK_FPS);
+  /** The frame selected by the time UI. Changes to frameInput are reflected in
+   * canvas after a short delay.
+   */
+  const [frameInput, setFrameInput] = useState(0);
+
+  // Flag indicating that frameInput should not be synced with playback.
+  const [isUserDirectlyControllingFrameInput, setIsUserDirectlyControllingFrameInput] = useState(false);
+
+  const timeSliderContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (timeControls.isPlaying()) {
+      setIsUserDirectlyControllingFrameInput(false);
+    }
+  }, [timeControls.isPlaying()]);
+
+  // Sync the time slider with the pending frame.
+  useEffect(() => {
+    // When user is controlling time slider, do not sync frame input w/ playback
+    if (!isUserDirectlyControllingFrameInput) {
+      return useViewerStateStore.subscribe((state) => state.pendingFrame, setFrameInput);
+    }
+    return;
+  }, [isUserDirectlyControllingFrameInput]);
+
+  // Store the current value of the time slider as its own state, and update
+  // the frame using a debounced value to prevent constant updates as it moves.
+  const debouncedFrameInput = useDebounce(frameInput, 250);
+  useEffect(() => {
+    if (!timeControls.isPlaying() && currentFrame !== debouncedFrameInput) {
+      setFrame(debouncedFrameInput);
+    }
+    // Dependency only contains debouncedFrameInput to prevent time from jumping back
+    // to old debounced values when time playback is paused.
+  }, [debouncedFrameInput]);
+
+  // When the slider is released, check if playback was occurring and resume it.
+  // We need to attach the pointerup event listener to the document because it will not fire
+  // if the user releases the pointer outside of the slider.
+  useEffect(() => {
+    const checkIfPlaybackShouldUnpause = async (event: PointerEvent): Promise<void> => {
+      const target = event.target;
+      if (target && timeSliderContainerRef.current?.contains(target as Node)) {
+        // If the user clicked and released on the slider, update the
+        // time immediately.
+        await setFrame(frameInput);
+      }
+      if (isUserDirectlyControllingFrameInput) {
+        await setFrame(frameInput);
+        timeControls.play();
+        // Update the frame and unpause playback when the slider is released.
+        setIsUserDirectlyControllingFrameInput(false);
+      }
+    };
+
+    document.addEventListener("pointerup", checkIfPlaybackShouldUnpause);
+    return () => {
+      document.removeEventListener("pointerup", checkIfPlaybackShouldUnpause);
+    };
+  }, [isUserDirectlyControllingFrameInput, frameInput]);
+
+  //// Keyboard Controls ////
+  // TODO: Make this a hook?
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      if (e.target instanceof HTMLInputElement) {
+        return;
+      }
+      if (e.key === "ArrowLeft" || e.key === "Left") {
+        timeControls.advanceFrame(-1);
+      } else if (e.key === "ArrowRight" || e.key === "Right") {
+        timeControls.advanceFrame(1);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [timeControls]);
+
+  //// Rendering ////
+
+  return (
+    <FlexRowAlignCenter $gap={4} style={{ flexWrap: "wrap" }}>
+      {timeControls.isPlaying() || isUserDirectlyControllingFrameInput ? (
+        // Swap between play and pause button
+        <IconButton
+          type="primary"
+          disabled={props.disabled}
+          onClick={() => {
+            timeControls.pause();
+            setFrameInput(currentFrame);
+          }}
+        >
+          <PauseOutlined />
+        </IconButton>
+      ) : (
+        <IconButton type="primary" disabled={props.disabled} onClick={() => timeControls.play()}>
+          <CaretRightOutlined />
+        </IconButton>
+      )}
+
+      <TimeSliderContainer
+        ref={timeSliderContainerRef}
+        onPointerDownCapture={() => {
+          if (timeControls.isPlaying()) {
+            // If the slider is dragged while playing, pause playback.
+            timeControls.pause();
+            setIsUserDirectlyControllingFrameInput(true);
+          }
+        }}
+      >
+        <Slider
+          min={0}
+          max={dataset ? dataset.numberOfFrames - 1 : 0}
+          disabled={props.disabled}
+          value={frameInput}
+          onChange={(value) => {
+            setFrameInput(value);
+          }}
+        />
+      </TimeSliderContainer>
+
+      <IconButton disabled={props.disabled} onClick={() => timeControls.advanceFrame(-1)} type="outlined">
+        <StepBackwardFilled />
+      </IconButton>
+      <IconButton disabled={props.disabled} onClick={() => timeControls.advanceFrame(1)} type="outlined">
+        <StepForwardFilled />
+      </IconButton>
+
+      <SpinBox
+        min={0}
+        max={dataset?.numberOfFrames && dataset?.numberOfFrames - 1}
+        value={frameInput}
+        onChange={setFrame}
+        disabled={props.disabled}
+        wrapIncrement={true}
+      />
+      <div style={{ display: "flex", flexDirection: "row", flexGrow: 1, justifyContent: "flex-end" }}>
+        <PlaybackSpeedControl
+          fps={playbackFps}
+          onChange={(fps) => {
+            setPlaybackFps(fps);
+            timeControls.setPlaybackFps(fps);
+          }}
+          disabled={props.disabled}
+        />
+      </div>
+    </FlexRowAlignCenter>
+  );
+}


### PR DESCRIPTION
Problem
=======
Closes #589, "Move time controls into its own component."

*Estimated review size: small, 15-20 minutes (faster if comparing against original changes)*

Solution
========
- Moved the playback controls out of `Viewer.tsx` and into a new component, `PlaybackControl.tsx`.

Steps to Verify:
----------------
1. Open preview link:
2. Start and stop time playback, move the time slider during playback, adjust the playback speed, try jumping to a specific time.