### PR TITLE
feat: Default channel palettes vary by channel quantity (channels pt. 4)

### DIFF
--- a/src/state/slices/channel_slice.ts
+++ b/src/state/slices/channel_slice.ts
@@ -4,11 +4,47 @@ import { StateCreator } from "zustand";
 import { ChannelRangePreset } from "../../colorizer/types";
 import { SerializedStoreData, SubscribableStore } from "../types";
 import { addDerivedStateSubscriber } from "../utils/store_utils";
+import { CollectionSlice } from "./collection_slice";
 import { DatasetSlice } from "./dataset_slice";
+
+import { Backdrop3dData } from "../../colorizer/Dataset";
+
+const WHITE = new Color(1, 1, 1);
+const MAGENTA = new Color(1, 0, 1);
+const CYAN = new Color(0, 1, 1);
+const YELLOW = new Color(1, 1, 0);
+const GREEN = new Color(0, 1, 0);
+
+const ONE_CHANNEL_PALETTE = [WHITE];
+const TWO_CHANNEL_PALETTE = [MAGENTA, GREEN];
+const THREE_CHANNEL_PALETTE = [MAGENTA, CYAN, YELLOW];
+
+function getDefaultColorForChannel(index: number, totalChannels: number): Color {
+  if (totalChannels <= 1) {
+    return ONE_CHANNEL_PALETTE[0];
+  } else if (totalChannels === 2) {
+    return TWO_CHANNEL_PALETTE[index] ?? WHITE;
+  } else {
+    return THREE_CHANNEL_PALETTE[index] ?? WHITE;
+  }
+}
+
+function getDefaultChannelSetting(index: number, totalChannels: number, backdropData?: Backdrop3dData): ChannelSetting {
+  return {
+    visible: index < 3,
+    color: getDefaultColorForChannel(index, totalChannels),
+    opacity: 1,
+    min: backdropData?.min ?? 0,
+    max: backdropData?.max ?? 255,
+    dataMin: backdropData?.min ?? 0,
+    dataMax: backdropData?.max ?? 255,
+  };
+}
 
 export type ChannelSetting = {
   visible: boolean;
   color: Color;
+  /** Opacity value in a [0, 1] range. */
   opacity: number;
   min: number;
   max: number;
@@ -56,32 +92,39 @@ export const createChannelSlice: StateCreator<ChannelSlice, [], [], ChannelSlice
   setApplyChannelRangePresetCallback: (callback) => set({ applyChannelRangePreset: callback }),
 });
 
-export const addChannelDerivedStateSubscribers = (store: SubscribableStore<ChannelSlice & DatasetSlice>): void => {
+export const addChannelDerivedStateSubscribers = (
+  store: SubscribableStore<ChannelSlice & DatasetSlice & CollectionSlice>
+): void => {
+  // When the collection changes, reset the channel settings.
+  addDerivedStateSubscriber(
+    store,
+    (state) => state.collection,
+    () => {
+      const backdropData = store.getState().dataset?.frames3d?.backdrops ?? [];
+      const newChannelSettings = backdropData.map((backdrop, index) => {
+        return getDefaultChannelSetting(index, backdropData.length, backdrop);
+      });
+      return {
+        channelSettings: newChannelSettings,
+      };
+    }
+  );
+
   // When the dataset updates, create a number of default channel settings equal
-  // to the number of backdrop channels in the dataset.
+  // to the number of backdrop channels in the dataset. Preserve existing settings
+  // for channels that currently exist.
   addDerivedStateSubscriber(
     store,
     (state) => ({ dataset: state.dataset }),
     ({ dataset }) => {
-      if (dataset && dataset.frames3d && dataset.frames3d.backdrops) {
-        // TODO: Add a color palette for channels. Ask scientists about
-        // suggested default behavior.
-        // TODO: Preserve colors when switching between datasets.
-        const newChannelSettings = dataset.frames3d.backdrops.map((backdrop) => ({
-          // TODO: Once controls are added for channel settings, update initial
-          // visibility settings. Consider only showing the first 3 channels by
-          // default.
-          visible: true,
-          color: new Color(0.5, 0.5, 0.5),
-          opacity: 1,
-          min: backdrop.min ?? 0,
-          max: backdrop.max ?? 255,
-          dataMin: backdrop.min ?? 0,
-          dataMax: backdrop.max ?? 255,
-        }));
-        return { channelSettings: newChannelSettings };
-      }
-      return {};
+      const backdropData = dataset?.frames3d?.backdrops ?? [];
+      const newChannelSettings = backdropData.map((backdrop, index) => {
+        const defaultSettings = getDefaultChannelSetting(index, backdropData.length, backdrop);
+        const currentSettings = store.getState().channelSettings[index] ?? {};
+        return { ...defaultSettings, ...currentSettings };
+      });
+
+      return { channelSettings: newChannelSettings };
     }
   );
 };

--- a/tests/state/ViewerState/channel_slice.test.ts
+++ b/tests/state/ViewerState/channel_slice.test.ts
@@ -1,0 +1,108 @@
+import { act, renderHook } from "@testing-library/react";
+import { Color } from "three";
+import { describe, expect, it } from "vitest";
+
+import { Dataset } from "../../../src/colorizer";
+import { ManifestFile } from "../../../src/colorizer/utils/dataset_utils";
+import { useViewerStateStore } from "../../../src/state";
+import { makeMockDataset } from "../../test_utils";
+import { MOCK_COLLECTION, MOCK_DATASET_MANIFEST } from "./constants";
+import { setDatasetAsync } from "./utils";
+
+const makeDatasetWithNChannels = async (n: number): Promise<Dataset> => {
+  const originalManifest = MOCK_DATASET_MANIFEST as ManifestFile;
+  const newManifest = {
+    ...originalManifest,
+    frames3d: {
+      ...originalManifest.frames3d,
+      backdrops: originalManifest.frames3d?.backdrops!.slice(0, n),
+    },
+  };
+  return await makeMockDataset(newManifest);
+};
+
+describe("ChannelSlice", () => {
+  describe("state subscribers", () => {
+    describe("resets channel settings when dataset changes", () => {
+      it("defaults to white for single-channel datasets", async () => {
+        const { result } = renderHook(() => useViewerStateStore());
+        const dataset = await makeDatasetWithNChannels(1);
+        await setDatasetAsync(result, dataset);
+        const channelSettings = result.current.channelSettings;
+        expect(channelSettings.length).toBe(1);
+        expect(channelSettings[0].color.getHex()).toBe(0xffffff);
+      });
+
+      it("defaults to magenta and green for two-channel datasets", async () => {
+        const { result } = renderHook(() => useViewerStateStore());
+        const dataset = await makeDatasetWithNChannels(2);
+        await setDatasetAsync(result, dataset);
+        const channelSettings = result.current.channelSettings;
+        expect(channelSettings.length).toBe(2);
+        expect(channelSettings[0].color.getHex()).toBe(0xff00ff);
+        expect(channelSettings[1].color.getHex()).toBe(0x00ff00);
+      });
+
+      it("defaults to magenta, cyan, and yellow for three-channel datasets", async () => {
+        const { result } = renderHook(() => useViewerStateStore());
+        const dataset = await makeDatasetWithNChannels(3);
+        await setDatasetAsync(result, dataset);
+        const channelSettings = result.current.channelSettings;
+        expect(channelSettings.length).toBe(3);
+        expect(channelSettings[0].color.getHex()).toBe(0xff00ff);
+        expect(channelSettings[1].color.getHex()).toBe(0x00ffff);
+        expect(channelSettings[2].color.getHex()).toBe(0xffff00);
+      });
+
+      it("updates the number of channels when the dataset updates", async () => {
+        const { result } = renderHook(() => useViewerStateStore());
+        const dataset1 = await makeDatasetWithNChannels(2);
+        await setDatasetAsync(result, dataset1);
+        expect(result.current.channelSettings.length).toBe(2);
+        const dataset2 = await makeDatasetWithNChannels(0);
+        await setDatasetAsync(result, dataset2);
+        expect(result.current.channelSettings.length).toBe(0);
+      });
+
+      it("preserves existing channel settings when the dataset updates", async () => {
+        const { result } = renderHook(() => useViewerStateStore());
+        const dataset1 = await makeDatasetWithNChannels(2);
+        await setDatasetAsync(result, dataset1);
+        expect(result.current.channelSettings.length).toBe(2);
+        act(() => {
+          useViewerStateStore.getState().updateChannelSettings(0, {
+            visible: false,
+          });
+        });
+        const dataset2 = await makeDatasetWithNChannels(0);
+        await setDatasetAsync(result, dataset2);
+        expect(result.current.channelSettings.length).toBe(0);
+      });
+    });
+
+    it("resets channel settings when collection changes", async () => {
+      const { result } = renderHook(() => useViewerStateStore());
+      const dataset = await makeDatasetWithNChannels(1);
+      await setDatasetAsync(result, dataset);
+
+      const initialChannelSettings = [...result.current.channelSettings];
+      expect(initialChannelSettings.length).toBe(1);
+      act(() => {
+        useViewerStateStore.getState().updateChannelSettings(0, {
+          visible: false,
+          color: new Color("#888888"),
+          opacity: 0.5,
+        });
+      });
+      expect(result.current.channelSettings).not.toEqual(initialChannelSettings);
+      expect(result.current.channelSettings[0].visible).toBe(false);
+      expect(result.current.channelSettings[0].color.getHexString()).toBe("888888");
+      expect(result.current.channelSettings[0].opacity).toBe(0.5);
+
+      act(() => {
+        useViewerStateStore.getState().setCollection(MOCK_COLLECTION);
+      });
+      expect(result.current.channelSettings).toEqual(initialChannelSettings);
+    });
+  });
+});


### PR DESCRIPTION
Problem
=======
Part 4 of 5 for #619, "Show other channels in addition to segmentations."

Solution
========
- Added default colors for background channels, which vary based on the number of channels in the dataset.
  - 1 channel: white
  - 2 channels: magenta, green
  - 3 channels: magenta, yellow, cyan

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
Testing URL saving
1. Open the preview link:
2. You should see the following settings in the channel settings:
3. 


Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
4. other important file

Thanks for contributing!
