### PR TITLE
fix: Show error message when .zip file cannot be parsed

### DIFF
--- a/src/colorizer/utils/collection_utils.ts
+++ b/src/colorizer/utils/collection_utils.ts
@@ -52,16 +52,40 @@ type AnyCollectionFile = CollectionFileV1_0_0 | CollectionFileV1_1_0;
  * @returns An object with fields reflecting the most recent CollectionFile spec.
  */
 export const updateCollectionVersion = (collection: AnyCollectionFile): CollectionFile => {
+  let ret: CollectionFile;
+
   if (isV1_0_0(collection)) {
-    return {
+    ret = {
       datasets: collection,
       metadata: {},
     };
+  } else {
+    if (collection.metadata === undefined) {
+      collection.metadata = {};
+    }
+    ret = collection;
   }
 
-  if (collection.metadata === undefined) {
-    collection.metadata = {};
+  // Validate collection
+  if (!Array.isArray(ret.datasets)) {
+    throw new Error("Collection 'datasets' field is not an array.");
+  } else {
+    for (const entry of ret.datasets) {
+      if (entry.path === undefined) {
+        console.error("Missing path in collection entry:", entry);
+        throw new Error(`A dataset entry is missing the 'path' field.`);
+      } else if (typeof entry.path !== "string") {
+        console.error("Received a non-string dataset path:", entry.path);
+        throw new Error(
+          `Received a non-string value for the 'path' field of a dataset entry. Check the console for more details.`
+        );
+      }
+      // If name is missing or not a string, use the path instead
+      if (typeof entry.name !== "string") {
+        entry.name = entry.path;
+      }
+    }
   }
 
-  return collection;
+  return ret;
 };

--- a/src/colorizer/utils/data_load_utils.ts
+++ b/src/colorizer/utils/data_load_utils.ts
@@ -100,7 +100,10 @@ export async function zipToFileMap(
   zipFile: File,
   onLoadProgress?: ReportLoadProgressCallback
 ): Promise<Record<string, File>> {
-  const zip = await JSZip.loadAsync(zipFile);
+  const zip = await JSZip.loadAsync(zipFile).catch((error) => {
+    console.error("Could not parse zip file:", error);
+    throw new Error(`Could not parse '${zipFile.name}'. Please check if it is a valid ZIP file.`);
+  });
 
   // Load all contents and save them as File objects
   const fileMap: Record<string, File> = {};

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -196,9 +196,15 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
       const handleProgressUpdate = (complete: number, total: number): void => {
         setZipLoadProgress(Math.floor((complete / total) * 100));
       };
-      const fileMap = await zipToFileMap(zipFile, handleProgressUpdate);
+      let fileMap: Record<string, File> = {};
+      try {
+        fileMap = await zipToFileMap(zipFile, handleProgressUpdate);
+      } catch (error) {
+        setErrorText(error instanceof Error ? error.message : String(error));
+        setIsLoadingZip(false);
+        return false;
+      }
       if (Object.keys(fileMap).length === 0) {
-        setErrorText("No files found in ZIP file.");
         setIsLoadingZip(false);
         return false;
       }

--- a/src/components/LoadZipModal.tsx
+++ b/src/components/LoadZipModal.tsx
@@ -67,7 +67,14 @@ export default function LoadZipModal(props: LoadZipModalProps): ReactElement {
       const handleProgressUpdate = (complete: number, total: number): void => {
         setLoadProgress(Math.floor((complete / total) * 100));
       };
-      const fileMap = await zipToFileMap(zipFile, handleProgressUpdate);
+      let fileMap: Record<string, File> = {};
+      try {
+        fileMap = await zipToFileMap(zipFile, handleProgressUpdate);
+      } catch (error) {
+        setErrorText(error instanceof Error ? error.message : String(error));
+        setIsLoadingZip(false);
+        return false;
+      }
       if (Object.keys(fileMap).length === 0) {
         setErrorText("No files found in ZIP file.");
         return false;


### PR DESCRIPTION
Problem
=======
Fixes a bug where malformed ZIP files would cause TFE to fail silently by adding handling for errors/exceptions.

Solution
========
- Added schema validation for Collection JSON files.
- Calls to `JSZip.loadAsync` now propagate errors when they occur.
- Added a `try/catch` and error message display in the ZIP file loading menus.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
2. other important file

Thanks for contributing!
