### PR TITLE
feat: Allow right click context menu items to be passed in via callback

### DIFF
--- a/src/components/Menus/RightClickContextMenu.tsx
+++ b/src/components/Menus/RightClickContextMenu.tsx
@@ -1,15 +1,6 @@
 import { ConfigProvider, Menu, type MenuProps, Popover } from "antd";
 import type { MenuInfo } from "rc-menu/lib/interface";
-import React, {
-  type PropsWithChildren,
-  type ReactElement,
-  useCallback,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { type PropsWithChildren, type ReactElement, useEffect, useId, useMemo, useRef, useState } from "react";
 import styled, { css } from "styled-components";
 
 import { MenuExpandArrowSVG } from "src/assets";
@@ -56,7 +47,7 @@ type RightClickContextMenuProps = {
    * When `items` is a nested array, items in each sub-array will be grouped
    * together in the menu, with a divider drawn between each group.
    */
-  getItems?: () => ContextMenuItem[][] | ContextMenuItem[];
+  getItems?: (event: MouseEvent) => ContextMenuItem[][] | ContextMenuItem[];
   /**
    * If disabled, does not show context menu and allows the default browser
    * context menu to appear.
@@ -228,18 +219,7 @@ function RightClickContextMenu(props: PropsWithChildren<RightClickContextMenuPro
   const [menuItems, setMenuItems] = useState<MenuItem[]>([]);
   const [keyToClickHandlerMap, setKeyToClickHandlerMap] = useState<Map<string, ClickHandler>>(new Map());
 
-  const [showContextMenu, _setShowContextMenu] = useState(false);
-
-  const setShowContextMenu = useCallback((value: boolean) => {
-    _setShowContextMenu(value);
-    if (value) {
-      // Update current menu items and click handlers
-      const inputItems = propsRef.current.items ?? propsRef.current.getItems?.() ?? [];
-      const { items, keyToClickHandlerMap } = getMenuItems(inputItems);
-      setMenuItems(items);
-      setKeyToClickHandlerMap(keyToClickHandlerMap);
-    }
-  }, []);
+  const [showContextMenu, setShowContextMenu] = useState(false);
 
   const hasIcons = useMemo(() => menuItems.some(doesItemHaveIcon), [menuItems]);
 
@@ -264,6 +244,11 @@ function RightClickContextMenu(props: PropsWithChildren<RightClickContextMenuPro
       ev.preventDefault();
       ev.stopPropagation();
       updatePopoverPosition(ev);
+      // Update current menu items and click handlers, then show the menu
+      const inputItems = propsRef.current.items ?? propsRef.current.getItems?.(ev) ?? [];
+      const { items, keyToClickHandlerMap } = getMenuItems(inputItems);
+      setMenuItems(items);
+      setKeyToClickHandlerMap(keyToClickHandlerMap);
       setShowContextMenu(true);
     };
 

--- a/src/components/Menus/RightClickContextMenu.tsx
+++ b/src/components/Menus/RightClickContextMenu.tsx
@@ -57,8 +57,8 @@ type RightClickContextMenuProps = {
 
 // MARK: Styling
 
-const StyledPopoverContainer = styled.div<{ $hasIcon?: boolean }>(
-  ({ $hasIcon }) => css`
+const StyledPopoverContainer = styled.div<{ $hasIcon?: boolean; $disabled?: boolean }>(
+  ({ $hasIcon, $disabled }) => css`
     // Position popover container totally over the child element that it wraps
     position: absolute;
     top: 0;
@@ -68,7 +68,7 @@ const StyledPopoverContainer = styled.div<{ $hasIcon?: boolean }>(
 
     // Pass pointer events through the popover container to the child content
     // container, except for the popover itself.
-    pointer-events: none;
+    pointer-events: ${$disabled ? "auto" : "none"};
     & .ant-popover {
       pointer-events: auto;
     }
@@ -301,7 +301,7 @@ function RightClickContextMenu(props: PropsWithChildren<RightClickContextMenuPro
         {props.children}
       </div>
 
-      <StyledPopoverContainer ref={popoverContainerRef} $hasIcon={hasIcons}>
+      <StyledPopoverContainer ref={popoverContainerRef} $hasIcon={hasIcons} $disabled={props.disabled}>
         <ConfigProvider
           theme={{
             components: {

--- a/src/components/Menus/RightClickContextMenu.tsx
+++ b/src/components/Menus/RightClickContextMenu.tsx
@@ -38,6 +38,7 @@ export type ContextMenuItem = {
 
 type RightClickContextMenuProps = {
   id?: string;
+
   /**
    * The items to display in the context menu. Items can have labels, icons,
    * click handlers, and children that are grouped into submenus.
@@ -45,7 +46,17 @@ type RightClickContextMenuProps = {
    * When `items` is a nested array, items in each sub-array will be grouped
    * together in the menu, with a divider drawn between each group.
    */
-  items: ContextMenuItem[][] | ContextMenuItem[];
+  items?: ContextMenuItem[][] | ContextMenuItem[];
+
+  /**
+   * A function that returns items to display in the context menu; overridden by
+   * `items` if provided. Items can have labels, icons, click handlers, and
+   * children that are grouped into submenus.
+   *
+   * When `items` is a nested array, items in each sub-array will be grouped
+   * together in the menu, with a divider drawn between each group.
+   */
+  getItems?: () => ContextMenuItem[][] | ContextMenuItem[];
 };
 
 // MARK: Styling
@@ -202,8 +213,12 @@ function RightClickContextMenu(props: PropsWithChildren<RightClickContextMenuPro
   const popoverContainerRef = useRef<HTMLDivElement>(null);
   const popoverAnchorRef = useRef<HTMLDivElement>(null);
 
+  // Store props as refs to prevent needing remount event listeners on every
+  // update
   const inputItemsRef = useRef(props.items);
   inputItemsRef.current = props.items;
+  const getItemsRef = useRef(props.getItems);
+  getItemsRef.current = props.getItems;
 
   // Stored as state so that the menu items remain consistent even if the input
   // items change, and only update when the context menu is opened/reopened.
@@ -216,7 +231,8 @@ function RightClickContextMenu(props: PropsWithChildren<RightClickContextMenuPro
     _setShowContextMenu(value);
     if (value) {
       // Update current menu items and click handlers
-      const { items, keyToClickHandlerMap } = getMenuItems(inputItemsRef.current);
+      const inputItems = inputItemsRef.current ?? getItemsRef.current?.() ?? [];
+      const { items, keyToClickHandlerMap } = getMenuItems(inputItems);
       setMenuItems(items);
       setKeyToClickHandlerMap(keyToClickHandlerMap);
     }
@@ -290,7 +306,7 @@ function RightClickContextMenu(props: PropsWithChildren<RightClickContextMenuPro
   );
 
   return (
-    <div id={id} style={{ position: "relative" }}>
+    <div id={id} style={{ position: "relative", width: "100%", height: "100%" }}>
       <div ref={contentContainerRef} style={{ width: "100%", height: "100%" }}>
         {props.children}
       </div>

--- a/src/components/Menus/RightClickContextMenu.tsx
+++ b/src/components/Menus/RightClickContextMenu.tsx
@@ -57,6 +57,11 @@ type RightClickContextMenuProps = {
    * together in the menu, with a divider drawn between each group.
    */
   getItems?: () => ContextMenuItem[][] | ContextMenuItem[];
+  /**
+   * If disabled, does not show context menu and allows the default browser
+   * context menu to appear.
+   */
+  disabled?: boolean;
 };
 
 // MARK: Styling
@@ -213,12 +218,10 @@ function RightClickContextMenu(props: PropsWithChildren<RightClickContextMenuPro
   const popoverContainerRef = useRef<HTMLDivElement>(null);
   const popoverAnchorRef = useRef<HTMLDivElement>(null);
 
-  // Store props as refs to prevent needing remount event listeners on every
+  // Store props as ref to prevent needing remount event listeners on every
   // update
-  const inputItemsRef = useRef(props.items);
-  inputItemsRef.current = props.items;
-  const getItemsRef = useRef(props.getItems);
-  getItemsRef.current = props.getItems;
+  const propsRef = useRef(props);
+  propsRef.current = props;
 
   // Stored as state so that the menu items remain consistent even if the input
   // items change, and only update when the context menu is opened/reopened.
@@ -231,7 +234,7 @@ function RightClickContextMenu(props: PropsWithChildren<RightClickContextMenuPro
     _setShowContextMenu(value);
     if (value) {
       // Update current menu items and click handlers
-      const inputItems = inputItemsRef.current ?? getItemsRef.current?.() ?? [];
+      const inputItems = propsRef.current.items ?? propsRef.current.getItems?.() ?? [];
       const { items, keyToClickHandlerMap } = getMenuItems(inputItems);
       setMenuItems(items);
       setKeyToClickHandlerMap(keyToClickHandlerMap);
@@ -255,6 +258,9 @@ function RightClickContextMenu(props: PropsWithChildren<RightClickContextMenuPro
       popoverAnchor.style.top = `${ev.clientY - rect.top}px`;
     };
     const onContextMenu = (ev: MouseEvent): void => {
+      if (propsRef.current.disabled) {
+        return;
+      }
       ev.preventDefault();
       ev.stopPropagation();
       updatePopoverPosition(ev);

--- a/src/components/Menus/RightClickContextMenu.tsx
+++ b/src/components/Menus/RightClickContextMenu.tsx
@@ -209,8 +209,7 @@ function RightClickContextMenu(props: PropsWithChildren<RightClickContextMenuPro
   const popoverContainerRef = useRef<HTMLDivElement>(null);
   const popoverAnchorRef = useRef<HTMLDivElement>(null);
 
-  // Store props as ref to prevent needing remount event listeners on every
-  // update
+  // Store props as ref so event listeners don't need to be remounted on update
   const propsRef = useRef(props);
   propsRef.current = props;
 


### PR DESCRIPTION
Problem
=======
Little refactor I split out of the next PR in this series, #980. This allows items in the context menu to be retrieved via a function, rather than being passed in directly as props.

In #980, the items in the context menu rely on some potentially expensive computations (traversing the entire lineage tree whenever an object is hovered/unhovered). We can improve performance by allowing these computations to only happen once on right click, rather than on every render.

I also added handling for disabling the right click context menu (though the functionality is currently unused).

*Estimated review size: tiny, 5 minutes*

Solution
========
- Added the `getItems` callback prop to `RightClickContextMenu`, allowing items to be calculated in a callback.
- Added `disabled` support.
- Fixed a bug where child objects would not be sized correctly.

## Type of change
* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

