### PR TITLE
feat: Lineage tree traversal helper methods (select all pt. 1)

### DIFF
--- a/src/components/Tabs/Plots/LineageGraph/tree_utils.ts
+++ b/src/components/Tabs/Plots/LineageGraph/tree_utils.ts
@@ -14,17 +14,17 @@ import type { LineageData, LineageDataRelationships, TrackInfo } from "./types";
  * @param callback The callback function to call for each parent track. Return
  * true to continue traversing the parents of that track, or false to stop.
  */
-function forEachAncestor(
+export function forEachAncestor(
   trackId: number,
   trackIdToData: Map<number, TrackInfo>,
   idToParents: Map<number, number[]>,
-  callback: (parent: TrackInfo) => boolean
+  callback: (parent: TrackInfo) => boolean | void
 ): void {
   const parents = idToParents.get(trackId) ?? [];
   for (const parentId of parents) {
     const parentData = trackIdToData.get(parentId);
     if (parentData) {
-      if (!callback(parentData)) {
+      if (callback(parentData) === false) {
         continue;
       }
       forEachAncestor(parentId, trackIdToData, idToParents, callback);
@@ -43,11 +43,11 @@ function forEachAncestor(
  * @param callback The callback function to call for each child track. Return
  * true to continue traversing the children of that track, or false to stop.
  */
-function forEachDescendant(
+export function forEachDescendant(
   trackId: number,
   trackIdToData: Map<number, TrackInfo>,
   idToChildren: Map<number, number[]>,
-  callback: (child: TrackInfo) => boolean
+  callback: (child: TrackInfo) => boolean | void
 ): void {
   if (trackId === undefined) {
     return;
@@ -56,12 +56,72 @@ function forEachDescendant(
   for (const childId of children) {
     const childNode = trackIdToData.get(childId);
     if (childNode) {
-      if (!callback(childNode)) {
+      if (callback(childNode) === false) {
         continue;
       }
       forEachDescendant(childId, trackIdToData, idToChildren, callback);
     }
   }
+}
+
+/** Returns true if all descendants match the provided validator function. */
+export function matchesAllDescendants(
+  trackId: number,
+  validator: (trackId: number) => boolean,
+  data: LineageData,
+  relationships: LineageDataRelationships
+): boolean {
+  let allMatch = true;
+  forEachDescendant(trackId, data.trackIdToTrackInfo, relationships.idToChildren, (child) => {
+    if (!allMatch || !validator(child.id)) {
+      allMatch = false;
+      return false;
+    }
+    return true;
+  });
+  return allMatch;
+}
+
+/** Returns true if all ancestors match the provided validator function. */
+export function matchesAllAncestors(
+  trackId: number,
+  validator: (trackId: number) => boolean,
+  data: LineageData,
+  relationships: LineageDataRelationships
+): boolean {
+  let allMatch = true;
+  forEachAncestor(trackId, data.trackIdToTrackInfo, relationships.idToParents, (parent) => {
+    if (!allMatch || !validator(parent.id)) {
+      allMatch = false;
+      return false;
+    }
+    return true;
+  });
+  return allMatch;
+}
+
+/** Returns the set of ancestor track IDs for the given track. */
+export function getAncestors(trackId: number, data: LineageData, relationships: LineageDataRelationships): Set<number> {
+  const ancestors: Set<number> = new Set();
+  forEachAncestor(trackId, data.trackIdToTrackInfo, relationships.idToParents, (parent) => {
+    ancestors.add(parent.id);
+    return true;
+  });
+  return ancestors;
+}
+
+/** Returns the set of descendant track IDs for the given track. */
+export function getDescendants(
+  trackId: number,
+  data: LineageData,
+  relationships: LineageDataRelationships
+): Set<number> {
+  const descendants: Set<number> = new Set();
+  forEachDescendant(trackId, data.trackIdToTrackInfo, relationships.idToChildren, (child) => {
+    descendants.add(child.id);
+    return true;
+  });
+  return descendants;
 }
 
 export type TreeExpandedState = {

--- a/src/components/Tabs/Plots/LineageGraph/tree_utils.ts
+++ b/src/components/Tabs/Plots/LineageGraph/tree_utils.ts
@@ -3,6 +3,33 @@ import type * as d3 from "d3";
 import type { LineageData, LineageDataRelationships, TrackInfo } from "./types";
 
 /**
+ * Calls a callback function for each relative (ancestor or descendant) of a
+ * track ID, recursively.
+ */
+function forEachRelative(
+  trackId: number,
+  trackIdToData: Map<number, TrackInfo>,
+  idToRelatives: Map<number, number[]>,
+  callback: (parent: TrackInfo) => boolean | void,
+  seenIds: Set<number>
+): void {
+  const relatives = idToRelatives.get(trackId) ?? [];
+  for (const relativeId of relatives) {
+    if (seenIds.has(relativeId)) {
+      continue;
+    }
+    seenIds.add(relativeId);
+    const parentData = trackIdToData.get(relativeId);
+    if (parentData) {
+      if (callback(parentData) === false) {
+        continue;
+      }
+      forEachRelative(relativeId, trackIdToData, idToRelatives, callback, seenIds);
+    }
+  }
+}
+
+/**
  * Recursively calls the provided callback function for all ancestors (parents,
  * grandparents, etc.) of the provided track ID. If the callback returns false,
  * the recursion will not continue for that parent.
@@ -12,7 +39,7 @@ import type { LineageData, LineageDataRelationships, TrackInfo } from "./types";
  * @param idToParents Map from track ID to its parent track IDs. (May be
  * multiple parents in the case of a merge node.)
  * @param callback The callback function to call for each parent track. Return
- * true to continue traversing the parents of that track, or false to stop.
+ * false to stop traversing the parents of the track.
  */
 export function forEachAncestor(
   trackId: number,
@@ -20,16 +47,8 @@ export function forEachAncestor(
   idToParents: Map<number, number[]>,
   callback: (parent: TrackInfo) => boolean | void
 ): void {
-  const parents = idToParents.get(trackId) ?? [];
-  for (const parentId of parents) {
-    const parentData = trackIdToData.get(parentId);
-    if (parentData) {
-      if (callback(parentData) === false) {
-        continue;
-      }
-      forEachAncestor(parentId, trackIdToData, idToParents, callback);
-    }
-  }
+  const seenIds = new Set<number>();
+  forEachRelative(trackId, trackIdToData, idToParents, callback, seenIds);
 }
 
 /**
@@ -41,7 +60,7 @@ export function forEachAncestor(
  * @param trackIdToData Map from track ID to its TrackInfo data.
  * @param idToChildren Map from track ID to its children track IDs.
  * @param callback The callback function to call for each child track. Return
- * true to continue traversing the children of that track, or false to stop.
+ * false to stop traversing the children of the track.
  */
 export function forEachDescendant(
   trackId: number,
@@ -49,19 +68,8 @@ export function forEachDescendant(
   idToChildren: Map<number, number[]>,
   callback: (child: TrackInfo) => boolean | void
 ): void {
-  if (trackId === undefined) {
-    return;
-  }
-  const children = idToChildren.get(trackId) ?? [];
-  for (const childId of children) {
-    const childNode = trackIdToData.get(childId);
-    if (childNode) {
-      if (callback(childNode) === false) {
-        continue;
-      }
-      forEachDescendant(childId, trackIdToData, idToChildren, callback);
-    }
-  }
+  const seen = new Set<number>();
+  forEachRelative(trackId, trackIdToData, idToChildren, callback, seen);
 }
 
 /** Returns true if all descendants match the provided validator function. */

--- a/tests/tree_utils.test.ts
+++ b/tests/tree_utils.test.ts
@@ -6,7 +6,11 @@ import {
   alignMergeNodes,
   collapseTrack,
   expandTrack,
+  getAncestors,
+  getDescendants,
   getInitialExpandedState,
+  matchesAllAncestors,
+  matchesAllDescendants,
   type TreeExpandedState,
 } from "src/components/Tabs/Plots/LineageGraph/tree_utils";
 import type { LineageData, TrackInfo } from "src/components/Tabs/Plots/LineageGraph/types";
@@ -175,6 +179,76 @@ describe("tree_utils", () => {
       expect(result.expandedTracks).toEqual(new Set([1, 5, 6, 7]));
       expect(result.previouslyExpandedTracks).toEqual(new Set([1, 5, 6, 7]));
     });
+  });
+
+  describe("getAncestors", () => {
+    const tests = [
+      ["handles invalid nodes", 1200, []],
+      ["returns set of ancestors", 4, [1, 2]],
+      ["returns empty set for nodes with no parents", 1, []],
+      ["returns coparents", 8, [1, 5, 6, 7]],
+    ] as const;
+
+    for (const [description, trackId, expectedAncestors] of tests) {
+      it(description, () => {
+        const ancestors = getAncestors(trackId, lineageData, relationships);
+        expect(ancestors).toEqual(new Set(expectedAncestors));
+      });
+    }
+  });
+
+  describe("getDescendants", () => {
+    const tests = [
+      ["handles invalid nodes", 1200, []],
+      ["returns set of descendants", 2, [3, 4]],
+      ["returns empty set for nodes with no children", 9, []],
+      ["returns descendants of merge nodes", 5, [6, 7, 8, 9]],
+    ] as const;
+
+    for (const [description, trackId, expectedDescendants] of tests) {
+      it(description, () => {
+        const descendants = getDescendants(trackId, lineageData, relationships);
+        expect(descendants).toEqual(new Set(expectedDescendants));
+      });
+    }
+  });
+
+  describe("matchesAllAncestors", () => {
+    const tests = [
+      ["returns true for nodes with all ancestors selected", 4, [1, 2], true],
+      ["returns false if any ancestor fails validator", 4, [2], false],
+      ["handles coparents", 9, [1, 5, 6, 7], true],
+      ["handles coparent failing validator", 9, [1, 5, 6], false], // 7 failed
+      ["returns true for nodes with no parents", 1, [], true],
+    ] as [string, number, number[], boolean][];
+
+    for (const [description, trackId, selectedAncestors, expectedResult] of tests) {
+      it(description, () => {
+        const selectedAncestorsSet = new Set(selectedAncestors);
+        const validator = (id: number) => selectedAncestorsSet.has(id);
+        const result = matchesAllAncestors(trackId, validator, lineageData, relationships);
+        expect(result).toBe(expectedResult);
+      });
+    }
+  });
+
+  describe("matchesAllDescendants", () => {
+    const tests = [
+      ["returns true for nodes with all descendants selected", 2, [3, 4], true],
+      ["returns false if any descendant fails validator", 2, [3], false],
+      ["handles merge nodes", 5, [6, 7, 8, 9], true],
+      ["handles merge nodes failing validator", 5, [6, 7, 8], false], // 9 failed
+      ["returns true for nodes with no children", 9, [], true],
+    ] as [string, number, number[], boolean][];
+
+    for (const [description, trackId, selectedDescendants, expectedResult] of tests) {
+      it(description, () => {
+        const selectedDescendantsSet = new Set(selectedDescendants);
+        const validator = (id: number) => selectedDescendantsSet.has(id);
+        const result = matchesAllDescendants(trackId, validator, lineageData, relationships);
+        expect(result).toBe(expectedResult);
+      });
+    }
   });
 });
 

--- a/tests/tree_utils.test.ts
+++ b/tests/tree_utils.test.ts
@@ -225,7 +225,7 @@ describe("tree_utils", () => {
     for (const [description, trackId, selectedAncestors, expectedResult] of tests) {
       it(description, () => {
         const selectedAncestorsSet = new Set(selectedAncestors);
-        const validator = (id: number) => selectedAncestorsSet.has(id);
+        const validator = (id: number): boolean => selectedAncestorsSet.has(id);
         const result = matchesAllAncestors(trackId, validator, lineageData, relationships);
         expect(result).toBe(expectedResult);
       });
@@ -244,7 +244,7 @@ describe("tree_utils", () => {
     for (const [description, trackId, selectedDescendants, expectedResult] of tests) {
       it(description, () => {
         const selectedDescendantsSet = new Set(selectedDescendants);
-        const validator = (id: number) => selectedDescendantsSet.has(id);
+        const validator = (id: number): boolean => selectedDescendantsSet.has(id);
         const result = matchesAllDescendants(trackId, validator, lineageData, relationships);
         expect(result).toBe(expectedResult);
       });

--- a/tests/tree_utils.test.ts
+++ b/tests/tree_utils.test.ts
@@ -183,7 +183,9 @@ describe("tree_utils", () => {
 
   describe("getAncestors", () => {
     const tests = [
-      ["handles invalid nodes", 1200, []],
+      ["handles nonexistent nodes", 1200, []],
+      ["handles bad input nodes", NaN, []],
+      ["handles bad input nodes", Infinity, []],
       ["returns set of ancestors", 4, [1, 2]],
       ["returns empty set for nodes with no parents", 1, []],
       ["returns coparents", 8, [1, 5, 6, 7]],
@@ -199,7 +201,9 @@ describe("tree_utils", () => {
 
   describe("getDescendants", () => {
     const tests = [
-      ["handles invalid nodes", 1200, []],
+      ["handles nonexistent nodes", 1200, []],
+      ["handles bad input nodes", NaN, []],
+      ["handles bad input nodes", Infinity, []],
       ["returns set of descendants", 2, [3, 4]],
       ["returns empty set for nodes with no children", 9, []],
       ["returns descendants of merge nodes", 5, [6, 7, 8, 9]],


### PR DESCRIPTION
Problem
=======
Some helper methods I split out of future PRs in this stack and added unit tests to!

Solution
========
- Added helper methods for checking the status of descendants and ancestors in the tree.
  - Added `matchesAllDescendants` and `matchesAllAncestors`
  - Added `getAncestors` and `getDescendants`
  - Updated `forEachAncestor` and `forEachDescendant` to allow callbacks that don't return boolean values for simplicity.
- Added unit tests.

## Type of change

* New feature (non-breaking change which adds functionality)
