### PR TITLE
fix: Color map reverse

### DIFF
--- a/src/colorizer/ColorRamp.ts
+++ b/src/colorizer/ColorRamp.ts
@@ -129,6 +129,6 @@ export default class ColorRamp {
    */
   public reverse(): ColorRamp {
     const newColorStops = [...this.colorStops].reverse();
-    return new ColorRamp(newColorStops);
+    return new ColorRamp(newColorStops, this.type);
   }
 }

--- a/src/components/Dropdowns/ColorRampDropdown.tsx
+++ b/src/components/Dropdowns/ColorRampDropdown.tsx
@@ -199,7 +199,7 @@ export default function ColorRampSelection(inputProps: ColorRampSelectionProps):
     return selectedRamp.createGradientCanvas(DROPDOWN_WIDTH_PX, theme.controls.height).toDataURL();
   }, [props.selectedRamp, props.reversed]);
 
-  const showAsReversed = props.reversed !== selectedRampData.reverseByDefault;
+  const showAsReversed = props.reversed !== !!selectedRampData.reverseByDefault;
   const selectedRampItem = {
     value: SELECTED_RAMP_ITEM_KEY,
     label: selectedRampData.name + (showAsReversed ? " (reversed)" : ""),


### PR DESCRIPTION
Problem
=======
Fixes two bugs:
1. The color map would show some color ramps as always being reversed.
2. The glasbey ramps would have incorrect behavior when reversed, because their type was not being preserved.

*Estimated review size: tiny, <5 minutes*

Solution
========
What I/we did to solve this problem

with @pairperson1

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* This change requires a documentation update
* This change requires updated or new tests

Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
4. other important file

Thanks for contributing!
