### PR TITLE
fix: Reversed ordering of export and cancel buttons in Export modal

### DIFF
--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -572,6 +572,9 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
         {(percentComplete !== 0 || isRecording) && (
           <StyledInlineProgress percent={percentComplete} error={!!errorText} />
         )}
+        <Button onClick={handleCancel} style={{ width: "76px" }} disabled={isPlayingCloseAnimation}>
+          {isRecording ? "Cancel" : "Close"}
+        </Button>
         <Button
           type={isRecording ? "default" : "primary"}
           onClick={isRecording ? handleStop : handleStartExport}
@@ -580,9 +583,6 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
           id={isRecording ? "export-modal-stop-button" : "export-modal-export-button"}
         >
           {isRecording ? "Stop" : "Export"}
-        </Button>
-        <Button onClick={handleCancel} style={{ width: "76px" }} disabled={isPlayingCloseAnimation}>
-          {isRecording ? "Cancel" : "Close"}
         </Button>
       </HorizontalDiv>
       {errorText && <p style={{ color: theme.color.text.error, textAlign: "left" }}>{errorText}</p>}


### PR DESCRIPTION
Problem
=======
Tiny fix for an issue noted during UX office hours. The primary action button ("Export") should be the rightmost action in the export modal.

*Estimated review size: tiny, 1 minute*

| Before | After |
| --- | --- |
| <img width="537" height="675" alt="{E6C513F0-1639-48FE-B965-C15BA1EF94E0}" src="https://github.com/user-attachments/assets/20e67375-2631-46aa-b429-a6c50e989b92" /> | <img width="561" height="694" alt="{73D65376-4103-4554-ACED-E7BEC2069ACD}" src="https://github.com/user-attachments/assets/4b1bfcf0-1652-4d4b-b303-bce6af54ed33" /> |

