### PR TITLE
fix: Show linear gradient ramps as reversed in dropdown

### DIFF
--- a/src/colorizer/ColorRamp.ts
+++ b/src/colorizer/ColorRamp.ts
@@ -80,7 +80,7 @@ export default class ColorRamp {
       // All other ramp types are linear gradients
       const gradientWidth = options?.vertical ? 0 : width;
       const gradientHeight = options?.vertical ? height : 0;
-      const gradient = ColorRamp.linearGradientFromColors(ctx, this.colorStops, gradientWidth, gradientHeight);
+      const gradient = ColorRamp.linearGradientFromColors(ctx, colorStops, gradientWidth, gradientHeight);
       ctx.fillStyle = gradient;
       ctx.fillRect(0, 0, width, height);
     }


### PR DESCRIPTION
Tiny fix! I think this line got reverted while I was merging changes, and I didn't catch it. Color maps are now shown with dark colors to the right.

| Before | After (these should be reversed so darker colors are on the right):
<img width="240" height="362" alt="image" src="https://github.com/user-attachments/assets/4449f75c-0f90-4198-9206-8f937e6f4658" />

After (fixed):

<img width="202" height="354" alt="image" src="https://github.com/user-attachments/assets/bd43ae53-6169-4592-a58b-ecd386a9ae26" />
