### PR TITLE
feat: Sync correlation plot state to URL

### DIFF
--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -1,5 +1,3 @@
-/* global RequestInit */
-// Typescript doesn't recognize RequestInit
 import { Color } from "three";
 
 import { MAX_FEATURE_CATEGORIES } from "src/colorizer/constants";
@@ -356,12 +354,14 @@ export function serializeFeatureList(features: string[], dataset?: Dataset): str
  * `URL_PARAM_ALL_FEATURES` placeholder.
  */
 export function deserializeFeatureList(features: string | null, dataset?: Dataset): string[] | undefined {
-  if (!features) {
+  if (features === null) {
     return undefined;
-  }
-  if (features === URL_PARAM_ALL_FEATURES) {
+  } else if (features === "") {
+    return [];
+  } else if (features === URL_PARAM_ALL_FEATURES) {
     return dataset ? [...dataset.featureKeys] : undefined;
   }
+
   let ret = features.split(",").map(decodeURIComponent);
   if (dataset) {
     ret = ret.filter((key) => dataset.hasFeatureKey(key));

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -1,7 +1,7 @@
 import { Color } from "three";
 
 import { MAX_FEATURE_CATEGORIES } from "src/colorizer/constants";
-import Dataset from "src/colorizer/Dataset";
+import type Dataset from "src/colorizer/Dataset";
 import {
   CentroidColorMode,
   type ChannelSetting,

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -351,8 +351,7 @@ export function serializeFeatureList(features: string[], dataset?: Dataset): str
 }
 
 /**
- * Deserializes a list of feature keys. If `dataset` is provided, includes only
- * keys that are present in the dataset and also handles the
+ * Deserializes a list of feature keys. If `dataset` is provided, handles the
  * `URL_PARAM_ALL_FEATURES` placeholder.
  */
 export function deserializeFeatureList(features: string | null, dataset?: Dataset): string[] | undefined {
@@ -363,12 +362,7 @@ export function deserializeFeatureList(features: string | null, dataset?: Datase
   } else if (features === URL_PARAM_ALL_FEATURES) {
     return dataset ? [...dataset.featureKeys] : undefined;
   }
-
-  let ret = features.split(",").map(decodeURIComponent);
-  if (dataset) {
-    ret = ret.filter((key) => dataset.hasFeatureKey(key));
-  }
-  return ret;
+  return features.split(",").map(decodeURIComponent);
 }
 
 export function serializeTrackPathSteps(

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -332,9 +332,11 @@ export function deserializeThresholds(thresholds: string | null): FeatureThresho
 
 /**
  * Serializes a list of feature keys as a list of encoded strings separated by
- * commas. If a dataset is provided, and the list of features is the full set of
- * features in the dataset, returns the placeholder `URL_PARAM_ALL_FEATURES`
- * instead.
+ * commas. If a dataset is provided, it will be used to filter the list of
+ * feature keys to only those that are present in the dataset.
+ *
+ * Additionally, if the list of features is the full set of features in the
+ * dataset, returns the placeholder `URL_PARAM_ALL_FEATURES` instead.
  */
 export function serializeFeatureList(features: string[], dataset?: Dataset): string {
   if (dataset) {

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -3,6 +3,7 @@
 import { Color } from "three";
 
 import { MAX_FEATURE_CATEGORIES } from "src/colorizer/constants";
+import Dataset from "src/colorizer/Dataset";
 import {
   CentroidColorMode,
   type ChannelSetting,
@@ -29,23 +30,29 @@ import { formatNumber } from "./math_utils";
 
 export const URL_COLOR_RAMP_REVERSED_SUFFIX = "!";
 export const URL_PATH_SHOW_ALL_SUFFIX = "!";
+export const URL_PARAM_ALL_FEATURES = "!";
+
 export enum UrlParam {
+  // Data sources
   COLLECTION = "collection",
   DATASET = "dataset",
   SOURCE_ZIP = "zip",
-  TRACK = "track",
-  FEATURE = "feature",
+  // View settings
   TIME = "t",
   THRESHOLDS = "filters",
+  SHOW_SCALEBAR = "scalebar",
+  SHOW_TIMESTAMP = "timestamp",
+  OPEN_TAB = "tab",
+  INTERPOLATE_3D = "interpolate",
+  // Track selection
+  TRACK = "track",
+  // Colorization
+  FEATURE = "feature",
   RANGE = "range",
+  KEEP_RANGE = "keep-range",
   COLOR_RAMP = "color",
   PALETTE = "palette",
   PALETTE_KEY = "palette-key",
-  SHOW_BACKDROP = "bg",
-  BACKDROP_KEY = "bg-key",
-  BACKDROP_BRIGHTNESS = "bg-brightness",
-  BACKDROP_SATURATION = "bg-sat",
-  OBJECT_OPACITY = "fg-alpha",
   OUTLIER_MODE = "outlier-mode",
   OUTLIER_COLOR = "outlier-color",
   FILTERED_MODE = "filter-mode",
@@ -56,11 +63,19 @@ export enum UrlParam {
   EDGE_COLOR = "edge-color",
   EDGE_MODE = "edge",
   SHOW_SEGMENTATIONS = "seg",
+  // Backdrops
+  SHOW_BACKDROP = "bg",
+  BACKDROP_KEY = "bg-key",
+  BACKDROP_BRIGHTNESS = "bg-brightness",
+  BACKDROP_SATURATION = "bg-sat",
+  OBJECT_OPACITY = "fg-alpha",
+  // Centroid viz
   SHOW_CENTROIDS = "centroids",
   CENTROID_COLOR_MODE = "centroid-mode",
   CENTROID_COLOR = "centroid-color",
   CENTROID_RADIUS = "centroid-radius",
   CENTROID_OPACITY = "ct-alpha",
+  // Path viz
   SHOW_PATH = "path",
   PATH_COLOR = "path-color",
   PATH_COLOR_RAMP = "path-ramp",
@@ -70,9 +85,7 @@ export enum UrlParam {
   PATH_STEPS = "path-steps",
   PATH_PERSIST_OUT_OF_RANGE = "path-persist",
   PATH_OVERLAY_OPACITY = "path-overlay",
-  SHOW_SCALEBAR = "scalebar",
-  SHOW_TIMESTAMP = "timestamp",
-  KEEP_RANGE = "keep-range",
+  // Scatter plot
   SCATTERPLOT_X_AXIS = "scatter-x",
   SCATTERPLOT_Y_AXIS = "scatter-y",
   SCATTERPLOT_BINS = "scatter-bins",
@@ -83,9 +96,8 @@ export enum UrlParam {
   SCATTERPLOT_SHOW_AVERAGE_LINE = "sc-avg",
   SCATTERPLOT_AVERAGE_LINE_WINDOW = "sc-avg-n",
   SCATTERPLOT_AVERAGE_LINE_WIDTH = "sc-avg-w",
-  OPEN_TAB = "tab",
+  // Vector viz
   SHOW_VECTOR = "vc",
-  INTERPOLATE_3D = "interpolate",
   VECTOR_KEY = "vc-key",
   VECTOR_COLOR = "vc-color",
   VECTOR_SCALE = "vc-scale",
@@ -93,7 +105,7 @@ export enum UrlParam {
   VECTOR_THICKNESS = "vc-thickness",
   VECTOR_TOOLTIP_MODE = "vc-tooltip",
   VECTOR_TIME_INTERVALS = "vc-time-int",
-  // Plot 3D
+  // 3D flow field plot
   PLOT3D_X_AXIS = "p3d-x",
   PLOT3D_Y_AXIS = "p3d-y",
   PLOT3D_Z_AXIS = "p3d-z",
@@ -106,6 +118,8 @@ export enum UrlParam {
   PLOT3D_AVERAGE_LINE_WINDOW = "p3d-avg-n",
   PLOT3D_USE_GAUSSIAN = "p3d-gauss",
   PLOT3D_GAUSSIAN_BANDWIDTH = "p3d-gauss-bw",
+  // Correlation Plot
+  CORRELATION_PLOT_FEATURES = "corr",
 }
 
 export enum ChannelSettingUrlParam {
@@ -316,6 +330,43 @@ export function deserializeThresholds(thresholds: string | null): FeatureThresho
     }
     return acc;
   }, [] as FeatureThreshold[]);
+}
+
+/**
+ * Serializes a list of feature keys as a list of encoded strings separated by
+ * commas. If a dataset is provided, and the list of features is the full set of
+ * features in the dataset, returns the placeholder `URL_PARAM_ALL_FEATURES`
+ * instead.
+ */
+export function serializeFeatureList(features: string[], dataset?: Dataset): string {
+  if (dataset) {
+    features = features.filter((key) => dataset.hasFeatureKey(key));
+    const featureSet = new Set(features);
+    if (featureSet.size === dataset.featureKeys.length) {
+      return URL_PARAM_ALL_FEATURES;
+    }
+  }
+
+  return features.map(encodeURIComponent).join(",");
+}
+
+/**
+ * Deserializes a list of feature keys. If `dataset` is provided, includes only
+ * keys that are present in the dataset and also handles the
+ * `URL_PARAM_ALL_FEATURES` placeholder.
+ */
+export function deserializeFeatureList(features: string | null, dataset?: Dataset): string[] | undefined {
+  if (!features) {
+    return undefined;
+  }
+  if (features === URL_PARAM_ALL_FEATURES) {
+    return dataset ? [...dataset.featureKeys] : undefined;
+  }
+  let ret = features.split(",").map(decodeURIComponent);
+  if (dataset) {
+    ret = ret.filter((key) => dataset.hasFeatureKey(key));
+  }
+  return ret;
 }
 
 export function serializeTrackPathSteps(

--- a/src/components/Tabs/CorrelationPlot/CorrelationPlotTab.tsx
+++ b/src/components/Tabs/CorrelationPlot/CorrelationPlotTab.tsx
@@ -70,20 +70,20 @@ export default memo(function CorrelationPlotTab(props: CorrelationPlotTabProps):
   const legendRef = useRef<HTMLDivElement>(null);
   const tooltipDivRef = useRef<HTMLDivElement>(null);
 
-  const correlationFeatures = useViewerStateStore((state) => state.correlationFeatures);
-  const setCorrelationFeatures = useViewerStateStore((state) => state.setCorrelationFeatures);
+  const selectedFeatures = useViewerStateStore((state) => state.correlationFeatures);
+  const setSelectedFeatures = useViewerStateStore((state) => state.setCorrelationFeatures);
   const lastRenderedPlotFeatures = useRef<Set<string>>(new Set());
 
   const sortedSelectedFeatures = useMemo(() => {
     // Keep in sorted order of the dataset
-    const featureSet = new Set(correlationFeatures);
+    const featureSet = new Set(selectedFeatures);
     return props.dataset?.featureKeys.filter((f) => featureSet.has(f)) || [];
-  }, [props.dataset, correlationFeatures]);
+  }, [props.dataset, selectedFeatures]);
 
   useEffect(() => {
     // Selects all features from the dataset on initial load.
-    if (props.dataset && correlationFeatures.length === 0) {
-      setCorrelationFeatures(props.dataset.featureKeys);
+    if (props.dataset && selectedFeatures.length === 0) {
+      setSelectedFeatures(props.dataset.featureKeys);
     }
   }, [props.dataset]);
 
@@ -95,7 +95,7 @@ export default memo(function CorrelationPlotTab(props: CorrelationPlotTabProps):
   // Plot Rendering
   //////////////////////////////////
 
-  const plotDependencies = [dataset, correlationFeatures];
+  const plotDependencies = [dataset, selectedFeatures];
 
   const renderPlot = async (_forceRelayout: boolean = false): Promise<void> => {
     if (!props.dataset || !legendRef.current || !plotDivRef.current || !tooltipDivRef.current) {
@@ -177,14 +177,14 @@ export default memo(function CorrelationPlotTab(props: CorrelationPlotTabProps):
           options={featureOptions}
           value={sortedSelectedFeatures}
           maxTagCount={"responsive"}
-          onClear={() => setCorrelationFeatures([])}
+          onClear={() => setSelectedFeatures([])}
           disabled={!props.dataset}
           onSelect={(value) => {
-            setCorrelationFeatures([...correlationFeatures, value as string]);
+            setSelectedFeatures([...selectedFeatures, value as string]);
           }}
-          onDeselect={(value) => setCorrelationFeatures(correlationFeatures.filter((f) => f !== value))}
+          onDeselect={(value) => setSelectedFeatures(selectedFeatures.filter((f) => f !== value))}
         ></Select>
-        <Button onClick={() => setCorrelationFeatures(props.dataset?.featureKeys || [])} type="primary">
+        <Button onClick={() => setSelectedFeatures(props.dataset?.featureKeys || [])} type="primary">
           Select all
         </Button>
       </FlexRowAlignCenter>

--- a/src/components/Tabs/CorrelationPlot/CorrelationPlotTab.tsx
+++ b/src/components/Tabs/CorrelationPlot/CorrelationPlotTab.tsx
@@ -70,7 +70,7 @@ export default memo(function CorrelationPlotTab(props: CorrelationPlotTabProps):
   const legendRef = useRef<HTMLDivElement>(null);
   const tooltipDivRef = useRef<HTMLDivElement>(null);
 
-  const selectedFeatures = useViewerStateStore((state) => state.correlationFeatures);
+  const selectedFeatures = useViewerStateStore((state) => state.correlationFeatures) ?? [];
   const setSelectedFeatures = useViewerStateStore((state) => state.setCorrelationFeatures);
   const lastRenderedPlotFeatures = useRef<Set<string>>(new Set());
 
@@ -79,13 +79,6 @@ export default memo(function CorrelationPlotTab(props: CorrelationPlotTabProps):
     const featureSet = new Set(selectedFeatures);
     return props.dataset?.featureKeys.filter((f) => featureSet.has(f)) || [];
   }, [props.dataset, selectedFeatures]);
-
-  useEffect(() => {
-    // Selects all features from the dataset on initial load.
-    if (props.dataset && selectedFeatures.length === 0) {
-      setSelectedFeatures(props.dataset.featureKeys);
-    }
-  }, [props.dataset]);
 
   // Debounce changes to the dataset to prevent noticeably blocking the UI thread with a re-render.
   // Show the loading spinner right away, but don't initiate the state update + render until the debounce has settled.

--- a/src/components/Tabs/CorrelationPlot/CorrelationPlotTab.tsx
+++ b/src/components/Tabs/CorrelationPlot/CorrelationPlotTab.tsx
@@ -12,6 +12,7 @@ import type { Dataset } from "src/colorizer";
 import type SharedWorkerPool from "src/colorizer/workers/SharedWorkerPool";
 import LoadingSpinner from "src/components/LoadingSpinner";
 import { useDebounce } from "src/hooks";
+import { useViewerStateStore } from "src/state";
 import { FlexColumnAlignCenter, FlexRowAlignCenter } from "src/styles/utils";
 
 import {
@@ -69,19 +70,20 @@ export default memo(function CorrelationPlotTab(props: CorrelationPlotTabProps):
   const legendRef = useRef<HTMLDivElement>(null);
   const tooltipDivRef = useRef<HTMLDivElement>(null);
 
-  const [selectedFeatures, setSelectedFeatures] = useState<string[]>([]);
+  const correlationFeatures = useViewerStateStore((state) => state.correlationFeatures);
+  const setCorrelationFeatures = useViewerStateStore((state) => state.setCorrelationFeatures);
   const lastRenderedPlotFeatures = useRef<Set<string>>(new Set());
 
   const sortedSelectedFeatures = useMemo(() => {
     // Keep in sorted order of the dataset
-    const featureSet = new Set(selectedFeatures);
+    const featureSet = new Set(correlationFeatures);
     return props.dataset?.featureKeys.filter((f) => featureSet.has(f)) || [];
-  }, [props.dataset, selectedFeatures]);
+  }, [props.dataset, correlationFeatures]);
 
   useEffect(() => {
     // Selects all features from the dataset on initial load.
-    if (props.dataset && selectedFeatures.length === 0) {
-      setSelectedFeatures(props.dataset.featureKeys);
+    if (props.dataset && correlationFeatures.length === 0) {
+      setCorrelationFeatures(props.dataset.featureKeys);
     }
   }, [props.dataset]);
 
@@ -93,7 +95,7 @@ export default memo(function CorrelationPlotTab(props: CorrelationPlotTabProps):
   // Plot Rendering
   //////////////////////////////////
 
-  const plotDependencies = [dataset, selectedFeatures];
+  const plotDependencies = [dataset, correlationFeatures];
 
   const renderPlot = async (_forceRelayout: boolean = false): Promise<void> => {
     if (!props.dataset || !legendRef.current || !plotDivRef.current || !tooltipDivRef.current) {
@@ -175,14 +177,14 @@ export default memo(function CorrelationPlotTab(props: CorrelationPlotTabProps):
           options={featureOptions}
           value={sortedSelectedFeatures}
           maxTagCount={"responsive"}
-          onClear={() => setSelectedFeatures([])}
+          onClear={() => setCorrelationFeatures([])}
           disabled={!props.dataset}
           onSelect={(value) => {
-            setSelectedFeatures([...selectedFeatures, value as string]);
+            setCorrelationFeatures([...correlationFeatures, value as string]);
           }}
-          onDeselect={(value) => setSelectedFeatures(selectedFeatures.filter((f) => f !== value))}
+          onDeselect={(value) => setCorrelationFeatures(correlationFeatures.filter((f) => f !== value))}
         ></Select>
-        <Button onClick={() => setSelectedFeatures(props.dataset?.featureKeys || [])} type="primary">
+        <Button onClick={() => setCorrelationFeatures(props.dataset?.featureKeys || [])} type="primary">
           Select all
         </Button>
       </FlexRowAlignCenter>

--- a/src/state/slices/correlation_slice.ts
+++ b/src/state/slices/correlation_slice.ts
@@ -1,0 +1,86 @@
+import { StateCreator } from "zustand";
+
+import { deserializeFeatureList, serializeFeatureList, UrlParam } from "src/colorizer/utils/url_utils";
+
+import { SerializedStoreData, SubscribableStore } from "../types";
+import { addDerivedStateSubscriber } from "../utils/store_utils";
+import { DatasetSlice } from "./dataset_slice";
+
+export type CorrelationSliceState = {
+  /** Current list of features selected for the correlation plot calculation. */
+  correlationFeatures: string[];
+};
+
+export type CorrelationSliceSerializableState = Pick<CorrelationSliceState, "correlationFeatures">;
+
+export type CorrelationSliceActions = {
+  setCorrelationFeatures: (features: string[]) => void;
+};
+
+export type CorrelationSlice = CorrelationSliceState & CorrelationSliceActions;
+
+export const createCorrelationSlice: StateCreator<CorrelationSlice & DatasetSlice, [], [], CorrelationSlice> = (
+  set,
+  get
+) => ({
+  correlationFeatures: [],
+
+  setCorrelationFeatures: (features: string[]) => {
+    const { dataset } = get();
+    if (dataset) {
+      features = features.filter((key) => dataset.hasFeatureKey(key));
+    }
+    set({ correlationFeatures: features });
+  },
+});
+
+export const addCorrelationDerivedStateSubscribers = (
+  store: SubscribableStore<CorrelationSlice & DatasetSlice>
+): void => {
+  addDerivedStateSubscriber(
+    store,
+    (state) => ({ dataset: state.dataset }),
+    ({ dataset }) => {
+      // Validate that all correlation features are in the dataset.
+      const newFeatures = store.getState().correlationFeatures.filter((feature) => dataset?.hasFeatureKey(feature));
+      if (newFeatures.length === store.getState().correlationFeatures.length) {
+        return {};
+      }
+      return {
+        correlationFeatures: newFeatures,
+      };
+    }
+  );
+};
+
+export const serializeCorrelationSlice = (
+  slice: Partial<CorrelationSliceSerializableState & DatasetSlice>
+): SerializedStoreData => {
+  const ret: SerializedStoreData = {};
+  if (slice.correlationFeatures) {
+    ret[UrlParam.CORRELATION_PLOT_FEATURES] = serializeFeatureList(
+      slice.correlationFeatures,
+      slice.dataset ?? undefined
+    );
+  }
+  return ret;
+};
+
+export const selectCorrelationSliceSerializationDeps = (
+  slice: CorrelationSlice
+): CorrelationSliceSerializableState => ({
+  correlationFeatures: slice.correlationFeatures,
+});
+
+export const loadCorrelationSliceFromParams = (
+  slice: CorrelationSlice & DatasetSlice,
+  params: URLSearchParams
+): void => {
+  const featuresParam = params.get(UrlParam.CORRELATION_PLOT_FEATURES);
+  if (featuresParam) {
+    const features = deserializeFeatureList(featuresParam, slice.dataset ?? undefined);
+    if (features) {
+      slice.setCorrelationFeatures(features);
+    }
+  }
+};

--- a/src/state/slices/correlation_slice.ts
+++ b/src/state/slices/correlation_slice.ts
@@ -7,8 +7,12 @@ import { addDerivedStateSubscriber } from "src/state/utils/store_utils";
 import type { DatasetSlice } from "./dataset_slice";
 
 export type CorrelationSliceState = {
-  /** Current list of features selected for the correlation plot calculation. */
-  correlationFeatures: string[];
+  /**
+   * Current list of features selected for the correlation plot calculation.
+   * Null if uninitialized; will be set to the full set of features when a
+   * dataset is loaded.
+   */
+  correlationFeatures: string[] | null;
 };
 
 export type CorrelationSliceSerializableState = Pick<CorrelationSliceState, "correlationFeatures">;
@@ -23,7 +27,7 @@ export const createCorrelationSlice: StateCreator<CorrelationSlice & DatasetSlic
   set,
   get
 ) => ({
-  correlationFeatures: [],
+  correlationFeatures: null,
 
   setCorrelationFeatures: (features: string[]) => {
     const { dataset } = get();
@@ -42,13 +46,19 @@ export const addCorrelationDerivedStateSubscribers = (
     (state) => ({ dataset: state.dataset }),
     ({ dataset }) => {
       if (dataset === null) {
-        return {};
+        return;
+      }
+      const correlationFeatures = store.getState().correlationFeatures;
+      if (correlationFeatures === null) {
+        return {
+          correlationFeatures: [...dataset.featureKeys],
+        };
       }
       // Validate that all correlation features are in the dataset.
-      const newFeatures = store.getState().correlationFeatures.filter((feature) => dataset.hasFeatureKey(feature));
-      if (newFeatures.length === store.getState().correlationFeatures.length) {
+      const newFeatures = correlationFeatures.filter((feature) => dataset.hasFeatureKey(feature));
+      if (newFeatures.length === correlationFeatures.length) {
         // Make no changes if all features are valid
-        return {};
+        return;
       }
       return {
         correlationFeatures: newFeatures,

--- a/src/state/slices/correlation_slice.ts
+++ b/src/state/slices/correlation_slice.ts
@@ -41,9 +41,13 @@ export const addCorrelationDerivedStateSubscribers = (
     store,
     (state) => ({ dataset: state.dataset }),
     ({ dataset }) => {
+      if (dataset === null) {
+        return {};
+      }
       // Validate that all correlation features are in the dataset.
-      const newFeatures = store.getState().correlationFeatures.filter((feature) => dataset?.hasFeatureKey(feature));
+      const newFeatures = store.getState().correlationFeatures.filter((feature) => dataset.hasFeatureKey(feature));
       if (newFeatures.length === store.getState().correlationFeatures.length) {
+        // Make no changes if all features are valid
         return {};
       }
       return {

--- a/src/state/slices/correlation_slice.ts
+++ b/src/state/slices/correlation_slice.ts
@@ -1,10 +1,10 @@
-import { StateCreator } from "zustand";
+import type { StateCreator } from "zustand";
 
 import { deserializeFeatureList, serializeFeatureList, UrlParam } from "src/colorizer/utils/url_utils";
+import type { SerializedStoreData, SubscribableStore } from "src/state/types";
+import { addDerivedStateSubscriber } from "src/state/utils/store_utils";
 
-import { SerializedStoreData, SubscribableStore } from "../types";
-import { addDerivedStateSubscriber } from "../utils/store_utils";
-import { DatasetSlice } from "./dataset_slice";
+import type { DatasetSlice } from "./dataset_slice";
 
 export type CorrelationSliceState = {
   /** Current list of features selected for the correlation plot calculation. */

--- a/src/state/slices/correlation_slice.ts
+++ b/src/state/slices/correlation_slice.ts
@@ -81,9 +81,9 @@ export const loadCorrelationSliceFromParams = (
   params: URLSearchParams
 ): void => {
   const featuresParam = params.get(UrlParam.CORRELATION_PLOT_FEATURES);
-  if (featuresParam) {
+  if (featuresParam !== null) {
     const features = deserializeFeatureList(featuresParam, slice.dataset ?? undefined);
-    if (features) {
+    if (features !== undefined) {
       slice.setCorrelationFeatures(features);
     }
   }

--- a/src/state/slices/index.ts
+++ b/src/state/slices/index.ts
@@ -97,6 +97,7 @@ export * from "./channel_slice";
 export * from "./collection_slice";
 export * from "./color_ramp_slice";
 export * from "./config_slice";
+export * from "./correlation_slice";
 export * from "./dataset_slice";
 export * from "./plot_3d_slice";
 export * from "./scatterplot_slice";

--- a/src/state/slices/index.ts
+++ b/src/state/slices/index.ts
@@ -37,6 +37,13 @@ import {
   createConfigSlice,
 } from "./config_slice";
 import {
+  addCorrelationDerivedStateSubscribers,
+  type CorrelationSliceActions,
+  type CorrelationSliceSerializableState,
+  type CorrelationSliceState,
+  createCorrelationSlice,
+} from "./correlation_slice";
+import {
   createDatasetSlice,
   type DatasetSliceActions,
   type DatasetSliceSerializableState,
@@ -103,6 +110,7 @@ export type ViewerStoreState = BackdropSliceState &
   CollectionSliceState &
   ColorRampSliceState &
   ConfigSliceState &
+  CorrelationSliceState &
   DatasetSliceState &
   Plot3dSliceState &
   ScatterPlotSliceState &
@@ -116,6 +124,7 @@ export type ViewerStoreActions = BackdropSliceActions &
   CollectionSliceActions &
   ColorRampSliceActions &
   ConfigSliceActions &
+  CorrelationSliceActions &
   DatasetSliceActions &
   ScatterPlotSliceActions &
   Plot3dSliceActions &
@@ -133,6 +142,7 @@ export type ViewerStoreSerializableState = BackdropSliceSerializableState &
   CollectionSliceSerializableState &
   ColorRampSliceSerializableState &
   ConfigSliceSerializableState &
+  CorrelationSliceSerializableState &
   DatasetSliceSerializableState &
   Plot3dSliceSerializableState &
   ScatterPlotSliceSerializableState &
@@ -155,6 +165,7 @@ export const viewerStateStoreCreator: StateCreator<ViewerStore> = (...a) => ({
   ...createCollectionSlice(...a),
   ...createColorRampSlice(...a),
   ...createConfigSlice(...a),
+  ...createCorrelationSlice(...a),
   ...createDatasetSlice(...a),
   ...createPlot3dSlice(...a),
   ...createScatterPlotSlice(...a),
@@ -174,6 +185,7 @@ export const addStoreStateSubscribers = (store: SubscribableStore<ViewerStore>):
   addChannelDerivedStateSubscribers(store);
   addColorRampDerivedStateSubscribers(store);
   addConfigDerivedStateSubscribers(store);
+  addCorrelationDerivedStateSubscribers(store);
   addScatterPlotSliceDerivedStateSubscribers(store);
   addPlot3dDerivedStateSubscribers(store);
   addThresholdDerivedStateSubscribers(store);

--- a/src/state/utils/store_io.ts
+++ b/src/state/utils/store_io.ts
@@ -5,6 +5,7 @@ import {
   loadChannelSliceFromParams,
   loadColorRampSliceFromParams,
   loadConfigSliceFromParams,
+  loadCorrelationSliceFromParams,
   loadDatasetSliceFromParams,
   loadPlot3dSliceFromParams,
   loadScatterPlotSliceFromParams,
@@ -17,6 +18,7 @@ import {
   selectCollectionSliceSerializationDeps,
   selectColorRampSliceSerializationDeps,
   selectConfigSliceSerializationDeps,
+  selectCorrelationSliceSerializationDeps,
   selectDatasetSliceSerializationDeps,
   selectPlot3dSliceSerializationDeps,
   selectScatterPlotSliceSerializationDeps,
@@ -29,6 +31,7 @@ import {
   serializeCollectionSlice,
   serializeColorRampSlice,
   serializeConfigSlice,
+  serializeCorrelationSlice,
   serializeDatasetSlice,
   serializePlot3dSlice,
   serializeScatterPlotSlice,
@@ -40,12 +43,6 @@ import {
   type ViewerStoreSerializableState,
 } from "src/state/slices";
 import type { SerializedStoreData, Store } from "src/state/types";
-
-import {
-  loadCorrelationSliceFromParams,
-  selectCorrelationSliceSerializationDeps,
-  serializeCorrelationSlice,
-} from "../slices/correlation_slice";
 
 // SERIALIZATION /////////////////////////////////////////////////////////////////////////
 

--- a/src/state/utils/store_io.ts
+++ b/src/state/utils/store_io.ts
@@ -41,6 +41,12 @@ import {
 } from "src/state/slices";
 import type { SerializedStoreData, Store } from "src/state/types";
 
+import {
+  loadCorrelationSliceFromParams,
+  selectCorrelationSliceSerializationDeps,
+  serializeCorrelationSlice,
+} from "../slices/correlation_slice";
+
 // SERIALIZATION /////////////////////////////////////////////////////////////////////////
 
 export const selectSerializationDependencies = (state: ViewerStore): Partial<ViewerStore> => ({
@@ -56,6 +62,7 @@ export const selectSerializationDependencies = (state: ViewerStore): Partial<Vie
   ...selectChannelSliceSerializationDeps(state),
   ...selectVectorSliceSerializationDeps(state),
   ...selectPlot3dSliceSerializationDeps(state),
+  ...selectCorrelationSliceSerializationDeps(state),
 });
 
 /**
@@ -79,6 +86,7 @@ export const serializeViewerState = (state: Partial<ViewerStoreSerializableState
     ...serializeVectorSlice(state),
     ...serializeChannelSlice(state),
     ...serializePlot3dSlice(state),
+    ...serializeCorrelationSlice(state),
   });
 };
 
@@ -159,6 +167,7 @@ export const loadViewerStateFromParams = (store: Store<ViewerStore>, params: URL
   loadVectorSliceFromParams(store.getState(), params);
   loadChannelSliceFromParams(store.getState(), params);
   loadPlot3dSliceFromParams(store.getState(), params);
+  loadCorrelationSliceFromParams(store.getState(), params);
 
   // 3. Dependent on dataset + track slices:
   loadTimeSliceFromParams(store.getState(), params);

--- a/tests/state/store_io.test.ts
+++ b/tests/state/store_io.test.ts
@@ -36,6 +36,7 @@ import {
   MOCK_DATASET_KEY,
   MockBackdropKeys,
   MockFeatureKeys,
+  MockSanitizedFeatureKeys,
 } from "tests/constants";
 import { sleep } from "tests/utils";
 
@@ -157,6 +158,11 @@ const EXAMPLE_STORE: ViewerStoreSerializableState = {
   plot3dLineMovingAverageWindow: 7,
   plot3dUseGaussian: true,
   plot3dGaussianBandwidthPct: 15,
+  correlationFeatures: [
+    MockFeatureKeys.FEATURE1,
+    MockFeatureKeys.FEATURE2,
+    MockSanitizedFeatureKeys.FEATURE4_SANITIZED_CHARS,
+  ],
 };
 
 // Omit key "palette" because it is overridden by key "palette-key"
@@ -238,6 +244,7 @@ const EXAMPLE_STORE_EXPECTED_PARAMS: ExpectedParamType = {
   "p3d-avg-w": "2",
   "p3d-gauss": "1",
   "p3d-gauss-bw": "15",
+  corr: "feature1,feature2,feature___20_4",
 };
 
 const EXAMPLE_STORE_EXPECTED_QUERY_STRING =
@@ -253,7 +260,7 @@ const EXAMPLE_STORE_EXPECTED_QUERY_STRING =
   "&c0=ven%3A1%2Ccol%3Aff0000ff%2Crmp%3A0%3A1%2Crng%3A-5%3A5" +
   "&c1=ven%3A0%2Ccol%3A00ff0000%2Crmp%3A0.300%3A4.200%2Crng%3A0%3A1" +
   "&c2=ven%3A1%2Ccol%3A0000ff04%2Crmp%3A3500%3A64231%2Crng%3A0%3A65535" +
-  "&p3d-x=feature1&p3d-y=feature2&p3d-z=feature3&p3d-vc-bins=20&p3d-vc-subs=3&p3d-vc-scale=1.500&p3d-vc-ramp=matplotlib-inferno&p3d-vc-thresh=10&p3d-avg-w=2&p3d-avg-n=7&p3d-gauss=1&p3d-gauss-bw=15";
+  "&p3d-x=feature1&p3d-y=feature2&p3d-z=feature3&p3d-vc-bins=20&p3d-vc-subs=3&p3d-vc-scale=1.500&p3d-vc-ramp=matplotlib-inferno&p3d-vc-thresh=10&p3d-avg-w=2&p3d-avg-n=7&p3d-gauss=1&p3d-gauss-bw=15&corr=feature1%2Cfeature2%2Cfeature___20_4";
 
 describe("serializeViewerState", () => {
   it("handles empty state", () => {

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -307,40 +307,36 @@ describe("Loading + saving from URL query strings", () => {
   });
 
   describe("serializeFeatureList / deserializeFeatureList", () => {
-    it("handles empty arrays", () => {
-      expect(serializeFeatureList([])).to.equal("");
-      expect(deserializeFeatureList("")).to.deep.equal([]);
-    });
+    const TESTS = [
+      { name: "handles empty arrays", features: [], expected: "" },
+      {
+        name: "can round-trip parse feature lists",
+        features: ["feature1", "feature2", "feature3"],
+        expected: "feature1,feature2,feature3",
+      },
+      {
+        name: "parses the URL_PARAM_ALL_FEATURES placeholder",
+        features: [...MOCK_DATASET.featureKeys],
+        expected: URL_PARAM_ALL_FEATURES,
+        dataset: MOCK_DATASET,
+      },
+      {
+        name: "does not filter features",
+        features: ["feature1", "feature2", "feature3", "nonexistent-feature"],
+        expected: "feature1,feature2,feature3,nonexistent-feature",
+        dataset: undefined,
+      },
+    ];
 
-    it("can round-trip parse feature lists", async () => {
-      const features = ["feature1", "feature2", "feature3"];
-      const serialized = serializeFeatureList(features, MOCK_DATASET);
-      expect(serialized).to.equal("feature1,feature2,feature3");
-      const deserialized = deserializeFeatureList(serialized, MOCK_DATASET);
-      expect(deserialized).to.deep.equal(features);
-    });
-
-    it("does not filter features if no dataset is provided", () => {
-      const features = ["feature1", "feature2", "feature3", "nonexistent-feature"];
-      const serialized = serializeFeatureList(features);
-      expect(serialized).to.equal("feature1,feature2,feature3,nonexistent-feature");
-      const deserialized = deserializeFeatureList(serialized);
-      expect(deserialized).to.deep.equal(features);
-    });
-
-    it("removes features that are not in the dataset, if provided", () => {
-      const features = ["feature1", "feature2", "feature3", "nonexistent-feature"];
-      const serialized = serializeFeatureList(features, MOCK_DATASET);
-      expect(serialized).to.equal("feature1,feature2,feature3");
-      const deserialized = deserializeFeatureList(serialized, MOCK_DATASET);
-      expect(deserialized).to.deep.equal(["feature1", "feature2", "feature3"]);
-    });
-
-    it("parses the URL_PARAM_ALL_FEATURES placeholder", () => {
-      const serialized = URL_PARAM_ALL_FEATURES;
-      const deserialized = deserializeFeatureList(serialized, MOCK_DATASET);
-      expect(deserialized).to.deep.equal([...MOCK_DATASET.featureKeys]);
-    });
+    for (const test of TESTS) {
+      it(test.name, () => {
+        const dataset = test.dataset;
+        const serialized = serializeFeatureList(test.features, dataset);
+        expect(serialized).to.equal(test.expected);
+        const deserialized = deserializeFeatureList(serialized, dataset);
+        expect(deserialized).to.deep.equal(test.features);
+      });
+    }
 
     it("ignores the URL_PARAM_ALL_FEATURES placeholder if no dataset is provided", () => {
       const serialized = URL_PARAM_ALL_FEATURES;

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -6,15 +6,20 @@ import { type FeatureThreshold, ThresholdType } from "src/colorizer/types";
 import {
   convertAllenPathToHttps,
   decodeHexAlphaColor,
+  deserializeFeatureList,
   deserializeThresholds,
   encodeColorWithAlpha,
   isAllenPath,
   isHexColor,
   isJson,
   isUrl,
+  serializeFeatureList,
   serializeThresholds,
+  URL_PARAM_ALL_FEATURES,
   VAST_FILES_URL,
 } from "src/colorizer/utils/url_utils";
+
+import { MOCK_DATASET } from "./constants";
 
 function padCategories(categories: boolean[]): boolean[] {
   const result = [...categories];
@@ -298,6 +303,49 @@ describe("Loading + saving from URL query strings", () => {
           enabledCategories: padCategories([true, true]),
         },
       ]);
+    });
+  });
+
+  describe("serializeFeatureList / deserializeFeatureList", () => {
+    it("handles empty arrays", () => {
+      expect(serializeFeatureList([])).to.equal("");
+      expect(deserializeFeatureList("")).to.deep.equal([]);
+    });
+
+    it("can round-trip parse feature lists", async () => {
+      const features = ["feature1", "feature2", "feature3"];
+      const serialized = serializeFeatureList(features, MOCK_DATASET);
+      expect(serialized).to.equal("feature1,feature2,feature3");
+      const deserialized = deserializeFeatureList(serialized, MOCK_DATASET);
+      expect(deserialized).to.deep.equal(features);
+    });
+
+    it("does not filter features if no dataset is provided", () => {
+      const features = ["feature1", "feature2", "feature3", "nonexistent-feature"];
+      const serialized = serializeFeatureList(features);
+      expect(serialized).to.equal("feature1,feature2,feature3,nonexistent-feature");
+      const deserialized = deserializeFeatureList(serialized);
+      expect(deserialized).to.deep.equal(features);
+    });
+
+    it("removes features that are not in the dataset, if provided", () => {
+      const features = ["feature1", "feature2", "feature3", "nonexistent-feature"];
+      const serialized = serializeFeatureList(features, MOCK_DATASET);
+      expect(serialized).to.equal("feature1,feature2,feature3");
+      const deserialized = deserializeFeatureList(serialized, MOCK_DATASET);
+      expect(deserialized).to.deep.equal(["feature1", "feature2", "feature3"]);
+    });
+
+    it("parses the URL_PARAM_ALL_FEATURES placeholder", () => {
+      const serialized = URL_PARAM_ALL_FEATURES;
+      const deserialized = deserializeFeatureList(serialized, MOCK_DATASET);
+      expect(deserialized).to.deep.equal([...MOCK_DATASET.featureKeys]);
+    });
+
+    it("ignores the URL_PARAM_ALL_FEATURES placeholder if no dataset is provided", () => {
+      const serialized = URL_PARAM_ALL_FEATURES;
+      const deserialized = deserializeFeatureList(serialized);
+      expect(deserialized).to.be.undefined;
     });
   });
 });


### PR DESCRIPTION
Problem
=======
Closes #957, "save correlation plot features to the URL."

This change stores the current set of selected correlation plot features to global state, and adds serialization + deserialization from the URL for them. 

*Estimated review size: small, 15 minutes*

Solution
========
- Added `correlation_slice` to global state slices, with the `correlationFeatures` state variable containing the current list of correlation features.
- Added serialization + deserialization logic for lists of feature values, including the `!` placeholder for when all features are selected.
- Updated unit tests.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open PR preview. I have selected a small subset of feature values for the correlation plot. https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-973/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&tab=correlation_plot&corr=volume%2Cheight%2Cxy_aspect_ratio%2Cgrowth_rate
2. Change the correlation plot feature selection.
3. Refresh the page. The selected features should reappear as before.

Screenshots (optional):
-----------------------

<img width="1840" height="1358" alt="{61C7AE7C-15E6-49C7-B1F1-839DDEF45E98}" src="https://github.com/user-attachments/assets/ebfcc349-a88e-4632-9527-0b93a51413f2" />


