### PR TITLE
refactor: Generic key types for Dropdown (plots pt. 1)

### DIFF
--- a/src/components/Dropdowns/SelectionDropdown.tsx
+++ b/src/components/Dropdowns/SelectionDropdown.tsx
@@ -9,7 +9,7 @@ import { FlexRowAlignCenter, VisuallyHidden } from "src/styles/utils";
 import StyledSelect from "./StyledSelect";
 import type { SelectItem } from "./types";
 
-export type SelectionDropdownProps = {
+export type SelectionDropdownProps<T extends string = string> = {
   /** Text label to include with the dropdown. */
   label?: string | null;
   /**
@@ -19,7 +19,7 @@ export type SelectionDropdownProps = {
   hideLabel?: boolean;
   id?: string;
   /** The value of the item that is currently selected. */
-  selected: string | SelectItem | undefined;
+  selected: T | SelectItem<T> | undefined;
   /**
    * An array of SelectItems that describes the item properties (`{value,
    * label}`), or an array of strings. Dropdown items will be presented in the
@@ -33,7 +33,7 @@ export type SelectionDropdownProps = {
    * `items` property on every render, which can cause unexpected or unwanted
    * behavior such as flickering on hover during rapid page updates.
    */
-  items: SelectItem[] | string[];
+  items: SelectItem<T>[] | T[];
   controlTooltipPlacement?: "top" | "bottom" | "left" | "right";
   tooltipPopupContainer?: HTMLElement;
   disabled?: boolean;
@@ -49,7 +49,7 @@ export type SelectionDropdownProps = {
    * Callback that is fired whenever an item in the dropdown is selected.
    * The callback will be passed the `value` of the selected item.
    */
-  onChange: ((value: string) => Promise<void>) | ((value: string) => void);
+  onChange: ((value: T) => Promise<void>) | ((value: T) => void);
   /**
    * If true, shows the label of the currently-selected item as a tooltip
    * when hovering over the input/selection area.
@@ -135,7 +135,9 @@ function formatAsSelectItems(items: string[] | SelectItem[]): SelectItem[] {
  * the `items` property on every render, which can cause unexpected or unwanted
  * behavior such as flickering on hover during rapid page updates.
  */
-export default function SelectionDropdown(inputProps: React.PropsWithChildren<SelectionDropdownProps>): ReactElement {
+export default function SelectionDropdown<T extends string = string>(
+  inputProps: React.PropsWithChildren<SelectionDropdownProps<T>>
+): ReactElement {
   const props = { ...defaultProps, ...inputProps };
 
   const options = useMemo(() => formatAsSelectItems(props.items), [props.items]);
@@ -269,7 +271,7 @@ export default function SelectionDropdown(inputProps: React.PropsWithChildren<Se
           onChange: (value) => {
             if (value && value.value) {
               setPendingValue(value);
-              Promise.allSettled([props.onChange(value.value)]).finally(() => {
+              Promise.allSettled([props.onChange(value.value as T)]).finally(() => {
                 setPendingValue(null);
               });
             }

--- a/src/components/Dropdowns/types.ts
+++ b/src/components/Dropdowns/types.ts
@@ -4,13 +4,13 @@ import type { Color } from "three";
 /**
  * A single option in a dropdown. Includes optional display properties.
  */
-export type SelectItem = {
+export type SelectItem<T extends string = string> = {
   /** Display value of the option. */
   label: string;
   /** The key or value the option. This will be returned when the option is
    * selected.
    */
-  value: string;
+  value: T;
   /** Optional color for the option. If set, a small color indicator will be
    * shown next to the label in the dropdown.
    */
@@ -20,7 +20,8 @@ export type SelectItem = {
   /** Optional tooltip for an option. If set, a tooltip will be shown when
    * the option is hovered or focused in the dropdown. */
   tooltip?: string | ReactNode;
-  /** Optional image source instead of a text label. If used, the label will be
+  /**
+   * Optional image source instead of a text label. If used, the label will be
    * used as alt text for the image.
    */
   image?: string;

--- a/src/components/Tabs/ScatterPlot/ScatterplotToolbar.tsx
+++ b/src/components/Tabs/ScatterPlot/ScatterplotToolbar.tsx
@@ -38,7 +38,7 @@ export default function ScatterplotToolbar(props: ScatterplotToolbarProps): Reac
           selected={scatterRangeType}
           items={PLOT_RANGE_SELECT_ITEMS}
           controlWidth={"130px"}
-          onChange={(value: string) => setRangeType(value as PlotRangeType)}
+          onChange={(value) => setRangeType(value)}
           showSelectedItemTooltip={false}
         ></SelectionDropdown>
       </div>


### PR DESCRIPTION
Problem
=======
Split out a minor refactor from #974 to make it easier to review. This change makes the SelectionDropdown generic over a key type, making it easier to work with enums without needing to perform a cast.

*Estimated review size: tiny, 5 minutes*

Solution
========
- Made `SelectItem` generic over a string-like key type.
- Updated `SelectionDropdown` to be generic over a key type in either the provided `SelectItem` items array or directly-passed keys.

Steps to Verify:
----------------
1. Open PR preview: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-975/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small
2. Interact with any dropdown. Behavior should work as before.
